### PR TITLE
Fix: remove invalid path_filters input from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,5 +25,4 @@ jobs:
     uses: c-daly/logos/.github/workflows/reusable-publish.yml@main
     with:
       image_name: sophia
-      path_filters: 'src/**,Dockerfile,pyproject.toml,poetry.lock'
     secrets: inherit


### PR DESCRIPTION
## Problem

Main branch publish workflow is failing with:

```
Invalid workflow file: .github/workflows/publish.yml#L28
The workflow is not valid. .github/workflows/publish.yml (Line: 28, Col: 21): 
Invalid input, path_filters is not defined in the referenced workflow.
```

## Fix

Remove `path_filters` input - it's not defined in the reusable-publish.yml workflow. Path filtering is already handled by the `on.push.paths` trigger at the top of the file.

## Related

- Issue #87