### PR TITLE
fix: standardize Milvus gRPC port to sophia +40000 offset

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -102,7 +102,7 @@ services:
     volumes:
     - sophia_test_milvus:/var/lib/milvus
     ports:
-    - 49530:19530
+    - 59530:19530
     - 49091:9091
     healthcheck:
       test:


### PR DESCRIPTION
## Summary
Part of logos#433 - Port standardization across LOGOS repos

Updates sophia Milvus gRPC port to use correct +40000 offset.

### Changes
- Updated `docker-compose.test.yml`:
  - Milvus gRPC: 49530 → 59530

Neo4j ports (47474/47687) and Milvus metrics (49091) were already correct.

### Port Values
| Service | Port |
|---------|------|
| Neo4j HTTP | 47474 |
| Neo4j Bolt | 47687 |
| Milvus gRPC | 59530 |
| Milvus Metrics | 49091 |