### PR TITLE
feat(#157): include node embeddings in /hcg/snapshot for explorer semantic layout

### DIFF
--- a/src/sophia/api/app.py
+++ b/src/sophia/api/app.py
@@ -111,6 +111,11 @@ from sophia.feedback import (
 # Configure structured logging for sophia
 logger = setup_logging("sophia")
 
+# Max uuids per Milvus `uuid in [...]` query in the snapshot embedding lookup.
+# Batching keeps the filter expression well under Milvus's expression-length cap
+# (a single unbatched list of 10k 36-char uuids is ~400 KB and gets rejected).
+_SNAPSHOT_EMB_BATCH = 512
+
 
 def _run_full_type_emergence_scan(
     hcg_client: Any, run_one: Callable[[str], None]
@@ -1932,31 +1937,55 @@ def create_app() -> FastAPI:
             # Fetch all nodes
             nodes = _hcg_client.list_all_nodes(node_type=entity_type, limit=limit)
 
-            # Optionally attach stored entity vectors (one batch Milvus query) so
-            # Apollo's explorer can lay nodes out by embedding (semantic layout).
+            # Optionally attach stored entity vectors so Apollo's explorer can
+            # lay nodes out by embedding (semantic layout). Two things matter:
+            #   1. Embeddings are sharded across per-type Milvus collections
+            #      (Entity/Concept/State/Process) and a snapshot returns nodes of
+            #      every type -- so each uuid must be looked up in the collection
+            #      that actually holds its vector, not just hcg_entity_embeddings,
+            #      or every Concept/State/Process node silently comes back null.
+            #   2. The `uuid in [...]` filter is batched: a single list of up to
+            #      10k 36-char uuids is ~400 KB and exceeds Milvus's expression
+            #      cap, which would throw and (via the except) null *everything*.
+            # uuid is a VARCHAR primary key, so each value is double-quoted.
             emb_by_uuid: Dict[str, Any] = {}
             if include_embeddings and nodes:
                 try:
                     # Default Milvus connection is established at startup.
                     from pymilvus import Collection
 
-                    _col = Collection("hcg_entity_embeddings")
-                    _col.load()
-                    # Filter by the UUIDs of the nodes we are actually rendering
-                    # rather than fetching an arbitrary slice of the collection;
-                    # otherwise, once the collection holds more rows than the
-                    # current batch, stored vectors for these nodes would be
-                    # missed. uuid is a VARCHAR primary key, so each value is
-                    # quoted (idiom mirrors logos_hcg.sync HCGMilvusSync).
-                    _node_uuids = [str(n["uuid"]) for n in nodes]
-                    qu = chr(34)  # double-quote char for VARCHAR literals
-                    _uuid_list = ", ".join(qu + u + qu for u in _node_uuids)
-                    for _row in _col.query(
-                        expr=f"uuid in [{_uuid_list}]",
-                        output_fields=["uuid", "embedding"],
-                        limit=len(_node_uuids),
-                    ):
-                        emb_by_uuid[_row["uuid"]] = _row.get("embedding")
+                    from logos_hcg.sync import COLLECTION_NAMES
+                    from sophia.ingestion.proposal_processor import _collection_for
+
+                    uuids_by_collection: Dict[str, list[str]] = {}
+                    for _n in nodes:
+                        _cname = COLLECTION_NAMES[_collection_for(_n["type"])]
+                        uuids_by_collection.setdefault(_cname, []).append(
+                            str(_n["uuid"])
+                        )
+
+                    for _cname, _uuids in uuids_by_collection.items():
+                        try:
+                            _col = Collection(_cname)
+                            _col.load()
+                            for _i in range(0, len(_uuids), _SNAPSHOT_EMB_BATCH):
+                                _batch = _uuids[_i : _i + _SNAPSHOT_EMB_BATCH]
+                                _uuid_list = ", ".join(f'"{u}"' for u in _batch)
+                                for _row in _col.query(
+                                    expr=f"uuid in [{_uuid_list}]",
+                                    output_fields=["uuid", "embedding"],
+                                    limit=len(_batch),
+                                ):
+                                    emb_by_uuid[_row["uuid"]] = _row.get("embedding")
+                        except Exception as _e:
+                            # Log per-collection so a genuine query failure is
+                            # visible, not indistinguishable from nodes that
+                            # simply have no stored vector.
+                            logger.warning(
+                                "snapshot embeddings unavailable for %s: %s",
+                                _cname,
+                                _e,
+                            )
                 except Exception as _e:
                     logger.warning(f"snapshot embeddings unavailable: {_e}")
 

--- a/src/sophia/api/app.py
+++ b/src/sophia/api/app.py
@@ -1907,6 +1907,10 @@ def create_app() -> FastAPI:
             le=10000,
             description="Maximum number of entities/edges to return",
         ),
+        include_embeddings: bool = Query(
+            default=False,
+            description="Attach each entity's stored vector (for semantic layout)",
+        ),
     ) -> HCGGraphSnapshotResponse:
         """Get a snapshot of the entire HCG graph for visualization.
 
@@ -1928,6 +1932,25 @@ def create_app() -> FastAPI:
             # Fetch all nodes
             nodes = _hcg_client.list_all_nodes(node_type=entity_type, limit=limit)
 
+            # Optionally attach stored entity vectors (one batch Milvus query) so
+            # Apollo's explorer can lay nodes out by embedding (semantic layout).
+            emb_by_uuid: Dict[str, Any] = {}
+            if include_embeddings:
+                try:
+                    # Default Milvus connection is established at startup.
+                    from pymilvus import Collection
+
+                    _col = Collection("hcg_entity_embeddings")
+                    _col.load()
+                    for _row in _col.query(
+                        expr="",
+                        output_fields=["uuid", "embedding"],
+                        limit=max(len(nodes), 1),
+                    ):
+                        emb_by_uuid[_row["uuid"]] = _row.get("embedding")
+                except Exception as _e:
+                    logger.warning(f"snapshot embeddings unavailable: {_e}")
+
             # Convert to response format
             entities: List[HCGEntityResponse] = []
             for node in nodes:
@@ -1940,6 +1963,7 @@ def create_app() -> FastAPI:
                         properties=props,
                         labels=[],
                         created_at=props.get("created"),
+                        embedding=emb_by_uuid.get(node["uuid"]),
                     )
                 )
 

--- a/src/sophia/api/app.py
+++ b/src/sophia/api/app.py
@@ -1935,17 +1935,26 @@ def create_app() -> FastAPI:
             # Optionally attach stored entity vectors (one batch Milvus query) so
             # Apollo's explorer can lay nodes out by embedding (semantic layout).
             emb_by_uuid: Dict[str, Any] = {}
-            if include_embeddings:
+            if include_embeddings and nodes:
                 try:
                     # Default Milvus connection is established at startup.
                     from pymilvus import Collection
 
                     _col = Collection("hcg_entity_embeddings")
                     _col.load()
+                    # Filter by the UUIDs of the nodes we are actually rendering
+                    # rather than fetching an arbitrary slice of the collection;
+                    # otherwise, once the collection holds more rows than the
+                    # current batch, stored vectors for these nodes would be
+                    # missed. uuid is a VARCHAR primary key, so each value is
+                    # quoted (idiom mirrors logos_hcg.sync HCGMilvusSync).
+                    _node_uuids = [str(n["uuid"]) for n in nodes]
+                    qu = chr(34)  # double-quote char for VARCHAR literals
+                    _uuid_list = ", ".join(qu + u + qu for u in _node_uuids)
                     for _row in _col.query(
-                        expr="",
+                        expr=f"uuid in [{_uuid_list}]",
                         output_fields=["uuid", "embedding"],
-                        limit=max(len(nodes), 1),
+                        limit=len(_node_uuids),
                     ):
                         emb_by_uuid[_row["uuid"]] = _row.get("embedding")
                 except Exception as _e:

--- a/src/sophia/api/models.py
+++ b/src/sophia/api/models.py
@@ -616,6 +616,11 @@ class HCGEntityResponse(BaseModel):
     created_at: Optional[str] = Field(
         default=None, description="ISO timestamp of creation"
     )
+    embedding: Optional[List[float]] = Field(
+        default=None,
+        description="Entity vector; populated only when include_embeddings=true, "
+        "for semantic (embedding-positioned) layout in the explorer",
+    )
 
 
 class HCGEdgeResponse(BaseModel):

--- a/tests/unit/api/test_hcg_endpoints.py
+++ b/tests/unit/api/test_hcg_endpoints.py
@@ -76,6 +76,79 @@ class TestHCGSnapshotEndpoint:
         assert "entities" in data
         assert "edges" in data
 
+    @patch("sophia.api.app._hcg_client")
+    def test_snapshot_embeddings_batched_and_routed_by_collection(
+        self, mock_hcg, client, auth_headers
+    ):
+        """include_embeddings looks each node up in the collection that holds its
+        vector (Entity vs Concept), and batches the `uuid in [...]` filter so the
+        expression stays under Milvus's length cap (greptile #158 + collection
+        sharding)."""
+        import re
+
+        # 3 entity nodes + 1 concept node. With the batch size forced to 2, the
+        # entity collection must be queried in 2 chunks; concept in 1.
+        mock_hcg.list_all_nodes.return_value = [
+            {"uuid": "e1", "type": "entity", "name": "e1", "properties": {}},
+            {"uuid": "e2", "type": "entity", "name": "e2", "properties": {}},
+            {"uuid": "e3", "type": "entity", "name": "e3", "properties": {}},
+            {"uuid": "c1", "type": "concept", "name": "c1", "properties": {}},
+        ]
+        mock_hcg.list_all_edges.return_value = []
+
+        store = {
+            "hcg_entity_embeddings": {
+                "e1": [0.1, 0.2],
+                "e2": [0.3, 0.4],
+                "e3": [0.5, 0.6],
+            },
+            "hcg_concept_embeddings": {"c1": [0.7, 0.8]},
+        }
+
+        class FakeCollection:
+            instances: list = []
+
+            def __init__(self, name):
+                self.name = name
+                self.queries = []
+                FakeCollection.instances.append(self)
+
+            def load(self):
+                pass
+
+            def query(self, expr, output_fields, limit):
+                uuids = re.findall(r'"([^"]+)"', expr)
+                assert len(uuids) <= 2  # batched: never the whole list at once
+                assert limit == len(uuids)
+                self.queries.append(uuids)
+                col = store.get(self.name, {})
+                return [{"uuid": u, "embedding": col[u]} for u in uuids if u in col]
+
+        with (
+            patch("pymilvus.Collection", FakeCollection),
+            patch("sophia.api.app._SNAPSHOT_EMB_BATCH", 2),
+        ):
+            response = client.get(
+                "/hcg/snapshot",
+                params={"include_embeddings": "true"},
+                headers=auth_headers,
+            )
+
+        assert response.status_code == 200
+        ents = {e["id"]: e["embedding"] for e in response.json()["entities"]}
+        # Every node got its vector -- including the concept node, whose vector
+        # lives in a different collection than hcg_entity_embeddings.
+        assert ents == {
+            "e1": [0.1, 0.2],
+            "e2": [0.3, 0.4],
+            "e3": [0.5, 0.6],
+            "c1": [0.7, 0.8],
+        }
+        by_name = {c.name: c for c in FakeCollection.instances}
+        # Entity collection queried in 2 batches ([e1,e2], [e3]); concept once.
+        assert by_name["hcg_entity_embeddings"].queries == [["e1", "e2"], ["e3"]]
+        assert by_name["hcg_concept_embeddings"].queries == [["c1"]]
+
 
 class TestHCGEntitiesEndpoint:
     """Tests for GET /hcg/entities endpoint."""


### PR DESCRIPTION
## Summary
Adds an opt-in `include_embeddings` query param to `GET /hcg/snapshot`. When set, each entity in the response carries its 1536-dim embedding, batch-fetched from the `hcg_entity_embeddings` Milvus collection. This is what the Apollo explorer's 3D **Semantic** layout consumes to position nodes by their embedding.

Closes #157.

## Changes
- `api/app.py` — `get_hcg_snapshot` gains `include_embeddings: bool = Query(default=False)`. When true, batch-queries Milvus (`hcg_entity_embeddings`) keyed by uuid and attaches `embedding` per node. Uses the Milvus connection established at startup (no dependency on the lifespan-local sync handle).
- `api/models.py` — `HCGEntityResponse` gains `embedding: Optional[List[float]]` (defaults `None`, so existing callers are unaffected).

## Behavior
- Default (`include_embeddings=false` / omitted): response is byte-for-byte unchanged — `embedding` is `null`.
- Opt-in: verified live against the cold-start corpus — **266/363** nodes returned with non-null 1536-dim embeddings; nodes without a stored vector return `null`.

## Verification
- `curl ".../hcg/snapshot?include_embeddings=true&limit=500"` → 266/363 with `dim=1536`.
- Apollo explorer (branch `feat/157-explorer-embedding-layout`) renders the 3D Semantic layout live on this data, 0 console errors.

## Downstream
Paired with apollo PR (apollo#…, branch `feat/157-explorer-embedding-layout`).