### PR TITLE
fix(proposal-worker): survive Redis outages instead of dying on dequeue

### DIFF
--- a/src/sophia/feedback/proposal_worker.py
+++ b/src/sophia/feedback/proposal_worker.py
@@ -56,8 +56,11 @@ class ProposalWorker:
                 "Proposal dequeue failed (Redis unavailable?); backing off %.1fs: %s",
                 self._error_backoff,
                 e,
+                exc_info=True,
             )
-            await asyncio.sleep(self._error_backoff)
+            # Don't burn the full backoff if we're shutting down mid-outage.
+            if self._running:
+                await asyncio.sleep(self._error_backoff)
             return
         if not message:
             return

--- a/src/sophia/feedback/proposal_worker.py
+++ b/src/sophia/feedback/proposal_worker.py
@@ -22,10 +22,14 @@ class ProposalWorker:
         queue: ProposalQueue,
         processor: ProposalProcessor,
         context_ttl: int = 3600,
+        error_backoff: float = 1.0,
     ):
         self.queue = queue
         self.processor = processor
         self.context_ttl = context_ttl
+        # Seconds to wait after a dequeue error before retrying, so a Redis
+        # outage throttles the loop instead of spinning hot.
+        self._error_backoff = error_backoff
         self._running = False
 
     async def start(self) -> None:
@@ -40,7 +44,21 @@ class ProposalWorker:
         logger.info("Proposal worker stopping")
 
     async def _process_one(self) -> None:
-        message = await asyncio.to_thread(self.queue.dequeue, timeout=1)
+        try:
+            message = await asyncio.to_thread(self.queue.dequeue, timeout=1)
+        except Exception as e:
+            # Redis unavailable (e.g. a transient outage): log, back off, and
+            # keep the loop alive so the worker resumes when Redis recovers.
+            # The dequeue is a blocking brpop; previously this call sat outside
+            # any guard, so a dropped connection killed the worker task and
+            # silently stopped the cache pipeline until a sophia restart.
+            logger.warning(
+                "Proposal dequeue failed (Redis unavailable?); backing off %.1fs: %s",
+                self._error_backoff,
+                e,
+            )
+            await asyncio.sleep(self._error_backoff)
+            return
         if not message:
             return
 

--- a/tests/unit/feedback/test_proposal_worker.py
+++ b/tests/unit/feedback/test_proposal_worker.py
@@ -20,6 +20,7 @@ class TestProposalWorkerResilience:
         queue = MagicMock()
         queue.dequeue.side_effect = ConnectionError("redis down")
         worker = ProposalWorker(queue=queue, processor=MagicMock())
+        worker._running = True
 
         slept: list[float] = []
 
@@ -31,7 +32,9 @@ class TestProposalWorkerResilience:
         # Must not raise -- previously this killed the worker task.
         await worker._process_one()
 
-        assert slept, "worker should back off after a dequeue error"
+        # Backed off by exactly _error_backoff (the sleep is guarded by
+        # self._running, set True above).
+        assert slept == [worker._error_backoff]
 
     async def test_worker_resumes_after_dequeue_error(self, monkeypatch):
         """After a transient dequeue error, the next message is processed."""
@@ -47,6 +50,7 @@ class TestProposalWorkerResilience:
             "stored_edge_ids": [],
         }
         worker = ProposalWorker(queue=queue, processor=processor)
+        worker._running = True
         monkeypatch.setattr(asyncio, "sleep", AsyncMock())
 
         await worker._process_one()  # errors, backs off, returns

--- a/tests/unit/feedback/test_proposal_worker.py
+++ b/tests/unit/feedback/test_proposal_worker.py
@@ -1,0 +1,56 @@
+"""Tests for ProposalWorker resilience to Redis outages.
+
+Regression: ``dequeue()`` does a blocking ``brpop``; when Redis drops the
+connection it raises. Previously that call sat OUTSIDE any try/except, so the
+exception propagated through ``start()``'s loop and killed the worker task
+permanently -- the background cache pipeline silently stopped until a sophia
+restart, which left every chat turn on the slow synchronous path. The worker
+must instead log, back off, and keep looping so it resumes when Redis recovers.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+from sophia.feedback.proposal_worker import ProposalWorker
+
+
+class TestProposalWorkerResilience:
+    async def test_process_one_survives_dequeue_error(self, monkeypatch):
+        """A Redis error from dequeue must not propagate out of _process_one."""
+        queue = MagicMock()
+        queue.dequeue.side_effect = ConnectionError("redis down")
+        worker = ProposalWorker(queue=queue, processor=MagicMock())
+
+        slept: list[float] = []
+
+        async def fake_sleep(delay):
+            slept.append(delay)
+
+        monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+        # Must not raise -- previously this killed the worker task.
+        await worker._process_one()
+
+        assert slept, "worker should back off after a dequeue error"
+
+    async def test_worker_resumes_after_dequeue_error(self, monkeypatch):
+        """After a transient dequeue error, the next message is processed."""
+        queue = MagicMock()
+        queue.dequeue.side_effect = [
+            ConnectionError("redis down"),
+            {"id": "m1", "payload": {"x": 1}, "conversation_id": "c1"},
+        ]
+        processor = MagicMock()
+        processor.process.return_value = {
+            "relevant_context": [{"node_uuid": "u"}],
+            "stored_node_ids": [],
+            "stored_edge_ids": [],
+        }
+        worker = ProposalWorker(queue=queue, processor=processor)
+        monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+
+        await worker._process_one()  # errors, backs off, returns
+        await worker._process_one()  # recovers, processes the message
+
+        processor.process.assert_called_once_with({"x": 1})
+        queue.store_context.assert_called_once()


### PR DESCRIPTION
## What
Guard the `ProposalWorker` dequeue loop so a transient Redis outage can't permanently kill the background worker.

## Why
`_process_one`'s `try/except` wrapped only the *processing*, not the blocking `brpop` `dequeue`. When Redis dropped, the dequeue raised, the exception propagated through `start()`'s loop, and the worker task died — silently stopping the proposal-queue / context-cache pipeline until a sophia restart. Every chat turn then fell back to the slow synchronous path. (Observed live this session: a Redis container restart left the worker dead; a queued probe sat undrained until sophia was restarted.)

## Fix
On a dequeue error: log, sleep `error_backoff` (default 1s), and continue the loop, so the worker resumes automatically when Redis recovers.

## Tests
New `test_proposal_worker`: a dequeue `ConnectionError` does not propagate out of `_process_one` and triggers a backoff; the worker resumes and processes the next message after a transient error. Full feedback suite green (13 passed); ruff/black/mypy clean.