### PR TITLE
feat: enable integration tests in CI with containers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ permissions:
   contents: read
 
 jobs:
+  # ---------------------------------------------------------------------------
+  # Standard CI: Unit tests (no external services)
+  # ---------------------------------------------------------------------------
   standard:
     uses: c-daly/logos/.github/workflows/reusable-standard-ci.yml@main
     with:
@@ -22,3 +25,67 @@ jobs:
       pytest_command: 'pytest tests/ -v -m "not integration" --cov=sophia --cov-report=term --cov-report=xml'
       coverage_python_version: '3.12'
       upload_coverage: false
+
+  # ---------------------------------------------------------------------------
+  # Integration Tests: Runs with real Neo4j and Milvus
+  # Uses offset ports (37xxx, 39xxx) to avoid conflicts with other repos
+  # ---------------------------------------------------------------------------
+  integration-test:
+    runs-on: ubuntu-latest
+    needs: standard
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: latest
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+
+      - name: Install dependencies
+        run: poetry install --with dev
+
+      - name: Start test services
+        run: |
+          docker compose -f tests/e2e/stack/sophia/docker-compose.test.yml up -d neo4j milvus-etcd milvus-minio milvus
+          
+      - name: Wait for Neo4j
+        run: |
+          echo "Waiting for Neo4j on port 37687..."
+          timeout 60 bash -c 'until docker exec sophia-test-neo4j cypher-shell -u neo4j -p neo4jtest "RETURN 1" 2>/dev/null; do sleep 2; done'
+          echo "Neo4j ready"
+
+      - name: Wait for Milvus
+        run: |
+          echo "Waiting for Milvus on port 39091..."
+          timeout 120 bash -c 'until curl -f http://localhost:39091/healthz 2>/dev/null; do sleep 2; done'
+          echo "Milvus ready"
+
+      - name: Run integration tests
+        env:
+          NEO4J_URI: bolt://localhost:37687
+          NEO4J_USER: neo4j
+          NEO4J_PASSWORD: neo4jtest
+          MILVUS_HOST: localhost
+          MILVUS_PORT: "39530"
+        run: |
+          poetry run pytest tests/integration/ -v --cov=sophia --cov-report=xml --cov-report=term
+
+      - name: Upload integration test coverage
+        uses: codecov/codecov-action@v4
+        with:
+          file: ./coverage.xml
+          flags: integration
+          fail_ci_if_error: false
+
+      - name: Stop services
+        if: always()
+        run: docker compose -f tests/e2e/stack/sophia/docker-compose.test.yml down -v

