### PR TITLE
feat: adopt standard CI workflow with canonical commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,13 @@ Thank you for your interest in contributing to Sophia! This document provides gu
 
 ## Development Setup
 
+### Prerequisites
+
+- Python >=3.11
+- Poetry (recommended)
+
+### Setup with Poetry
+
 1. Clone the repository:
    ```bash
    git clone https://github.com/c-daly/sophia.git
@@ -19,13 +26,27 @@ Thank you for your interest in contributing to Sophia! This document provides gu
 
 3. Install dependencies:
    ```bash
-   poetry install
+   poetry install --with dev
    ```
 
 4. Run tests to verify your setup:
    ```bash
    poetry run pytest
    ```
+
+## CI Parity: Running All Checks Locally
+
+Before opening a pull request, run these commands to mirror the GitHub Actions CI pipeline:
+
+```bash
+poetry install --with dev
+poetry run ruff check src tests
+poetry run black --check src tests
+poetry run mypy src
+poetry run pytest tests/ -v -m "not integration" --cov=sophia --cov-report=term --cov-report=xml
+```
+
+All checks must pass for your PR to be merged. Note: Integration tests requiring Neo4j/Milvus are excluded from CI using the `-m "not integration"` marker.
 
 ## Development Workflow
 
@@ -43,10 +64,11 @@ Thank you for your interest in contributing to Sophia! This document provides gu
    poetry run pytest
    ```
 
-5. Format and lint your code:
+5. Format and lint your code (see CI Parity section above for all checks):
    ```bash
    poetry run black src tests
    poetry run ruff check src tests
+   poetry run mypy src
    ```
 
 6. Commit your changes with a clear commit message:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Sophia
 
+[![CI](https://github.com/c-daly/sophia/actions/workflows/ci.yml/badge.svg)](https://github.com/c-daly/sophia/actions/workflows/ci.yml)
+
 **Non-linguistic cognitive core for Project LOGOS**
 
 Sophia is a foundational infrastructure for building knowledge graphs and managing cognitive data structures. It provides a flexible, extensible framework for representing and storing knowledge in a graph-based format.


### PR DESCRIPTION
## Summary
This PR implements the CI parity requirements from issue #19 by adding documentation for canonical commands and CI status badges.

## Changes
- ✅ Added CI status badge to README
- ✅ Added "CI Parity" section to CONTRIBUTING.md with canonical commands
- ✅ Updated development workflow documentation
- ✅ All checks pass locally:
  - `poetry run ruff check src tests` ✅
  - `poetry run black --check src tests` ✅
  - `poetry run mypy src` ✅
  - `poetry run pytest tests/ -v -m "not integration" --cov=sophia --cov-report=term --cov-report=xml` ✅ (78% coverage)

## Notes
- The reusable workflow was already configured in `.github/workflows/ci.yml`
- README already had "Local Testing (CI Parity)" section with correct commands
- Integration tests are properly marked with `@pytest.mark.integration` and excluded in CI via `-m "not integration"`
- Neo4j/Milvus dependencies are mocked in unit tests
- 164 unit tests pass (17 integration tests deselected)
- SHACL validation and planner tests already integrated into the unit test suite

Resolves #19
Related to c-daly/apollo#32