### PR TITLE
chore: add CI discipline tooling

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,46 @@
+<!--
+Pull Request template for Project LOGOS
+Ensure the PR references its issue (use `Closes #<issue-number>` when ready to close).
+-->
+
+# PR Title
+[area] Short summary (#<issue>)
+
+## Summary
+Brief description of the change and why it is needed. Keep it short and focused.
+
+## Related Issue
+Closes #<issue-number>
+Or: See #<issue-number> (explain partial coverage)
+
+## Changes
+- Files / modules changed:
+  - `path/to/file.py`
+  - `webapp/src/components/MyPanel.tsx`
+
+## How to run / test locally
+Include exact commands and environment setup (copyable):
+
+```bash
+# From repo root
+pip install -e ".[dev]"
+cd webapp && npm install
+# Start mock webapp
+cd webapp && npm run dev:mock
+# Run Python tests
+pytest
+```
+
+## Checklist (required)
+- [ ] Linked the related issue (`Closes #<n>` or `See #<n>`)
+- [ ] Tests added or updated
+- [ ] Linting/formatting run (`black`/`ruff`; `npm run lint` for webapp)
+- [ ] Type checks (Python `mypy`/TS `npm run type-check`) as applicable
+- [ ] Documentation updated (README, `docs/`, or OpenAPI spec)
+- [ ] CI is passing
+
+## Reviewers / Code owners
+Please request at least one reviewer from the relevant area (use `CODEOWNERS` if present).
+
+## Notes
+Any additional notes for reviewers, rationale, or things to watch for.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,10 @@
 <!--
-Pull Request template for Project LOGOS
+Pull Request template for sophia
 Ensure the PR references its issue (use `Closes #<issue-number>` when ready to close).
 -->
 
 # PR Title
-[area] Short summary (#<issue>)
+[area] Short summary (#<issue-number>)
 
 ## Summary
 Brief description of the change and why it is needed. Keep it short and focused.
@@ -16,26 +16,22 @@ Or: See #<issue-number> (explain partial coverage)
 ## Changes
 - Files / modules changed:
   - `path/to/file.py`
-  - `webapp/src/components/MyPanel.tsx`
 
 ## How to run / test locally
 Include exact commands and environment setup (copyable):
 
 ```bash
 # From repo root
-pip install -e ".[dev]"
-cd webapp && npm install
-# Start mock webapp
-cd webapp && npm run dev:mock
-# Run Python tests
-pytest
+poetry install --with dev
+# Run tests (excludes ML tests requiring PyTorch)
+poetry run pytest tests/ -m "not requires_torch"
 ```
 
 ## Checklist (required)
 - [ ] Linked the related issue (`Closes #<n>` or `See #<n>`)
 - [ ] Tests added or updated
-- [ ] Linting/formatting run (`black`/`ruff`; `npm run lint` for webapp)
-- [ ] Type checks (Python `mypy`/TS `npm run type-check`) as applicable
+- [ ] Linting/formatting run (`ruff check --fix .` + `ruff format .`)
+- [ ] Type checks (`poetry run mypy src/`) as applicable
 - [ ] Documentation updated (README, `docs/`, or OpenAPI spec)
 - [ ] CI is passing
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -30,7 +30,7 @@ poetry run pytest tests/ -m "not requires_torch"
 ## Checklist (required)
 - [ ] Linked the related issue (`Closes #<n>` or `See #<n>`)
 - [ ] Tests added or updated
-- [ ] Linting/formatting run (`ruff check --fix .` + `ruff format .`)
+- [ ] Linting/formatting run (`ruff check --fix .` + `black .`)
 - [ ] Type checks (`poetry run mypy src/`) as applicable
 - [ ] Documentation updated (README, `docs/`, or OpenAPI spec)
 - [ ] CI is passing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,12 @@ permissions:
   contents: read
 
 jobs:
+  pr-checks:
+    if: github.event_name == 'pull_request'
+    uses: c-daly/logos/.github/workflows/reusable-pr-checks.yml@main
+    with:
+      require_issue_linkage: false
+
   # ---------------------------------------------------------------------------
   # Standard CI: Full tests with real services (Neo4j, Milvus)
   # Skips ML tests that require PyTorch (marked with @pytest.mark.requires_torch)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   pr-checks:
     if: github.event_name == 'pull_request'
-    uses: c-daly/logos/.github/workflows/reusable-pr-checks.yml@main
+    uses: c-daly/logos/.github/workflows/reusable-pr-checks.yml@ci/v2
     with:
       require_issue_linkage: false
 
@@ -31,7 +31,7 @@ jobs:
   # Uses consistent 47xxx ports per LOGOS ecosystem standard (logos_config.SOPHIA_PORTS)
   # ---------------------------------------------------------------------------
   standard:
-    uses: c-daly/logos/.github/workflows/reusable-standard-ci.yml@ci/v1
+    uses: c-daly/logos/.github/workflows/reusable-standard-ci.yml@ci/v2
     with:
       python_versions: '["3.12"]'
       python_package_manager: 'poetry'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,11 @@ repos:
       - id: ruff
         # --exit-non-zero-on-fix: require devs to review auto-fixes before committing
         args: [--fix, --exit-non-zero-on-fix]
-      - id: ruff-format
+
+  - repo: https://github.com/psf/black
+    rev: "25.11.0"
+    hooks:
+      - id: black
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.2
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+
+  - repo: local
+    hooks:
+      - id: pytest-push
+        name: pytest (pre-push)
+        entry: poetry run pytest tests/ -x -q --timeout=60
+        language: system
+        stages: [pre-push]
+        pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,7 @@ repos:
     rev: v0.11.2
     hooks:
       - id: ruff
+        # --exit-non-zero-on-fix: require devs to review auto-fixes before committing
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
 
@@ -18,7 +19,7 @@ repos:
     hooks:
       - id: pytest-push
         name: pytest (pre-push)
-        entry: poetry run pytest tests/ -x -q --timeout=60
+        entry: poetry run pytest tests/ -x -q -m "not requires_torch"
         language: system
         stages: [pre-push]
         pass_filenames: false


### PR DESCRIPTION
## Summary
- Add PR template matching logos standard (includes issue linkage checklist)
- Add `pr-checks` job to CI for issue linkage verification (warn-only)
- Add standardized `.pre-commit-config.yaml` (ruff, pre-commit-hooks, pytest pre-push)

## Related Issue
See c-daly/logos#416

## Test plan
- [ ] Verify PR template appears on new PRs
- [ ] Verify pr-checks job runs on PRs (requires logos PR merged first)
- [ ] Run `pre-commit run --all-files` locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)