### PR TITLE
Fix: regenerate poetry.lock and fix linting errors

### DIFF
--- a/examples/jepa_poc_demo.py
+++ b/examples/jepa_poc_demo.py
@@ -23,7 +23,7 @@ import sys
 import asyncio
 import tempfile
 from pathlib import Path
-from typing import Dict, Any, List, Optional
+from typing import Any
 
 # Check for torch availability
 try:

--- a/examples/media_ingest_example.py
+++ b/examples/media_ingest_example.py
@@ -10,7 +10,7 @@ This example shows how to:
 import requests
 from PIL import Image
 import io
-from typing import Dict, Any, Optional
+from typing import Dict, Any
 
 # Configuration
 API_BASE_URL = "http://localhost:8000"

--- a/examples/milestone_m3_demo.py
+++ b/examples/milestone_m3_demo.py
@@ -21,7 +21,7 @@ from sophia import (
     ContinuousWorkingMemoryGenerative,
 )
 from sophia.knowledge_graph import Node, Edge
-from typing import Dict, Any, List, Optional
+from typing import Dict, Any
 
 
 def create_world_model() -> KnowledgeGraph:

--- a/examples/poc_jepa_demo.py
+++ b/examples/poc_jepa_demo.py
@@ -22,7 +22,6 @@ from PIL import Image
 
 from sophia.jepa import JEPARunner
 from sophia.jepa.models import SimulationContext, Entity
-from typing import Dict, Any, List, Optional
 
 
 def create_sample_image() -> str:

--- a/poetry.lock
+++ b/poetry.lock
@@ -2860,6 +2860,21 @@ files = [
 ]
 
 [[package]]
+name = "types-requests"
+version = "2.32.4.20250913"
+description = "Typing stubs for requests"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "types_requests-2.32.4.20250913-py3-none-any.whl", hash = "sha256:78c9c1fffebbe0fa487a418e0fa5252017e9c60d1a2da394077f1780f655d7e1"},
+    {file = "types_requests-2.32.4.20250913.tar.gz", hash = "sha256:abd6d4f9ce3a9383f269775a9835a4c24e5cd6b9f647d64f88aa4613c33def5d"},
+]
+
+[package.dependencies]
+urllib3 = ">=2"
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 description = "Backported and Experimental Type Hints for Python 3.9+"
@@ -2904,7 +2919,7 @@ version = "2.5.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc"},
     {file = "urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760"},
@@ -3260,4 +3275,4 @@ ml-gpu = []
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "a6f111cd0dd4548149730b88ac81acfdc7d7b6e913d759d6661fc2e0f6f53f5e"
+content-hash = "97896d894bdc727fe2609c385db2ff9af2423b2da14527e71a45ecf23a84ce04"


### PR DESCRIPTION
## Summary

Fixes CI failures by regenerating `poetry.lock` and fixing linting errors.

## Changes

- Regenerated `poetry.lock` to sync with `pyproject.toml`
- Fixed 10 linting errors in example files

Fixes #87

## Reference

- CI Run #239