--- a/scripts/run_integration.sh
+++ b/scripts/run_integration.sh
@@ -1,0 +1,213 @@
+#!/bin/bash
+# Sophia E2E/Integration test runner script with convenience commands
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+STACK_DIR="${REPO_ROOT}/tests/e2e/stack/sophia"
+COMPOSE_FILE="${DOCKER_COMPOSE_FILE:-${STACK_DIR}/docker-compose.test.yml}"
+
+# Sophia uses offset ports to avoid conflicts with other LOGOS repos
+NEO4J_HTTP_PORT="${NEO4J_HTTP_PORT:-37474}"
+NEO4J_BOLT_PORT="${NEO4J_BOLT_PORT:-37687}"
+MILVUS_PORT="${MILVUS_PORT:-39530}"
+MILVUS_METRICS_PORT="${MILVUS_METRICS_PORT:-39091}"
+
+NEO4J_CONTAINER="${NEO4J_CONTAINER:-sophia-test-neo4j}"
+MILVUS_CONTAINER="${MILVUS_CONTAINER:-sophia-test-milvus}"
+NEO4J_USER="${NEO4J_USER:-neo4j}"
+NEO4J_PASSWORD="${NEO4J_PASSWORD:-neo4jtest}"
+
+export NEO4J_HTTP_PORT NEO4J_BOLT_PORT MILVUS_PORT MILVUS_METRICS_PORT
+export NEO4J_CONTAINER MILVUS_CONTAINER NEO4J_USER NEO4J_PASSWORD
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+compose() {
+    docker compose -f "${COMPOSE_FILE}" "$@"
+}
+
+function print_usage() {
+    echo "Usage: $0 [command]"
+    echo ""
+    echo "Commands:"
+    echo "  test       Run integration tests (default)"
+    echo "  up         Start services only"
+    echo "  down       Stop and remove services"
+    echo "  logs       Show service logs"
+    echo "  status     Check service status"
+    echo "  clean      Clean up everything including volumes"
+    echo "  help       Show this help message"
+    echo ""
+    echo "Port Configuration (Sophia uses offset ports):"
+    echo "  Neo4j:  ${NEO4J_BOLT_PORT} (bolt), ${NEO4J_HTTP_PORT} (http)"
+    echo "  Milvus: ${MILVUS_PORT} (grpc), ${MILVUS_METRICS_PORT} (health)"
+    echo ""
+    echo "Examples:"
+    echo "  $0                  # Run full test"
+    echo "  $0 up              # Start services for manual testing"
+    echo "  $0 logs            # View logs"
+    echo "  $0 down            # Stop services"
+}
+
+function stop_containers_on_ports() {
+    local ports=(
+        "${NEO4J_HTTP_PORT}"
+        "${NEO4J_BOLT_PORT}"
+        "${MILVUS_PORT}"
+        "${MILVUS_METRICS_PORT}"
+    )
+    for port in "${ports[@]}"; do
+        local container=$(docker ps --format '{{.ID}}' --filter "publish=${port}" 2>/dev/null)
+        if [ -n "$container" ]; then
+            echo -e "${YELLOW}Stopping container using port ${port}...${NC}"
+            docker stop "$container" 2>/dev/null || true
+        fi
+    done
+}
+
+function start_services() {
+    echo -e "${BLUE}Stopping any containers using test ports...${NC}"
+    stop_containers_on_ports
+    compose down 2>/dev/null || true
+    
+    echo -e "${BLUE}Starting Sophia test services...${NC}"
+    compose up -d
+    
+    echo -e "${YELLOW}Waiting for services to be healthy...${NC}"
+    sleep 5
+    
+    # Check Neo4j
+    echo -n "Neo4j: "
+    local max_attempts=30
+    local attempt=1
+    while [ $attempt -le $max_attempts ]; do
+        if compose exec -T neo4j cypher-shell -u neo4j -p neo4jtest "RETURN 1" > /dev/null 2>&1; then
+            echo -e "${GREEN}✓ Ready${NC}"
+            break
+        fi
+        echo -n "."
+        sleep 2
+        ((attempt++))
+    done
+    if [ $attempt -gt $max_attempts ]; then
+        echo -e "${RED}✗ Not ready (timeout)${NC}"
+    fi
+    
+    # Check Milvus
+    echo -n "Milvus: "
+    max_attempts=60
+    attempt=1
+    while [ $attempt -le $max_attempts ]; do
+        if curl -s -f "http://localhost:${MILVUS_METRICS_PORT}/healthz" > /dev/null 2>&1; then
+            echo -e "${GREEN}✓ Ready${NC}"
+            break
+        fi
+        echo -n "."
+        sleep 2
+        ((attempt++))
+    done
+    if [ $attempt -gt $max_attempts ]; then
+        echo -e "${RED}✗ Not ready (timeout)${NC}"
+    fi
+}
+
+function stop_services() {
+    echo -e "${BLUE}Stopping Sophia test services...${NC}"
+    compose down
+    echo -e "${GREEN}Services stopped${NC}"
+}
+
+function show_logs() {
+    compose logs "$@"
+}
+
+function check_status() {
+    echo -e "${BLUE}Service Status:${NC}"
+    compose ps
+    
+    echo ""
+    echo -e "${BLUE}Health Checks:${NC}"
+    
+    echo -n "Neo4j (bolt://localhost:${NEO4J_BOLT_PORT}): "
+    if compose exec -T neo4j cypher-shell -u neo4j -p neo4jtest "RETURN 1" > /dev/null 2>&1; then
+        echo -e "${GREEN}✓ Healthy${NC}"
+    else
+        echo -e "${RED}✗ Unhealthy${NC}"
+    fi
+    
+    echo -n "Milvus (localhost:${MILVUS_PORT}): "
+    if curl -s -f "http://localhost:${MILVUS_METRICS_PORT}/healthz" > /dev/null 2>&1; then
+        echo -e "${GREEN}✓ Healthy${NC}"
+    else
+        echo -e "${RED}✗ Unhealthy${NC}"
+    fi
+}
+
+function run_tests() {
+    echo -e "${BLUE}Running Sophia integration tests...${NC}"
+    cd "${REPO_ROOT}"
+    
+    # Export environment variables for tests
+    export NEO4J_URI="bolt://localhost:${NEO4J_BOLT_PORT}"
+    export NEO4J_USER NEO4J_PASSWORD
+    export MILVUS_HOST="localhost"
+    export MILVUS_PORT
+    
+    echo -e "${YELLOW}NEO4J_URI=${NEO4J_URI}${NC}"
+    echo -e "${YELLOW}MILVUS_HOST=localhost:${MILVUS_PORT}${NC}"
+
+    set +e
+    poetry run pytest tests/integration/ -v --tb=short
+    local test_status=$?
+    set -e
+
+    return $test_status
+}
+
+function clean_all() {
+    echo -e "${YELLOW}Cleaning up all Sophia test resources...${NC}"
+    compose down -v
+    echo -e "${GREEN}Cleanup complete${NC}"
+}
+
+# Main command handling
+COMMAND="${1:-test}"
+
+case "$COMMAND" in
+    test)
+        start_services
+        run_tests
+        ;;
+    up)
+        start_services
+        ;;
+    down)
+        stop_services
+        ;;
+    logs)
+        shift
+        show_logs "$@"
+        ;;
+    status)
+        check_status
+        ;;
+    clean)
+        clean_all
+        ;;
+    help|--help|-h)
+        print_usage
+        ;;
+    *)
+        echo -e "${RED}Unknown command: $COMMAND${NC}"
+        echo ""
+        print_usage
+        exit 1
+        ;;
+esac

