### PR TITLE
fix(ci): force localhost for Neo4j/Milvus in integration tests

### DIFF
--- a/scripts/run_integration_stack.sh
+++ b/scripts/run_integration_stack.sh
@@ -148,9 +148,10 @@ for service in "${SERVICES[@]}"; do
 done
 
 # Export standard env vars (from .env.test, with localhost for host access)
-export MILVUS_HOST=${MILVUS_HOST:-"localhost"}
+# Override the Docker network hostnames with localhost since pytest runs from host
+export MILVUS_HOST="localhost"
 export MILVUS_PORT=${MILVUS_PORT:-"39530"}
-export NEO4J_URI=${NEO4J_URI:-"bolt://localhost:37687"}
+export NEO4J_URI="bolt://localhost:37687"
 export NEO4J_USER=${NEO4J_USER:-"neo4j"}
 export NEO4J_PASSWORD=${NEO4J_PASSWORD:-"neo4jtest"}
 export RUN_SOPHIA_INTEGRATION=1


### PR DESCRIPTION
## Summary

Fix integration tests failing because pytest can't resolve Docker network hostnames.

## Problem

The `.env.test` file contains Docker network hostnames:
```
NEO4J_URI=bolt://neo4j:37687
```

This gets sourced by `run_integration_stack.sh` before running pytest. The script tried to use default syntax (`${NEO4J_URI:-"bolt://localhost:37687"}`), but that only sets a value if the var is **unset** - it doesn't override.

Since pytest runs from the host machine (not inside Docker), it can't resolve `neo4j:37687` and all tests fail with:
```
Failed to DNS resolve address neo4j:37687
```

## Fix

Force `localhost` for Neo4j and Milvus hosts since pytest always runs from the host:
```bash
export MILVUS_HOST="localhost"
export NEO4J_URI="bolt://localhost:37687"
```

## Related

Follow-up to #54 which fixed container health checks but didn't catch this issue.