### PR TITLE
chore: use reusable publish workflow from logos [SUPERSEDED by #84]

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,10 @@ on:
     types: [published]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   publish:
     uses: c-daly/logos/.github/workflows/reusable-publish.yml@main


### PR DESCRIPTION
## Summary

~~Uses the reusable publish workflow from logos for standardized Docker image publishing.~~

**Superseded by [#84](https://github.com/c-daly/sophia/pull/84)** - The changes from this PR have been incorporated into the logos#433 shared config PR, which includes additional JEPA improvements.

## Original Changes

- Switched to reusable `reusable-publish.yml` workflow from logos
- Added required `permissions: packages: write` block for GHCR

## Status

This PR can be closed. Please review #84 instead.