### PR TITLE
docs: update token to sophia_dev across examples

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,11 @@
 # Sophia API Configuration
 
-# Authentication token (REQUIRED for production)
-# Generate a secure token and set this environment variable
-SOPHIA_API_TOKEN=dev-token-change-in-production
+# Authentication token (REQUIRED)
+# This token is validated against incoming Authorization: Bearer headers.
+# All clients (Apollo, Hermes) must send this same token.
+# For development: use "sophia_dev"
+# For production: generate a secure random token
+SOPHIA_API_TOKEN=sophia_dev
 
 # Neo4j Configuration
 NEO4J_URI=bolt://localhost:7687

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     ports:
       - "8000:8000"
     environment:
-      - SOPHIA_API_TOKEN=${SOPHIA_API_TOKEN:-dev-token-change-in-production}
+      - SOPHIA_API_TOKEN=${SOPHIA_API_TOKEN:-sophia_dev}
       - NEO4J_URI=bolt://neo4j:7687
       - NEO4J_USER=neo4j
       - NEO4J_PASSWORD=neo4jtest

--- a/docs/MEDIA_INGESTION.md
+++ b/docs/MEDIA_INGESTION.md
@@ -78,7 +78,7 @@ Upload a media file for processing.
 **Example (curl):**
 ```bash
 curl -X POST http://localhost:8000/ingest/media \
-  -H "Authorization: Bearer dev-token-change-in-production" \
+  -H "Authorization: Bearer sophia_dev" \
   -F "file=@/path/to/image.jpg" \
   -F "media_type=image" \
   -F "question=What objects are visible?"
@@ -89,7 +89,7 @@ curl -X POST http://localhost:8000/ingest/media \
 import requests
 
 url = "http://localhost:8000/ingest/media"
-headers = {"Authorization": "Bearer dev-token-change-in-production"}
+headers = {"Authorization": "Bearer sophia_dev"}
 
 files = {"file": ("photo.jpg", open("photo.jpg", "rb"), "image/jpeg")}
 data = {
@@ -148,11 +148,11 @@ List media samples with optional filtering and pagination.
 ```bash
 # List all images
 curl -X GET "http://localhost:8000/media/samples?media_type=image&limit=10" \
-  -H "Authorization: Bearer dev-token-change-in-production"
+  -H "Authorization: Bearer sophia_dev"
 
 # List samples after a timestamp
 curl -X GET "http://localhost:8000/media/samples?after_timestamp=2025-01-15T00:00:00Z" \
-  -H "Authorization: Bearer dev-token-change-in-production"
+  -H "Authorization: Bearer sophia_dev"
 ```
 
 **Example (Python):**
@@ -160,7 +160,7 @@ curl -X GET "http://localhost:8000/media/samples?after_timestamp=2025-01-15T00:0
 import requests
 
 url = "http://localhost:8000/media/samples"
-headers = {"Authorization": "Bearer dev-token-change-in-production"}
+headers = {"Authorization": "Bearer sophia_dev"}
 params = {
     "media_type": "image",
     "limit": 20,
@@ -213,7 +213,7 @@ Retrieve details for a specific media sample.
 **Example (curl):**
 ```bash
 curl -X GET http://localhost:8000/media/samples/ms_abc123 \
-  -H "Authorization: Bearer dev-token-change-in-production"
+  -H "Authorization: Bearer sophia_dev"
 ```
 
 **Example (Python):**
@@ -222,7 +222,7 @@ import requests
 
 sample_id = "ms_abc123"
 url = f"http://localhost:8000/media/samples/{sample_id}"
-headers = {"Authorization": "Bearer dev-token-change-in-production"}
+headers = {"Authorization": "Bearer sophia_dev"}
 
 response = requests.get(url, headers=headers)
 if response.status_code == 200:

--- a/examples/media_ingest_example.py
+++ b/examples/media_ingest_example.py
@@ -13,7 +13,7 @@ import io
 
 # Configuration
 API_BASE_URL = "http://localhost:8000"
-API_TOKEN = "dev-token-change-in-production"
+API_TOKEN = "sophia_dev"
 HEADERS = {"Authorization": f"Bearer {API_TOKEN}"}
 
 


### PR DESCRIPTION
## Summary

Standardizes authentication token to `sophia_dev` across all examples and documentation.

## Changes

- `.env.example`: Update token documentation to use `sophia_dev`
- `docs/MEDIA_INGESTION.md`: Update curl examples with correct token
- `examples/media_ingest_example.py`: Update example script with correct token
- `docker-compose.yml`: Ensure consistent token configuration

## Rationale

All services in the LOGOS stack now use `sophia_dev` as the standard development token. This ensures:
- Consistent configuration across Apollo, Hermes, and Sophia
- Working media upload pipeline out of the box
- Clear documentation for developers

## Related

- Companion PRs:
  - apollo: `feat/110-media-upload-via-hermes`
  - hermes: `feat/110-media-ingest-proxy`
  - logos: `docs/phase2-status-dec2` (#410)