### PR TITLE
ci: separate build and publish workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+name: Build Sophia Container
+
+on:
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'Dockerfile'
+      - 'pyproject.toml'
+      - 'poetry.lock'
+      - '.github/workflows/build.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Sophia container
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,13 @@
 name: Publish Sophia Container
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'Dockerfile'
+      - 'pyproject.toml'
+      - 'poetry.lock'
   release:
     types: [published]
   workflow_dispatch:
@@ -31,6 +38,20 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Build Sophia container
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/sophia:${{ steps.version.outputs.version }}
+            ghcr.io/${{ github.repository_owner }}/sophia:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -38,18 +59,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push Sophia container
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ./Dockerfile
-          platforms: linux/amd64
-          push: true
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/sophia:${{ steps.version.outputs.version }}
-            ghcr.io/${{ github.repository_owner }}/sophia:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Push Sophia container
+        run: |
+          docker push ghcr.io/${{ github.repository_owner }}/sophia:${{ steps.version.outputs.version }}
+          docker push ghcr.io/${{ github.repository_owner }}/sophia:latest
 
       - name: Image published
         run: |


### PR DESCRIPTION
## Summary

Separates container build and publish into distinct workflows for better CI safety.

## Changes

### New `build.yml`
- Triggers on PRs when relevant paths change (src/, Dockerfile, pyproject.toml, poetry.lock)
- Builds container without pushing
- Validates Dockerfile works before merging

### Updated `publish.yml`
- Triggers on main push and releases (added main push trigger)
- Separate build step (with `load: true`) then push step
- Clearer separation of concerns

## Testing

- [ ] Build workflow triggers on this PR
- [ ] Container builds successfully

## Related

Part of c-daly/logos#423