### PR TITLE
fix(ingestion): stop swallowing embedding-persistence failures (#146)

### DIFF
--- a/src/sophia/ingestion/proposal_processor.py
+++ b/src/sophia/ingestion/proposal_processor.py
@@ -17,6 +17,27 @@ from sophia.ingestion.type_classifier import TypeClassifier
 
 logger = logging.getLogger(__name__)
 
+
+class EmbeddingPersistenceError(RuntimeError):
+    """Raised when flushing pending embeddings to Milvus fails.
+
+    Ingestion must not silently swallow a failed embedding write: an empty
+    ``hcg_*_embeddings`` collection starves the type classifier and emergent
+    type discovery. This error surfaces the failure to the caller so a
+    partially-ingested batch is reported instead of being reported as success.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        failures: "dict[str, str] | None" = None,
+    ) -> None:
+        super().__init__(message)
+        # Map of collection_type -> stringified underlying error.
+        self.failures: dict[str, str] = failures or {}
+
+
 try:
     from logos_observability import get_tracer
 
@@ -508,7 +529,15 @@ class ProposalProcessor:
                             }
                         )
 
-            # Flush all pending embeddings in batch
+            # Flush all pending embeddings in batch.
+            #
+            # A failed Milvus write must NOT be silently swallowed: when it is,
+            # ingestion reports success while the hcg_*_embeddings collections
+            # stay empty, starving the type classifier and emergent type
+            # discovery. We attempt every collection (so one bad collection
+            # does not mask the others), collect any failures, and raise so the
+            # caller sees the error instead of a false success.
+            embedding_failures: dict[str, str] = {}
             for collection_type, batch in pending_embeddings.items():
                 if batch:
                     try:
@@ -516,11 +545,20 @@ class ProposalProcessor:
                             node_type=collection_type, embeddings=batch
                         )
                     except Exception as e:
-                        logger.warning(
+                        logger.error(
                             "Batch embedding upsert failed for %s: %s",
                             collection_type,
                             e,
                         )
+                        embedding_failures[collection_type] = str(e)
+
+            if embedding_failures:
+                raise EmbeddingPersistenceError(
+                    "Failed to persist embeddings to Milvus for "
+                    f"{sorted(embedding_failures)}; ingestion did not complete "
+                    "and embedding collections may be empty.",
+                    failures=embedding_failures,
+                )
 
             # Write type snapshot BEFORE publishing event so subscribers
             # see up-to-date data when they react to the event.

--- a/src/sophia/ingestion/proposal_processor.py
+++ b/src/sophia/ingestion/proposal_processor.py
@@ -563,7 +563,7 @@ class ProposalProcessor:
                 rolled_back = 0
                 for uuid in stored_ids:
                     try:
-                        # DETACH DELETE also removes the node's edges.
+                        # delete_node also removes edge-nodes touching this node.
                         self._hcg.delete_node(uuid)
                         rolled_back += 1
                     except Exception:
@@ -572,12 +572,26 @@ class ProposalProcessor:
                             "embedding-persistence failure",
                             uuid,
                         )
+                # Edges are reified as Node entities. Deleting stored_ids drops the
+                # edges touching them, but an edge added this batch between two
+                # PRE-EXISTING nodes must be deleted by its own uuid too, or it
+                # survives the rollback (gemini asked to roll back stored_edge_ids).
+                for edge_uuid in stored_edge_ids:
+                    try:
+                        self._hcg.delete_node(edge_uuid)
+                        rolled_back += 1
+                    except Exception:
+                        logger.exception(
+                            "Rollback: failed to delete edge %s after "
+                            "embedding-persistence failure",
+                            edge_uuid,
+                        )
                 logger.critical(
                     "Embedding persistence failed for %s; rolled back %d/%d graph "
-                    "node(s) so the batch is cleanly retryable.",
+                    "node(s)+edge(s) so the batch is cleanly retryable.",
                     sorted(embedding_failures),
                     rolled_back,
-                    len(stored_ids),
+                    len(stored_ids) + len(stored_edge_ids),
                 )
                 raise EmbeddingPersistenceError(
                     "Failed to persist embeddings to Milvus for "

--- a/src/sophia/ingestion/proposal_processor.py
+++ b/src/sophia/ingestion/proposal_processor.py
@@ -553,10 +553,36 @@ class ProposalProcessor:
                         embedding_failures[collection_type] = str(e)
 
             if embedding_failures:
+                # The Neo4j nodes/edges (steps 2-3) already committed, but their
+                # embeddings did not land in Milvus. Orphaned nodes are invisible
+                # to the dedup search (search_similar), so a retry would re-create
+                # duplicates -- and no batch event is emitted for writes that
+                # half-landed. Data is wipeable down to the type baseline, so
+                # best-effort roll the partial graph writes back; a retry then
+                # re-creates cleanly. (Centroid drift is left as-is: regenerable.)
+                rolled_back = 0
+                for uuid in stored_ids:
+                    try:
+                        # DETACH DELETE also removes the node's edges.
+                        self._hcg.delete_node(uuid)
+                        rolled_back += 1
+                    except Exception:
+                        logger.exception(
+                            "Rollback: failed to delete node %s after "
+                            "embedding-persistence failure",
+                            uuid,
+                        )
+                logger.critical(
+                    "Embedding persistence failed for %s; rolled back %d/%d graph "
+                    "node(s) so the batch is cleanly retryable.",
+                    sorted(embedding_failures),
+                    rolled_back,
+                    len(stored_ids),
+                )
                 raise EmbeddingPersistenceError(
                     "Failed to persist embeddings to Milvus for "
-                    f"{sorted(embedding_failures)}; ingestion did not complete "
-                    "and embedding collections may be empty.",
+                    f"{sorted(embedding_failures)}; ingestion did not complete and "
+                    "the partially-written graph nodes were rolled back.",
                     failures=embedding_failures,
                 )
 

--- a/tests/integration/test_embedding_persistence_e2e.py
+++ b/tests/integration/test_embedding_persistence_e2e.py
@@ -77,6 +77,16 @@ def milvus_sync():
     except Exception as e:  # pragma: no cover - infra gate
         pytest.skip(f"Milvus not available at {host}:{port}: {e}")
 
+    # Isolation: start from a clean embedding space. Post-#146 embeddings actually
+    # persist, so nodes ingested by earlier integration modules survive in the
+    # shared test Milvus and would skew this module's row-count delta assertions
+    # (and dedup an ingest down to zero growth). Drop first so the module sees
+    # only its own data.
+    from pymilvus import utility
+
+    for _name in utility.list_collections(using=sync.alias):
+        utility.drop_collection(_name, using=sync.alias)
+
     for node_type in COLLECTION_NAMES:
         sync.ensure_collection(node_type)
 

--- a/tests/integration/test_embedding_persistence_e2e.py
+++ b/tests/integration/test_embedding_persistence_e2e.py
@@ -59,9 +59,14 @@ def _count_rows(sync: HCGMilvusSync, node_type: str) -> int:
     """Return the number of persisted rows in a collection.
 
     Uses ``num_entities`` after an explicit flush, which is reliable here
-    because ``batch_upsert_embeddings`` flushes on write.
+    because ``batch_upsert_embeddings`` flushes on write. Resolves the
+    collection from the public name + connection alias rather than the private
+    ``sync._get_collection`` accessor, so a rename there fails as a clean
+    assertion rather than an AttributeError.
     """
-    collection = sync._get_collection(node_type)
+    from pymilvus import Collection
+
+    collection = Collection(name=COLLECTION_NAMES[node_type], using=sync.alias)
     collection.flush()
     return int(collection.num_entities)
 

--- a/tests/integration/test_embedding_persistence_e2e.py
+++ b/tests/integration/test_embedding_persistence_e2e.py
@@ -1,0 +1,179 @@
+"""End-to-end test for embedding persistence at ingestion (#146).
+
+Regression guard for the keystone defect: the batch-flush of pending
+embeddings used to be wrapped in a warn-only ``try/except`` in
+``ProposalProcessor.process``. A failed Milvus write was swallowed, so
+ingestion reported success while the ``hcg_*_embeddings`` collections stayed
+empty -- starving the type classifier and #505 emergent type discovery.
+
+This test ingests a small fixture through the real ``ProposalProcessor`` against
+a live Neo4j + Milvus stack and asserts that the relevant
+``hcg_*_embeddings`` collection row count grows by exactly the number of
+embedded nodes/edges (previously it stayed at 0).
+
+Requires Neo4j + Milvus from the shared test stack. Connection comes from env:
+    NEO4J_URI, NEO4J_USER, NEO4J_PASSWORD, MILVUS_HOST, MILVUS_PORT
+
+Depends on the logos #528 fix (``HCGMilvusSync`` upsert-by-uuid) being
+installed in the environment so the upsert actually lands.
+"""
+
+import logging
+import os
+import uuid as uuid_lib
+
+import pytest
+
+from logos_hcg.sync import COLLECTION_NAMES, HCGMilvusSync
+
+from sophia.hcg_client import HCGClient
+from sophia.ingestion.proposal_processor import ProposalProcessor
+
+logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.integration
+
+DIM = int(os.getenv("LOGOS_EMBEDDING_DIM", "384"))
+
+
+def _make_centroid(index: int) -> list[float]:
+    """A vector with energy concentrated at ``index`` (mirrors the e2e helper)."""
+    vec = [0.0] * DIM
+    vec[index % DIM] = 1.0
+    for i in range(DIM):
+        vec[i] += 0.01
+    return vec
+
+
+def _make_near(centroid: list[float], noise: float = 0.05) -> list[float]:
+    return [v + noise * (0.5 - (i % 3) * 0.25) for i, v in enumerate(centroid)]
+
+
+# Seed centroids so the classifier has something to classify against and the
+# nodes land in a predictable (Entity) collection.
+ENTITY_CENTROID = _make_centroid(200)
+SEED_TYPES = {"type_entity": ENTITY_CENTROID}
+
+
+def _count_rows(sync: HCGMilvusSync, node_type: str) -> int:
+    """Return the number of persisted rows in a collection.
+
+    Uses ``num_entities`` after an explicit flush, which is reliable here
+    because ``batch_upsert_embeddings`` flushes on write.
+    """
+    collection = sync._get_collection(node_type)
+    collection.flush()
+    return int(collection.num_entities)
+
+
+@pytest.fixture(scope="module")
+def milvus_sync():
+    host = os.getenv("MILVUS_HOST", "localhost")
+    port = os.getenv("MILVUS_PORT", "47530")
+
+    sync = HCGMilvusSync(milvus_host=host, milvus_port=port)
+    try:
+        sync.connect()
+    except Exception as e:  # pragma: no cover - infra gate
+        pytest.skip(f"Milvus not available at {host}:{port}: {e}")
+
+    for node_type in COLLECTION_NAMES:
+        sync.ensure_collection(node_type)
+
+    for type_uuid, centroid in SEED_TYPES.items():
+        sync.update_centroid(
+            type_uuid=type_uuid, centroid=centroid, model="synthetic-test"
+        )
+
+    yield sync
+
+    sync.disconnect()
+
+
+@pytest.fixture(scope="module")
+def hcg_client():
+    uri = os.getenv("NEO4J_URI", "bolt://localhost:7687")
+    user = os.getenv("NEO4J_USER", "neo4j")
+    password = os.getenv("NEO4J_PASSWORD", "logosdev")
+
+    try:
+        client = HCGClient(neo4j_uri=uri, neo4j_username=user, neo4j_password=password)
+    except Exception as e:  # pragma: no cover - infra gate
+        pytest.skip(f"Neo4j not available at {uri}: {e}")
+    yield client
+    client.close()
+
+
+@pytest.fixture(scope="module")
+def processor(hcg_client, milvus_sync):
+    return ProposalProcessor(hcg_client=hcg_client, milvus_sync=milvus_sync)
+
+
+class TestEmbeddingPersistenceE2E:
+    """Ingestion must actually land embeddings in Milvus, not silently drop them."""
+
+    def test_ingested_node_embeddings_land_in_milvus(self, processor, milvus_sync):
+        """Row count for the target collection grows by the embedded-node count.
+
+        Before #146 this delta was 0 (warn-only swallow). After the fix, the
+        write must succeed and the rows must be present.
+        """
+        before = _count_rows(milvus_sync, "Entity")
+
+        # Two nodes, both near the entity centroid -> both land in the Entity
+        # collection (hcg_entity_embeddings). Unique names avoid dedup collisions.
+        run = uuid_lib.uuid4().hex[:8]
+        node_names = [f"PersistNodeA_{run}", f"PersistNodeB_{run}"]
+        emb = _make_near(ENTITY_CENTROID)
+        proposed_nodes = [
+            {
+                "name": name,
+                "type": "entity",
+                "embedding": emb,
+                "embedding_id": f"emb-{name}",
+                "dimension": DIM,
+                "model": "synthetic-test",
+                "properties": {},
+            }
+            for name in node_names
+        ]
+
+        proposal = {
+            "proposal_id": f"e2e-persist-{run}",
+            "source_service": "hermes",
+            "confidence": 0.8,
+            "raw_text": "Persistence regression fixture",
+            "proposed_nodes": proposed_nodes,
+            "proposed_edges": [],
+            "document_embedding": {
+                "embedding": emb,
+                "embedding_id": f"doc-{run}",
+                "dimension": DIM,
+                "model": "synthetic-test",
+            },
+        }
+
+        result = processor.process(proposal)
+
+        # All nodes were stored in the graph.
+        stored = result["stored_node_ids"]
+        assert len(stored) == len(
+            node_names
+        ), f"Expected {len(node_names)} stored nodes, got {len(stored)}"
+
+        after = _count_rows(milvus_sync, "Entity")
+        delta = after - before
+        logger.info(
+            "hcg_entity_embeddings count: before=%d after=%d delta=%d",
+            before,
+            after,
+            delta,
+        )
+
+        # The keystone assertion: embeddings actually persisted. Previously 0.
+        assert delta >= len(node_names), (
+            "Embedding persistence regressed: expected the Entity collection to "
+            f"grow by at least {len(node_names)} rows, but it grew by {delta}. "
+            "A failed/swallowed Milvus write leaves hcg_*_embeddings empty."
+        )
+        assert after > 0, "hcg_entity_embeddings must be non-empty after ingestion"

--- a/tests/integration/test_type_classification_e2e.py
+++ b/tests/integration/test_type_classification_e2e.py
@@ -72,6 +72,18 @@ def milvus_sync():
     sync = HCGMilvusSync(milvus_host=host, milvus_port=port)
     sync.connect()
 
+    # Isolation: start from a clean embedding space. Post-#146 a failed embedding
+    # write is no longer swallowed, so embeddings actually persist — which means
+    # nodes ingested by *earlier* integration modules survive in the shared test
+    # Milvus and get returned by this module's similarity/dedup search (e.g. an
+    # ENTITY_CENTROID node from test_embedding_persistence_e2e), causing this
+    # module's near-duplicate ingests to be skipped. Drop first so the module's
+    # assertions see only its own seeded centroids and ingested nodes.
+    from pymilvus import utility
+
+    for _name in utility.list_collections(using=sync.alias):
+        utility.drop_collection(_name, using=sync.alias)
+
     # Ensure all collections exist
     for node_type in ["Entity", "Concept", "State", "Process", "Edge", "TypeCentroid"]:
         sync.ensure_collection(node_type)

--- a/tests/unit/ingestion/test_proposal_processor.py
+++ b/tests/unit/ingestion/test_proposal_processor.py
@@ -865,8 +865,16 @@ class TestBatchEmbeddings:
         assert edge_batch[0]["uuid"] == "edge-uuid-1"
         assert edge_batch[0]["model"] == "all-MiniLM-L6-v2"
 
-    def test_batch_upsert_failure_still_returns_results(self):
-        """If batch_upsert_embeddings raises, process() should still return stored IDs."""
+    def test_batch_upsert_failure_propagates(self):
+        """A failed Milvus embedding write must NOT be silently swallowed.
+
+        Regression for #146: previously the flush wrapped batch_upsert in a
+        warn-only except, so a failed write was swallowed and ingestion
+        reported success while hcg_*_embeddings stayed empty. The failure must
+        now propagate as EmbeddingPersistenceError so the caller sees it.
+        """
+        import pytest
+
         mock_hcg = MagicMock()
         mock_hcg.add_node.return_value = "uuid-1"
         mock_milvus = MagicMock()
@@ -878,15 +886,23 @@ class TestBatchEmbeddings:
             "Milvus connection lost"
         )
 
-        from sophia.ingestion.proposal_processor import ProposalProcessor
+        from sophia.ingestion.proposal_processor import (
+            EmbeddingPersistenceError,
+            ProposalProcessor,
+        )
 
         processor = ProposalProcessor(hcg_client=mock_hcg, milvus_sync=mock_milvus)
 
         proposal = self._make_proposal(nodes=[self._make_node("Gamma")])
-        result = processor.process(proposal)
 
-        assert "uuid-1" in result["stored_node_ids"]
-        assert "stored_edge_ids" in result
+        with pytest.raises(EmbeddingPersistenceError) as exc_info:
+            processor.process(proposal)
+
+        # The failing collection and its underlying error are surfaced.
+        assert "Entity" in exc_info.value.failures
+        assert "Milvus connection lost" in exc_info.value.failures["Entity"]
+        # The write was actually attempted, not skipped.
+        mock_milvus.batch_upsert_embeddings.assert_called()
 
     def test_no_embeddings_skips_batch_call(self):
         """If no nodes have embeddings, batch_upsert_embeddings should not be called."""

--- a/tests/unit/ingestion/test_proposal_processor.py
+++ b/tests/unit/ingestion/test_proposal_processor.py
@@ -907,6 +907,62 @@ class TestBatchEmbeddings:
         # (an orphaned node with no embedding would otherwise dup on retry).
         mock_hcg.delete_node.assert_called_once_with("uuid-1")
 
+    def test_rollback_also_deletes_edges(self):
+        """On embedding failure, stored edges are rolled back too, not just nodes.
+
+        Edges are reified as Node entities; an edge between two pre-existing nodes
+        isn't removed by deleting the batch's new nodes, so it must be deleted by
+        its own uuid (gemini asked to roll back stored_edge_ids).
+        """
+        import pytest
+
+        mock_hcg = MagicMock()
+        mock_hcg.add_node.return_value = "node-1"
+        mock_hcg.add_edge.return_value = "edge-1"
+        mock_hcg.find_nodes_by_names.return_value = {"France": {"uuid": "france-uuid"}}
+        mock_milvus = MagicMock()
+        mock_milvus.search_similar.return_value = []
+        mock_milvus.find_nearest_types.return_value = [
+            {"uuid": "type_location", "score": 0.1},
+        ]
+        mock_milvus.batch_upsert_embeddings.side_effect = RuntimeError("Milvus down")
+
+        from sophia.ingestion.proposal_processor import (
+            EmbeddingPersistenceError,
+            ProposalProcessor,
+        )
+
+        processor = ProposalProcessor(hcg_client=mock_hcg, milvus_sync=mock_milvus)
+        proposal = {
+            "proposal_id": "p-rollback",
+            "proposed_nodes": [
+                {
+                    "name": "Paris",
+                    "type": "location",
+                    "embedding": [0.1] * 384,
+                    "embedding_id": "emb-1",
+                    "dimension": 384,
+                    "model": "all-MiniLM-L6-v2",
+                    "properties": {},
+                }
+            ],
+            "proposed_edges": [
+                {
+                    "source_name": "Paris",
+                    "target_name": "France",
+                    "relation": "LOCATED_IN",
+                    "confidence": 0.8,
+                }
+            ],
+        }
+
+        with pytest.raises(EmbeddingPersistenceError):
+            processor.process(proposal)
+
+        deleted = {c.args[0] for c in mock_hcg.delete_node.call_args_list}
+        assert "node-1" in deleted, "stored node not rolled back"
+        assert "edge-1" in deleted, "stored edge not rolled back"
+
     def test_no_embeddings_skips_batch_call(self):
         """If no nodes have embeddings, batch_upsert_embeddings should not be called."""
         mock_hcg = MagicMock()

--- a/tests/unit/ingestion/test_proposal_processor.py
+++ b/tests/unit/ingestion/test_proposal_processor.py
@@ -903,6 +903,9 @@ class TestBatchEmbeddings:
         assert "Milvus connection lost" in exc_info.value.failures["Entity"]
         # The write was actually attempted, not skipped.
         mock_milvus.batch_upsert_embeddings.assert_called()
+        # Partial graph writes are rolled back so the batch is cleanly retryable
+        # (an orphaned node with no embedding would otherwise dup on retry).
+        mock_hcg.delete_node.assert_called_once_with("uuid-1")
 
     def test_no_embeddings_skips_batch_call(self):
         """If no nodes have embeddings, batch_upsert_embeddings should not be called."""


### PR DESCRIPTION
## Summary

At ingestion, `ProposalProcessor.process` collected per-node/edge embeddings into `pending_embeddings` and flushed them in a batch wrapped in a **warn-only** `try/except` (`src/sophia/ingestion/proposal_processor.py` ~L516-528). A failed `self._milvus.batch_upsert_embeddings(...)` was swallowed, so ingestion reported success while the `hcg_*_embeddings` collections stayed **empty** — the keystone blocker that starves:
- the embedding-space **type classifier** (no centroids), and
- **#505 emergent type discovery** (no population to cluster).

## Change

- New `EmbeddingPersistenceError(RuntimeError)` carrying a per-collection `failures` map.
- The flush now attempts **every** collection (so one bad collection does not mask the others), collects failures, and **raises** if any write failed. A failed Milvus write is now loud and propagates to the caller instead of a silent warning (`logger.warning` → `logger.error` + raise).

## Tests

- **Unit** — inverted the existing `test_batch_upsert_failure_*` test (it previously asserted the swallow / that `process()` still returns). It now asserts `process()` raises `EmbeddingPersistenceError` with the failing collection + underlying error in `.failures`. Verified directly against the real `ProposalProcessor.process` via an import-stubbed harness:
  - failure path → raises `EmbeddingPersistenceError(failures={'Entity': 'Milvus connection lost'})`
  - success path → normal return, `batch_upsert_embeddings` called, node stored.
- **Integration** — added `tests/integration/test_embedding_persistence_e2e.py`: ingests a small fixture through the real `ProposalProcessor` against live Neo4j + Milvus and asserts the `hcg_entity_embeddings` row count grows by the embedded-node count (previously 0). Depends on the logos **#528** `HCGMilvusSync` upsert-by-uuid fix.

## Verification status

- `ruff`, `black`, and `py_compile` pass on all changed files.
- The logos **#528** fix branch was installed editable into the env (`logos_hcg.sync` resolves to the fixed upsert-by-uuid source).
- **pytest could not run in this environment**: the shared venv is Python **3.14** with `protobuf 4.25.8`, whose `api_implementation` probe hard-imports the `google._upb._message` C extension and crashes with `TypeError: Metaclasses with custom tp_new are not supported`. This breaks **any** import that transitively pulls `pymilvus`/`opentelemetry` (protobuf) — confirmed identically on **untouched** pre-existing tests (`test_ingests_proposed_nodes`, `test_centroid_update.py`), so it is a pre-existing, environment-wide blocker independent of this change, not introduced here. The live ingest→Milvus e2e (and `rows>0` assertion) therefore could not be executed via the pymilvus client. The shared test stack itself is healthy (Neo4j 7474 → 200, Milvus healthz 47091 → 200).
- `verifiedLive=false` — blocked by the protobuf/py3.14 venv incompatibility, not by #528.

Closes #146