--- a/tests/integration/test_media_ingestion_integration.py
+++ b/tests/integration/test_media_ingestion_integration.py
@@ -2,6 +2,9 @@
 
 These tests require Neo4j to be running.
 Run with: pytest tests/integration/test_media_ingestion_integration.py -v -m integration
+
+In CI, these run automatically with containerized Neo4j.
+Locally, start services with: docker compose -f docker-compose.test.yml up -d
 """
 
 import io
@@ -13,17 +16,10 @@ from fastapi.testclient import TestClient
 from sophia.api.app import create_app
 
 
-# Support both new and legacy env var names for backwards compatibility
-RUN_SOPHIA_INTEGRATION = os.getenv("RUN_SOPHIA_INTEGRATION") == "1"
-RUN_MEDIA_INTEGRATION = os.getenv("RUN_MEDIA_INTEGRATION") == "1"
-INTEGRATION_ENABLED = RUN_SOPHIA_INTEGRATION or RUN_MEDIA_INTEGRATION
-
+# Integration tests are run by CI with real services.
+# The pytest.mark.integration marker allows running unit tests separately with -m "not integration"
 pytestmark = [
     pytest.mark.integration,
-    pytest.mark.skipif(
-        not INTEGRATION_ENABLED,
-        reason="Integration tests require external Neo4j; set RUN_SOPHIA_INTEGRATION=1 to enable.",
-    ),
 ]
 
 
@@ -36,8 +32,8 @@ def test_token():
 @pytest.fixture
 def client(test_token):
     """Create FastAPI test client with lifespan context."""
-    # Set up environment for integration testing
-    # Use 37xxx ports to match CI docker-compose.test.yml
+    # Use offset ports (37xxx) to avoid conflicts with other repos' test stacks
+    # CI sets these via env vars; defaults match tests/e2e/stack/sophia/docker-compose.test.yml
     os.environ.setdefault("NEO4J_URI", "bolt://localhost:37687")
     os.environ.setdefault("NEO4J_USER", "neo4j")
     os.environ.setdefault("NEO4J_PASSWORD", "neo4jtest")

--- a/tests/integration/test_prototype_integration.py
+++ b/tests/integration/test_prototype_integration.py
@@ -2,6 +2,9 @@
 
 These tests require Neo4j and Milvus to be running.
 Run with: pytest tests/integration/test_prototype_integration.py -v -m integration
+
+In CI, these run automatically with containerized Neo4j and Milvus.
+Locally, start services with: docker compose -f docker-compose.test.yml up -d
 """
 
 import os
