### PR TITLE
Pin publish.yml to ci/v2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,13 +22,13 @@ permissions:
 
 jobs:
   publish:
-    uses: c-daly/logos/.github/workflows/reusable-publish.yml@ci/v1
+    uses: c-daly/logos/.github/workflows/reusable-publish.yml@ci/v2
     with:
       image_name: sophia
     secrets: inherit
 
   publish-ml:
-    uses: c-daly/logos/.github/workflows/reusable-publish.yml@ci/v1
+    uses: c-daly/logos/.github/workflows/reusable-publish.yml@ci/v2
     with:
       image_name: sophia
       tag_override: ml-latest


### PR DESCRIPTION
## Summary
- Update reusable-publish.yml references from @ci/v1/@main to @ci/v2

## Test plan
- [ ] Verify publish workflow still triggers correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)