### PR TITLE
ci: adopt reusable workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,55 +6,20 @@ on:
   pull_request:
     branches: [ main, develop ]
 
-jobs:
-  test:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.11", "3.12"]
+permissions:
+  contents: read
 
-    steps:
-    - uses: actions/checkout@v4
-    
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-    
-    - name: Install Poetry
-      run: |
-        curl -sSL https://install.python-poetry.org | python3 -
-        echo "$HOME/.local/bin" >> $GITHUB_PATH
-    
-    - name: Configure Poetry
-      run: |
-        poetry config virtualenvs.create true
-        poetry config virtualenvs.in-project true
-    
-    - name: Cache dependencies
-      uses: actions/cache@v3
-      with:
-        path: .venv
-        key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
-        restore-keys: |
-          venv-${{ runner.os }}-${{ matrix.python-version }}-
-    
-    - name: Install dependencies
-      run: |
-        poetry install
-    
-    - name: Run linters
-      run: |
-        poetry run black --check src tests
-        poetry run ruff check src tests
-    
-    - name: Run tests
-      run: |
-        poetry run pytest tests/ -v -m "not integration" --cov=sophia --cov-report=xml
-    
-    - name: Upload coverage
-      uses: codecov/codecov-action@v3
-      if: matrix.python-version == '3.12'
-      with:
-        file: ./coverage.xml
-        fail_ci_if_error: false
+jobs:
+  standard:
+    uses: c-daly/logos/.github/workflows/reusable-standard-ci.yml@main
+    with:
+      python_versions: '["3.11","3.12"]'
+      python_package_manager: 'poetry'
+      python_command_prefix: 'poetry run '
+      poetry_install_args: '--with dev'
+      python_lint_paths: 'src tests'
+      mypy_targets: 'src'
+      pytest_command: 'pytest tests/ -v -m "not integration" --cov=sophia --cov-report=term --cov-report=xml'
+      coverage_python_version: '3.12'
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -212,6 +212,20 @@ curl -X POST http://localhost:8000/execute \
   }'
 ```
 
+## Local Testing (CI Parity)
+
+Sophia uses the shared LOGOS workflow template. Run the same commands locally before opening a PR:
+
+```bash
+poetry install --with dev
+poetry run ruff check src tests
+poetry run black --check src tests
+poetry run mypy src
+poetry run pytest tests/ -v -m "not integration" --cov=sophia --cov-report=term --cov-report=xml
+```
+
+If these commands pass locally, they will pass the GitHub Actions gate defined in `.github/workflows/ci.yml`.
+
 ### Running Locally (Development)
 
 For development without Docker:

--- a/poetry.lock
+++ b/poetry.lock
@@ -715,7 +715,7 @@ version = "2.3.5"
 description = "Fundamental package for array computing in Python"
 optional = false
 python-versions = ">=3.11"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "numpy-2.3.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:de5672f4a7b200c15a4127042170a694d4df43c992948f5e1af57f0174beed10"},
     {file = "numpy-2.3.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:acfd89508504a19ed06ef963ad544ec6664518c863436306153e13e94605c218"},
@@ -1783,6 +1783,21 @@ doc = ["reno", "sphinx"]
 test = ["pytest", "tornado (>=4.5)", "typeguard"]
 
 [[package]]
+name = "types-networkx"
+version = "3.5.0.20251106"
+description = "Typing stubs for networkx"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "types_networkx-3.5.0.20251106-py3-none-any.whl", hash = "sha256:674c53111d5ca6cf96eb6ccd3152d0d52c2720b8ddea8082c7b0116a21347a30"},
+    {file = "types_networkx-3.5.0.20251106.tar.gz", hash = "sha256:2f17a53a35cf6dbbb031039c19bf0f127ec1b37f3530c57a517a0dd67a42e343"},
+]
+
+[package.dependencies]
+numpy = ">=1.20"
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 description = "Backported and Experimental Type Hints for Python 3.9+"
@@ -2149,4 +2164,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "24dfab7235ec732472801a06b8c9b4adacc359a948b8fe56e98d02035438b579"
+content-hash = "75a02c6144c29113db0354b1d2de4328bb51a4953d5e76a797890b7ccdf69020"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ ruff = ">=0.1.0"
 mypy = ">=1.0.0"
 httpx = ">=0.24.0"
 pytest-asyncio = ">=0.21.0"
+types-networkx = ">=2.6.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/src/sophia/api/app.py
+++ b/src/sophia/api/app.py
@@ -3,7 +3,7 @@
 import os
 import uuid
 import logging
-from typing import List, Optional
+from typing import List, Optional, AsyncIterator
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, Depends, HTTPException, status
@@ -126,7 +126,7 @@ _jepa_runner: Optional[JEPARunner] = None
 
 
 @asynccontextmanager
-async def lifespan(app: FastAPI):
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     """Application lifespan context manager."""
     global _planner, _executor, _hcg_client, _cwm_g, _cwm_a, _kg, _jepa_runner
 

--- a/src/sophia/storage/database.py
+++ b/src/sophia/storage/database.py
@@ -1,9 +1,10 @@
 """Database abstraction layer for persistent storage."""
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 
 from sqlalchemy import create_engine, Column, String, JSON, MetaData, Table
 from sqlalchemy.orm import sessionmaker, Session
+from sqlalchemy.engine import CursorResult
 
 
 class Database:
@@ -224,11 +225,14 @@ class Database:
         """
         session = self._get_session()
         try:
-            result = session.execute(
-                self.nodes_table.delete().where(self.nodes_table.c.id == node_id)
+            result = cast(
+                CursorResult[Any],
+                session.execute(
+                    self.nodes_table.delete().where(self.nodes_table.c.id == node_id)
+                ),
             )
             session.commit()
-            return result.rowcount > 0
+            return bool(result.rowcount and result.rowcount > 0)
         finally:
             session.close()
 
@@ -243,11 +247,14 @@ class Database:
         """
         session = self._get_session()
         try:
-            result = session.execute(
-                self.edges_table.delete().where(self.edges_table.c.id == edge_id)
+            result = cast(
+                CursorResult[Any],
+                session.execute(
+                    self.edges_table.delete().where(self.edges_table.c.id == edge_id)
+                ),
             )
             session.commit()
-            return result.rowcount > 0
+            return bool(result.rowcount and result.rowcount > 0)
         finally:
             session.close()
 


### PR DESCRIPTION
## Summary
- switch .github/workflows/ci.yml to the shared LOGOS template with Poetry + coverage on 3.12
- add the matching local command list to README so devs can mirror CI
- fix mypy issues (networkx stubs, SQLAlchemy rowcount typing, lifespan annotation) so the new job stays green

## Testing
- poetry run mypy src
- poetry run pytest tests/ -v -m "not integration"