### PR TITLE
fix(#148): entity identity is embedding-based, never name-based

### DIFF
--- a/src/sophia/hcg_client/client.py
+++ b/src/sophia/hcg_client/client.py
@@ -113,17 +113,15 @@ class HCGClient(LogosHCGClient):
             raise ValueError("node_type cannot be empty")
 
         # Generate UUID if not provided, reject empty string.
-        # When no uuid is given, check for an existing node with the same
-        # name+type to avoid creating duplicates on repeated ingestion.
+        # #148: identity is never name-based. Sophia is non-linguistic, so the
+        # literal name string is not an identity key -- omitting the uuid always
+        # mints a fresh uuid4. Entity deduplication is decided in embedding space
+        # by the upstream resolver (proposal_processor), not by name+type
+        # equality; folding two distinct entities together on a shared name would
+        # be a lossy, text-based merge. Duplicates are recoverable; false merges
+        # are not.
         if uuid is None:
-            existing = self._execute_query(
-                "MATCH (n:Node {name: $name, type: $type}) RETURN n.uuid AS uuid LIMIT 1",
-                {"name": name, "type": node_type},
-            )
-            if existing:
-                uuid = existing[0]["uuid"]
-            else:
-                uuid = str(uuid4())
+            uuid = str(uuid4())
         elif uuid == "":
             raise ValueError("uuid cannot be empty")
 

--- a/src/sophia/ingestion/proposal_processor.py
+++ b/src/sophia/ingestion/proposal_processor.py
@@ -117,7 +117,7 @@ def _squared_l2_distance(a: list[float], b: list[float]) -> float:
     computed here are directly comparable to ``ENTITY_MATCH_THRESHOLD`` and to
     ``search_similar`` scores. Lower is more similar.
     """
-    return sum((x - y) ** 2 for x, y in zip(a, b))
+    return sum((x - y) ** 2 for x, y in zip(a, b, strict=True))
 
 
 class ProposalProcessor:
@@ -306,14 +306,18 @@ class ProposalProcessor:
                     if embedding:
                         best_uuid: str | None = None
                         best_dist = ENTITY_MATCH_THRESHOLD
-                        for _coll, pending in pending_embeddings.items():
-                            for pending_node in pending:
-                                dist = _squared_l2_distance(
-                                    embedding, pending_node["embedding"]
-                                )
-                                if dist < best_dist:
-                                    best_dist = dist
-                                    best_uuid = pending_node["uuid"]
+                        # Scope to THIS node's collection only. The persisted
+                        # Milvus dedup (2a) searches node_type=collection, so
+                        # cross-collection merges must not happen here either --
+                        # batch membership must not change whether two nodes
+                        # collapse into one (#151 review).
+                        for pending_node in pending_embeddings.get(collection, []):
+                            dist = _squared_l2_distance(
+                                embedding, pending_node["embedding"]
+                            )
+                            if dist < best_dist:
+                                best_dist = dist
+                                best_uuid = pending_node["uuid"]
                         if best_uuid is not None:
                             logger.info(
                                 "Entity '%s' matches a sibling created earlier in "

--- a/src/sophia/ingestion/proposal_processor.py
+++ b/src/sophia/ingestion/proposal_processor.py
@@ -110,6 +110,16 @@ def _collection_for(node_type: str) -> str:
     return _NODE_TYPE_TO_COLLECTION.get(node_type.lower(), "Entity")
 
 
+def _squared_l2_distance(a: list[float], b: list[float]) -> float:
+    """Squared Euclidean (L2) distance between two vectors.
+
+    Matches Milvus' L2 metric (which returns squared distance), so distances
+    computed here are directly comparable to ``ENTITY_MATCH_THRESHOLD`` and to
+    ``search_similar`` scores. Lower is more similar.
+    """
+    return sum((x - y) ** 2 for x, y in zip(a, b))
+
+
 class ProposalProcessor:
     """Processes proposals from Hermes into graph knowledge."""
 
@@ -280,6 +290,41 @@ class ProposalProcessor:
                         node_type = proposed.get("type", "entity")
 
                     collection = _collection_for(node_type)
+
+                    # 2a-pre. In-process dedup against siblings created earlier
+                    # in THIS ingest. The Milvus index (2a) is only flushed after
+                    # the node loop (see pending_embeddings, 2d), so the search
+                    # below cannot see a node created moments ago in the same
+                    # batch -- the same entity proposed twice would mint two
+                    # nodes (#148). Identity is embedding-based, never name-based:
+                    # compare this mention's embedding (squared L2) against the
+                    # pending embeddings of nodes already created this ingest and
+                    # reuse the closest sibling below ENTITY_MATCH_THRESHOLD. A
+                    # node with NO embedding carries no meaning signal, so it is
+                    # deliberately not deduped here -- the downstream resolver
+                    # handles that later.
+                    if embedding:
+                        best_uuid: str | None = None
+                        best_dist = ENTITY_MATCH_THRESHOLD
+                        for _coll, pending in pending_embeddings.items():
+                            for pending_node in pending:
+                                dist = _squared_l2_distance(
+                                    embedding, pending_node["embedding"]
+                                )
+                                if dist < best_dist:
+                                    best_dist = dist
+                                    best_uuid = pending_node["uuid"]
+                        if best_uuid is not None:
+                            logger.info(
+                                "Entity '%s' matches a sibling created earlier in "
+                                "this ingest (%s, L2=%.3f); reusing, skipping "
+                                "creation",
+                                name,
+                                best_uuid,
+                                best_dist,
+                            )
+                            name_to_uuid[name] = best_uuid
+                            continue
 
                     # 2a. Search for existing node with similar embedding
                     if embedding:

--- a/tests/integration/test_embedding_persistence_e2e.py
+++ b/tests/integration/test_embedding_persistence_e2e.py
@@ -139,22 +139,28 @@ class TestEmbeddingPersistenceE2E:
         """
         before = _count_rows(milvus_sync, "Entity")
 
-        # Two nodes, both near the entity centroid -> both land in the Entity
-        # collection (hcg_entity_embeddings). Unique names avoid dedup collisions.
+        # Two DISTINCT entities. Identity is embedding-based (#148), so two nodes
+        # sharing one vector now correctly dedup to a single node. Give each a
+        # distinct vector that still classifies as Entity (only the entity centroid
+        # is seeded) but sits well beyond ENTITY_MATCH_THRESHOLD, so both persist.
         run = uuid_lib.uuid4().hex[:8]
         node_names = [f"PersistNodeA_{run}", f"PersistNodeB_{run}"]
-        emb = _make_near(ENTITY_CENTROID)
+        node_embeddings = [
+            _make_near(ENTITY_CENTROID, noise=0.05),
+            _make_near(ENTITY_CENTROID, noise=0.40),
+        ]
+        emb = node_embeddings[0]
         proposed_nodes = [
             {
                 "name": name,
                 "type": "entity",
-                "embedding": emb,
+                "embedding": node_emb,
                 "embedding_id": f"emb-{name}",
                 "dimension": DIM,
                 "model": "synthetic-test",
                 "properties": {},
             }
-            for name in node_names
+            for name, node_emb in zip(node_names, node_embeddings)
         ]
 
         proposal = {

--- a/tests/integration/test_node_identity_live.py
+++ b/tests/integration/test_node_identity_live.py
@@ -1,0 +1,90 @@
+"""Integration test (#148): entity identity is embedding-based, never name-based.
+
+Direct ``HCGClient`` -> live Neo4j. Proves against the real graph what the unit
+tests assert against mocks: two ``add_node`` calls with the same name+type but
+no explicit uuid create TWO distinct nodes -- the literal name is not an
+identity key. An explicit uuid still upserts a single node (MERGE on uuid).
+
+Requires Neo4j; skips when unavailable. Created nodes are removed in teardown.
+"""
+
+from __future__ import annotations
+
+import os
+from uuid import uuid4
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+def hcg():
+    from sophia.hcg_client import HCGClient
+
+    uri = os.getenv("NEO4J_URI", "bolt://localhost:7687")
+    user = os.getenv("NEO4J_USER", "neo4j")
+    password = os.getenv("NEO4J_PASSWORD", "logosdev")
+    try:
+        client = HCGClient(neo4j_uri=uri, neo4j_username=user, neo4j_password=password)
+        client._execute_query("RETURN 1 AS ok", {})  # connectivity probe
+    except Exception as exc:  # pragma: no cover - infra-dependent
+        pytest.skip(f"Neo4j not available at {uri}: {exc}")
+    yield client
+    client.close()
+
+
+def test_same_name_type_creates_distinct_nodes_in_graph(hcg):
+    """Two omitted-uuid mentions of the same name+type are distinct graph nodes.
+
+    The name string is never a merge key (#148): each call mints its own uuid4,
+    so the graph ends up holding two nodes, not one.
+    """
+    name = f"dedup_probe_{uuid4().hex}"
+    created: list[str] = []
+    try:
+        uuid_a = hcg.add_node(name=name, node_type="entity", source="test_148")
+        uuid_b = hcg.add_node(name=name, node_type="entity", source="test_148")
+        created = [uuid_a, uuid_b]
+
+        # Distinct identities: name is not a merge key.
+        assert uuid_a != uuid_b
+
+        rows = hcg._execute_query(
+            "MATCH (n:Node {name: $name, type: $type}) RETURN n.uuid AS uuid",
+            {"name": name, "type": "entity"},
+        )
+        uuids = sorted(r["uuid"] for r in rows)
+        assert uuids == sorted([uuid_a, uuid_b]), uuids
+        assert len(uuids) == 2
+    finally:
+        for u in created:
+            try:
+                hcg.delete_node(u)
+            except Exception:
+                pass
+
+
+def test_explicit_uuid_upserts_single_node_in_graph(hcg):
+    """An explicit uuid still MERGEs to a single node across repeated calls."""
+    name = f"upsert_probe_{uuid4().hex}"
+    node_uuid = f"fixed_{uuid4().hex}"
+    try:
+        u1 = hcg.add_node(
+            name=name, node_type="entity", uuid=node_uuid, source="test_148"
+        )
+        u2 = hcg.add_node(
+            name=name, node_type="entity", uuid=node_uuid, source="test_148"
+        )
+        assert u1 == u2 == node_uuid
+
+        rows = hcg._execute_query(
+            "MATCH (n:Node {uuid: $uuid}) RETURN n.uuid AS uuid",
+            {"uuid": node_uuid},
+        )
+        assert len(rows) == 1
+    finally:
+        try:
+            hcg.delete_node(node_uuid)
+        except Exception:
+            pass

--- a/tests/unit/hcg_client/test_client_wrapper.py
+++ b/tests/unit/hcg_client/test_client_wrapper.py
@@ -266,13 +266,8 @@ def test_health_check_uses_session(
 def test_add_node_generates_uuid_when_not_provided(
     monkeypatch: pytest.MonkeyPatch, client: HCGClient
 ) -> None:
-    """UUID is auto-generated when not provided."""
-    mock_execute = MagicMock(
-        side_effect=[
-            [],  # dedup lookup returns no existing node
-            [{"uuid": "auto-generated"}],  # MERGE query
-        ]
-    )
+    """UUID is auto-generated when not provided -- no name lookup precedes it."""
+    mock_execute = MagicMock(return_value=[{"uuid": "auto-generated"}])
     monkeypatch.setattr(client, "_execute_query", mock_execute)
 
     client.add_node(
@@ -280,8 +275,10 @@ def test_add_node_generates_uuid_when_not_provided(
         node_type="test_type",
     )
 
-    # Second call is the MERGE — check that a proper uuid was generated
-    merge_call = mock_execute.call_args_list[1]
+    # #148: identity is never name-based, so there is no dedup lookup --
+    # the single query is the MERGE, which carries a freshly minted uuid4.
+    assert mock_execute.call_count == 1
+    merge_call = mock_execute.call_args_list[0]
     params = merge_call[0][1]
     assert len(params["uuid"]) == 36
     assert params["uuid"].count("-") == 4

--- a/tests/unit/ingestion/test_node_dedup.py
+++ b/tests/unit/ingestion/test_node_dedup.py
@@ -1,11 +1,22 @@
-"""Tests for node deduplication on name+type."""
+"""Tests for node identity: uuid minting is embedding-based, never name-based.
+
+#148: Sophia is non-linguistic. ``add_node`` must NOT treat name+type as an
+identity key -- two entities that happen to share a name+type are distinct
+nodes unless an explicit uuid says otherwise. Name-based deduplication used to
+live here (a name+type MATCH that reused the existing uuid); it was removed
+because the literal name string is *text used as a key*, and entity identity is
+decided in embedding space by the upstream resolver, not by string equality.
+Homonyms collapsing is an accepted edge case of the embedding resolver, not of
+a name lookup. These tests pin the new contract: omitting the uuid always mints
+a fresh uuid4 with no name lookup.
+"""
 
 from unittest.mock import MagicMock, patch
 
 from sophia.hcg_client.client import HCGClient
 
 
-class TestNodeDedup:
+class TestNodeIdentity:
     def _make_client(self):
         """Build an HCGClient with mocked Neo4j driver."""
         with patch.object(HCGClient, "__init__", lambda self: None):
@@ -16,51 +27,42 @@ class TestNodeDedup:
         client._database = "neo4j"
         return client
 
-    def test_reuses_uuid_for_existing_name_type(self):
-        """When add_node is called without a uuid and a node with the same
-        name+type already exists, the existing uuid should be reused."""
+    def test_omitting_uuid_mints_fresh_uuid_without_name_lookup(self):
+        """Without a uuid, add_node mints a fresh uuid4 and performs no name
+        lookup -- a single MERGE call, never a name+type MATCH."""
         client = self._make_client()
+        client._execute_query = MagicMock(return_value=[{"uuid": "ignored"}])
 
-        # Mock _execute_query to return existing node on lookup, then
-        # return uuid on MERGE
-        existing_uuid = "existing-uuid-123"
-        client._execute_query = MagicMock(
-            side_effect=[
-                [{"uuid": existing_uuid}],  # lookup query
-                [{"uuid": existing_uuid}],  # MERGE query
-            ]
-        )
+        client.add_node(name="Ireland", node_type="location")
 
-        result = client.add_node(name="Ireland", node_type="location")
+        # Exactly one query: the MERGE. No name+type lookup precedes it.
+        assert client._execute_query.call_count == 1
+        query = client._execute_query.call_args_list[0][0][0]
+        assert "MERGE" in query
+        params = client._execute_query.call_args_list[0][0][1]
+        # A real uuid4 was generated for the node, not derived from the name.
+        assert len(params["uuid"]) == 36
+        assert params["uuid"].count("-") == 4
 
-        assert result == existing_uuid
-        # First call is the lookup
-        lookup_call = client._execute_query.call_args_list[0]
-        assert "MATCH" in lookup_call[0][0]
-        assert lookup_call[0][1]["name"] == "Ireland"
-        assert lookup_call[0][1]["type"] == "location"
-
-    def test_generates_new_uuid_when_no_existing_node(self):
-        """When no node with name+type exists, a new uuid is generated."""
+    def test_same_name_and_type_get_distinct_uuids(self):
+        """Two nodes sharing name+type are distinct identities (#148): the
+        literal name is never used as a merge key. Each omitted-uuid call mints
+        its own uuid4 -- one MERGE per call, distinct uuids."""
         client = self._make_client()
+        client._execute_query = MagicMock(return_value=[{"uuid": "ignored"}])
 
-        client._execute_query = MagicMock(
-            side_effect=[
-                [],  # lookup returns nothing
-                [{"uuid": "new-uuid"}],  # MERGE query
-            ]
-        )
+        client.add_node(name="Mercury", node_type="entity")
+        client.add_node(name="Mercury", node_type="entity")
 
-        result = client.add_node(name="NewPlace", node_type="location")
-
-        assert result is not None
-        # First call is the lookup, second is MERGE
-        assert len(client._execute_query.call_args_list) == 2
+        # One MERGE per call -- no preceding name lookup.
+        assert client._execute_query.call_count == 2
+        first = client._execute_query.call_args_list[0][0][1]["uuid"]
+        second = client._execute_query.call_args_list[1][0][1]["uuid"]
+        assert first != second
 
     def test_explicit_uuid_skips_lookup(self):
-        """When uuid is explicitly provided, no lookup is performed."""
+        """An explicit uuid is used verbatim with a single MERGE call."""
         client = self._make_client()
-
         client._execute_query = MagicMock(return_value=[{"uuid": "explicit-uuid"}])
 
         result = client.add_node(
@@ -68,5 +70,6 @@ class TestNodeDedup:
         )
 
         assert result == "explicit-uuid"
-        # Only one call — no lookup, just MERGE
         assert client._execute_query.call_count == 1
+        params = client._execute_query.call_args_list[0][0][1]
+        assert params["uuid"] == "explicit-uuid"

--- a/tests/unit/ingestion/test_proposal_processor.py
+++ b/tests/unit/ingestion/test_proposal_processor.py
@@ -274,6 +274,78 @@ class TestProposalProcessor:
             "embedding-less entity; expected exactly 2 (no name-based dedup)"
         )
 
+    def test_similar_embeddings_in_different_collections_not_merged(self):
+        """Cross-collection nodes must not be merged by in-process dedup (#151).
+
+        Two mentions with (near-)identical embeddings but classified into
+        different collections (Entity vs Concept) are distinct identities. The
+        persisted Milvus dedup (2a) is collection-scoped, so the in-process pass
+        must be too -- batch membership alone must not collapse two nodes that
+        separate batches would keep apart.
+        """
+        from types import SimpleNamespace
+
+        from sophia.ingestion.proposal_processor import ProposalProcessor
+
+        mock_hcg = MagicMock()
+        mock_hcg.add_node.side_effect = [f"uuid-{i}" for i in range(10)]
+        mock_hcg.get_node.return_value = None
+
+        mock_milvus = MagicMock()
+        mock_milvus.search_similar.return_value = []
+
+        processor = ProposalProcessor(hcg_client=mock_hcg, milvus_sync=mock_milvus)
+        # Force two different collections for identical embeddings.
+        processor._classifier = MagicMock()
+        processor._classifier.classify.side_effect = [
+            SimpleNamespace(
+                type_name="entity",
+                type_uuid="type_entity",
+                confidence=0.9,
+                needs_reclassification=False,
+            ),
+            SimpleNamespace(
+                type_name="concept",
+                type_uuid="type_concept",
+                confidence=0.9,
+                needs_reclassification=False,
+            ),
+        ]
+
+        emb = [0.1] * 384
+        result = processor.process(
+            {
+                "proposal_id": "p-xcoll",
+                "source_service": "hermes",
+                "confidence": 0.7,
+                "raw_text": "x",
+                "proposed_nodes": [
+                    {
+                        "name": "Alpha",
+                        "type": "entity",
+                        "embedding": list(emb),
+                        "embedding_id": "e1",
+                        "dimension": 384,
+                        "model": "m",
+                        "properties": {},
+                    },
+                    {
+                        "name": "Beta",
+                        "type": "concept",
+                        "embedding": list(emb),
+                        "embedding_id": "e2",
+                        "dimension": 384,
+                        "model": "m",
+                        "properties": {},
+                    },
+                ],
+                "proposed_edges": [],
+            }
+        )
+
+        # Identical embeddings but different collections => two distinct nodes.
+        assert len(result["stored_node_ids"]) == 2, result["stored_node_ids"]
+
     def test_skips_empty_name_nodes(self):
         from sophia.ingestion.proposal_processor import ProposalProcessor
 

--- a/tests/unit/ingestion/test_proposal_processor.py
+++ b/tests/unit/ingestion/test_proposal_processor.py
@@ -151,6 +151,129 @@ class TestProposalProcessor:
             c["node_uuid"] == "existing-paris" for c in result["relevant_context"]
         )
 
+    def test_same_entity_twice_in_one_ingest_yields_one_node(self):
+        """A repeated entity within a single ingest must not double the node count.
+
+        Acceptance criterion for #148: when the same entity is proposed twice in
+        one proposal -- with (near-)identical embeddings -- exactly one graph
+        node is created. The Milvus dedup search cannot catch this because the
+        first node's embedding is only flushed to the index AFTER the node loop
+        completes, so ``search_similar`` returns no match for the second mention
+        (modeled here as []). Dedup must instead compare the second mention's
+        embedding against the in-process embeddings of nodes already created in
+        this same ingest (L2 distance below ENTITY_MATCH_THRESHOLD => reuse).
+        Identity is embedding-based, never name-based: Sophia is non-linguistic.
+        """
+        from sophia.ingestion.proposal_processor import ProposalProcessor
+
+        mock_hcg = MagicMock()
+        # Distinct uuids per add_node call: the bug mints a second entity uuid.
+        mock_hcg.add_node.side_effect = [f"uuid-{i}" for i in range(10)]
+        mock_hcg.get_node.return_value = None
+
+        mock_milvus = MagicMock()
+        # Empty index throughout: the first node's embedding has not been flushed
+        # yet when the second mention is processed, so the search misses it. The
+        # in-process embedding dedup must catch it instead.
+        mock_milvus.search_similar.return_value = []
+        mock_milvus.find_nearest_types.return_value = [
+            {"uuid": "type_entity", "score": 0.1},
+        ]
+
+        processor = ProposalProcessor(hcg_client=mock_hcg, milvus_sync=mock_milvus)
+        node = {
+            "name": "Plate Tectonics",
+            "type": "entity",
+            "embedding": [0.1] * 384,
+            "embedding_id": "emb-1",
+            "dimension": 384,
+            "model": "all-MiniLM-L6-v2",
+            "properties": {},
+        }
+        result = processor.process(
+            {
+                "proposal_id": "p-dup",
+                "source_service": "hermes",
+                "confidence": 0.7,
+                "raw_text": "Plate tectonics, plate tectonics.",
+                # Same entity (identical embedding) proposed twice in one ingest.
+                "proposed_nodes": [dict(node), dict(node)],
+                "proposed_edges": [],
+            }
+        )
+
+        # Exactly one entity node, despite two mentions.
+        assert len(result["stored_node_ids"]) == 1, (
+            f"expected 1 entity node, got {len(result['stored_node_ids'])}: "
+            f"{result['stored_node_ids']}"
+        )
+        # The repeat resolves to the already-created node's uuid (no new uuid).
+        entity_add_calls = [
+            c
+            for c in mock_hcg.add_node.call_args_list
+            if c.kwargs.get("name") == "Plate Tectonics"
+        ]
+        assert len(entity_add_calls) == 1, (
+            f"add_node called {len(entity_add_calls)} times for the repeated "
+            "entity; expected exactly 1"
+        )
+
+    def test_same_entity_twice_without_embeddings_yields_two_nodes(self):
+        """Embedding-less repeats are NOT deduped within ingest -- by design.
+
+        A node with no embedding carries no meaning signal, so within-ingest
+        dedup (which is embedding-based, #148) deliberately does not collapse it.
+        Two embedding-less mentions of the same name therefore create TWO nodes;
+        any later consolidation is the downstream resolver's job, not the
+        recorder's. This test pins that intent so it is explicit rather than a
+        silent regression -- and guards against any name-based fallback creeping
+        back in (Sophia is non-linguistic; identity is never name-based).
+        """
+        from sophia.ingestion.proposal_processor import ProposalProcessor
+
+        mock_hcg = MagicMock()
+        mock_hcg.add_node.side_effect = [f"uuid-{i}" for i in range(10)]
+        mock_hcg.get_node.return_value = None
+
+        mock_milvus = MagicMock()
+        mock_milvus.search_similar.return_value = []
+        mock_milvus.find_nearest_types.return_value = [
+            {"uuid": "type_entity", "score": 0.1},
+        ]
+
+        processor = ProposalProcessor(hcg_client=mock_hcg, milvus_sync=mock_milvus)
+        # No "embedding" key: these mentions have no meaning signal.
+        node = {
+            "name": "Plate Tectonics",
+            "type": "entity",
+            "properties": {},
+        }
+        result = processor.process(
+            {
+                "proposal_id": "p-dup-noemb",
+                "source_service": "hermes",
+                "confidence": 0.7,
+                "raw_text": "Plate tectonics, plate tectonics.",
+                "proposed_nodes": [dict(node), dict(node)],
+                "proposed_edges": [],
+            }
+        )
+
+        # Two nodes: embedding-less repeats are deferred to the resolver.
+        assert len(result["stored_node_ids"]) == 2, (
+            f"expected 2 nodes (no within-ingest dedup without embeddings), got "
+            f"{len(result['stored_node_ids'])}: {result['stored_node_ids']}"
+        )
+        entity_add_calls = [
+            c
+            for c in mock_hcg.add_node.call_args_list
+            if c.kwargs.get("name") == "Plate Tectonics"
+        ]
+        assert len(entity_add_calls) == 2, (
+            f"add_node called {len(entity_add_calls)} times for the repeated "
+            "embedding-less entity; expected exactly 2 (no name-based dedup)"
+        )
+
     def test_skips_empty_name_nodes(self):
         from sophia.ingestion.proposal_processor import ProposalProcessor
 
@@ -798,10 +921,15 @@ class TestBatchEmbeddings:
 
         processor = ProposalProcessor(hcg_client=mock_hcg, milvus_sync=mock_milvus)
 
+        # Distinct embeddings: these are different entities in different
+        # collections. (The default _make_node embedding is identical for every
+        # node, which the within-ingest embedding dedup would correctly collapse
+        # into one node -- defeating this test's purpose of exercising separate
+        # per-collection batches.)
         proposal = self._make_proposal(
             nodes=[
-                self._make_node("Alpha", node_type="entity"),
-                self._make_node("Beta", node_type="concept"),
+                self._make_node("Alpha", node_type="entity", embedding=[0.1] * 384),
+                self._make_node("Beta", node_type="concept", embedding=[0.9] * 384),
             ]
         )
         processor.process(proposal)


### PR DESCRIPTION
Closes #148.

## What
Entity de-duplication is decided in embedding space, not by the literal name string.

- **`hcg_client.add_node`**: when `uuid` is `None`, always mint a fresh `uuid4` — removed the `name+type` MATCH/reuse. Folding two distinct entities that happen to share a name is a lossy, text-based merge; duplicates are recoverable, false merges are not. (15/16 callers pass an explicit uuid; only the ingest path is affected.)
- **`proposal_processor`**: in-process (2a-pre) embedding dedup against siblings created earlier in the same ingest — the Milvus index is only flushed after the node loop, so the persisted search can't catch same-batch duplicates. Squared-L2 < `ENTITY_MATCH_THRESHOLD`.

Homonyms collapsing is an accepted edge case of the embedding resolver (Sophia is non-linguistic; an embedding is a vector, not text).

## Tests
- Rewrote `test_node_dedup` → `TestNodeIdentity`: same name+type → **distinct** uuids, no name lookup; explicit uuid → single MERGE.
- Updated `test_client_wrapper` (no dedup lookup).
- New live-Neo4j integration test: two same-name entities → two nodes; explicit uuid → one node.
- Full `tests/unit` green (315 passed); ruff/black/mypy clean.