@@ -12,23 +15,16 @@ from sophia.api.app import create_app
 from sophia.hcg_client import HCGClient
 
 
-# Support both new and legacy env var names for backwards compatibility
-RUN_SOPHIA_INTEGRATION = os.getenv("RUN_SOPHIA_INTEGRATION") == "1"
-RUN_PROTOTYPE_INTEGRATION = os.getenv("RUN_PROTOTYPE_INTEGRATION") == "1"
-INTEGRATION_ENABLED = RUN_SOPHIA_INTEGRATION or RUN_PROTOTYPE_INTEGRATION
-
+# Integration tests are run by CI with real services.
+# The pytest.mark.integration marker allows running unit tests separately with -m "not integration"
 pytestmark = [
     pytest.mark.integration,
-    pytest.mark.skipif(
-        not INTEGRATION_ENABLED,
-        reason="Integration tests require external Neo4j/Milvus; set RUN_SOPHIA_INTEGRATION=1 to enable.",
-    ),
 ]
 
 
 @pytest.fixture
 def neo4j_uri():
-    """Neo4j connection URI."""
+    """Neo4j connection URI - uses offset port 37687."""
     return os.getenv("NEO4J_URI", "bolt://localhost:37687")
 
 
@@ -52,25 +48,22 @@ def milvus_host():
 
 @pytest.fixture
 def milvus_port():
-    """Milvus port."""
+    """Milvus port - uses offset port 39530."""
     return int(os.getenv("MILVUS_PORT", "39530"))
 
 
 @pytest.fixture
 def hcg_client(neo4j_uri, neo4j_username, neo4j_password, milvus_host, milvus_port):
     """Create HCG client for test setup."""
-    try:
-        client = HCGClient(
-            neo4j_uri=neo4j_uri,
-            neo4j_username=neo4j_username,
-            neo4j_password=neo4j_password,
-            milvus_host=milvus_host,
-            milvus_port=milvus_port,
-        )
-        yield client
-        client.close()
-    except Exception as e:
-        pytest.skip(f"HCG services not available: {e}")
+    client = HCGClient(
+        neo4j_uri=neo4j_uri,
+        neo4j_username=neo4j_username,
+        neo4j_password=neo4j_password,
+        milvus_host=milvus_host,
+        milvus_port=milvus_port,
+    )
+    yield client
+    client.close()
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Enable integration tests to run in CI by adding container infrastructure for Neo4j and Milvus.

## Changes

### CI Workflow (`.github/workflows/ci.yml`)
- Add new `integration-test` job that runs after unit tests pass
- Uses docker compose to start Neo4j and Milvus containers
- Waits for services to be healthy before running tests
- Uses offset ports (37xxx, 39xxx) to avoid conflicts with other LOGOS repos

### Integration Tests
- **`test_media_ingestion_integration.py`**: Remove `skipif` condition - tests now run in CI
- **`test_prototype_integration.py`**: Remove `skipif` condition - tests now run in CI
- Both tests use environment variables for connection config (NEO4J_URI, MILVUS_HOST, etc.)

### Local Testing Script
- Add `scripts/run_integration.sh` for convenient local testing
- Commands: `up`, `down`, `test`, `status`, `logs`, `clean`
- Mirrors pattern from `logos/tests/e2e/run_e2e.sh`

## Port Configuration

Sophia uses offset ports to avoid conflicts:
| Service | Port | Purpose |
|---------|------|---------|
| Neo4j HTTP | 37474 | Browser |
| Neo4j Bolt | 37687 | Connections |
| Milvus gRPC | 39530 | Vector ops |
| Milvus Health | 39091 | Health checks |

## Testing

```bash
# Local testing
./scripts/run_integration.sh up      # Start containers
./scripts/run_integration.sh test    # Run tests
./scripts/run_integration.sh down    # Stop containers

# Or all-in-one
./scripts/run_integration.sh
```

## Related

Part of Phase 2.5 testing infrastructure improvements (issue c-daly/logos#416)