### PR TITLE
feat(#505): emergent type hierarchy (lineage + nested subtypes) + match-before-mint (#504)

### DIFF
--- a/src/sophia/hcg_client/client.py
+++ b/src/sophia/hcg_client/client.py
@@ -436,6 +436,42 @@ class HCGClient(LogosHCGClient):
             )
         return results
 
+    def get_nodes_by_type_uuid(self, type_uuid: str) -> list[dict]:
+        """Fetch all content nodes whose ``type_uuid`` property equals *type_uuid*.
+
+        Type membership is a pure node property: a node belongs to a minted
+        type iff its authoritative ``type_uuid`` points at that type-definition.
+        This replaces the prior instance->type ``IS_A`` edge bookkeeping -- the
+        edge was redundant with this property and only polluted the edge graph
+        (#505). Returns node dicts with the standard ``uuid``/``name``/``type``/
+        ``properties`` keys plus a top-level ``type_uuid`` for the membership
+        guard in the emergence handler. Edge nodes are excluded.
+        """
+        query = """
+        MATCH (n:Node {type_uuid: $type_uuid})
+        WHERE n.relation IS NULL
+        RETURN n.uuid as uuid, n.name as name, n.type as type,
+               n.type_uuid as type_uuid, properties(n) as props
+        """
+        records = self._execute_read(query, {"type_uuid": type_uuid})
+
+        results: list[dict] = []
+        for record in records:
+            props = dict(record["props"])
+            for key in ["uuid", "name", "type"]:
+                props.pop(key, None)
+            props = self._decode_properties(props)
+            results.append(
+                {
+                    "uuid": record["uuid"],
+                    "name": record["name"],
+                    "type": record["type"],
+                    "type_uuid": record["type_uuid"],
+                    "properties": props,
+                }
+            )
+        return results
+
     def find_nodes_by_names(self, names: list[str]) -> dict[str, dict]:
         """Find multiple content nodes by exact name match in a single query.
 

--- a/src/sophia/ingestion/proposal_processor.py
+++ b/src/sophia/ingestion/proposal_processor.py
@@ -388,6 +388,14 @@ class ProposalProcessor:
                         # is the centroid-classified one above.
                         node_props["hermes_type_hint"] = proposed.get("type")
 
+                        # Membership is a pure property: stamp the authoritative
+                        # `type_uuid` pointer at the node's type-definition. This
+                        # replaces the old instance->type IS_A edge (redundant
+                        # bookkeeping over `type_uuid` that only polluted the edge
+                        # graph); emergence loads members by this property (#505).
+                        type_def_uuid = f"type_{node_type}"
+                        node_props["type_uuid"] = type_def_uuid
+
                         node_uuid = self._hcg.add_node(
                             name=name,
                             node_type=node_type,
@@ -403,9 +411,11 @@ class ProposalProcessor:
                         logger.error(f"Failed to create node '{name}': {e}")
                         continue
 
-                    # 2c. Connect to type definition via IS_A edge.
-                    # Ensure the type-definition node exists (MERGE is idempotent).
-                    type_def_uuid = f"type_{node_type}"
+                    # 2c. Ensure the type-definition node exists (MERGE is
+                    # idempotent). The node's membership in this type is the
+                    # `type_uuid` property stamped above -- we deliberately do NOT
+                    # create an instance->type IS_A edge (redundant bookkeeping
+                    # over `type_uuid` that only polluted the edge graph) (#505).
                     _is_new_type = type_def_uuid not in self._seen_type_uuids
                     self._seen_type_uuids.add(type_def_uuid)
                     try:
@@ -416,14 +426,9 @@ class ProposalProcessor:
                             source="sophia",
                             derivation="observed",
                         )
-                        self._hcg.add_edge(
-                            source_uuid=node_uuid,
-                            target_uuid=type_def_uuid,
-                            relation="IS_A",
-                        )
                     except Exception as e:
                         logger.warning(
-                            "Could not create IS_A edge to type '%s': %s",
+                            "Could not ensure type-definition node for '%s': %s",
                             node_type,
                             e,
                         )

--- a/src/sophia/ingestion/type_classifier.py
+++ b/src/sophia/ingestion/type_classifier.py
@@ -67,7 +67,12 @@ class TypeClassifier:
         best = results[0]
         best_distance = best["score"]
         best_uuid = best["uuid"]
-        best_name = best_uuid.removeprefix("type_")
+        # Use the type-definition's clean human label (e.g. "organism"), NOT
+        # the uuid stripped of "type_": minted uuids carry a random hex suffix,
+        # so deriving the name from the uuid produced "organism_<hex>" labels
+        # that then overwrote the clean emergence name on the type-def.
+        best_node = self._hcg.get_node(best_uuid) if self._hcg else None
+        best_name = (best_node or {}).get("name") or best_uuid.removeprefix("type_")
 
         # Confidence: inverse of distance, clamped to [0, 1]
         if best_distance <= 0:

--- a/src/sophia/ingestion/type_classifier.py
+++ b/src/sophia/ingestion/type_classifier.py
@@ -70,9 +70,21 @@ class TypeClassifier:
         # Use the type-definition's clean human label (e.g. "organism"), NOT
         # the uuid stripped of "type_": minted uuids carry a random hex suffix,
         # so deriving the name from the uuid produced "organism_<hex>" labels
-        # that then overwrote the clean emergence name on the type-def.
-        best_node = self._hcg.get_node(best_uuid) if self._hcg else None
-        best_name = (best_node or {}).get("name") or best_uuid.removeprefix("type_")
+        # that then overwrote the clean emergence name on the type-def. The
+        # lookup is best-effort: a graph error must fall back to the uuid-derived
+        # name rather than abort classification (the caller may be mid-ingest
+        # with Neo4j flaky).
+        best_name = best_uuid.removeprefix("type_")
+        if self._hcg is not None:
+            try:
+                best_node = self._hcg.get_node(best_uuid)
+                if best_node and best_node.get("name"):
+                    best_name = best_node["name"]
+            except Exception:
+                logger.debug(
+                    "type name lookup failed for %s; using uuid-derived name",
+                    best_uuid,
+                )
 
         # Confidence: inverse of distance, clamped to [0, 1]
         if best_distance <= 0:

--- a/src/sophia/maintenance/config.py
+++ b/src/sophia/maintenance/config.py
@@ -50,13 +50,6 @@ class MaintenanceConfig(BaseSettings):
         description="Largest membership sent verbatim to Hermes name_cluster; "
         "larger clusters are sampled.",
     )
-    min_cohesion_improvement: float = Field(
-        default=0.15,
-        gt=0,
-        le=1.0,
-        description="Minimum fractional variance reduction a split must achieve "
-        "to be accepted.",
-    )
     hermes_confidence_floor: float = Field(
         default=0.5,
         ge=0,

--- a/src/sophia/maintenance/config.py
+++ b/src/sophia/maintenance/config.py
@@ -63,3 +63,11 @@ class MaintenanceConfig(BaseSettings):
         le=1.0,
         description="Discard Hermes cluster names below this confidence.",
     )
+    type_match_threshold: float = Field(
+        default=0.9,
+        ge=0,
+        le=1.0,
+        description="Cosine similarity above which an emergent cluster is "
+        "reconciled into an existing type (its members are retyped to that type) "
+        "instead of minting a new duplicate type (#504 match-before-mint).",
+    )

--- a/src/sophia/maintenance/emergence_handler.py
+++ b/src/sophia/maintenance/emergence_handler.py
@@ -17,6 +17,7 @@ from sophia.maintenance.config import MaintenanceConfig
 from sophia.maintenance.emergence_clustering import find_emergent_hierarchy
 from sophia.maintenance.emergence_types import EmergentCluster, Member
 from sophia.maintenance.structural_signature import build_signature
+from sophia.maintenance.type_minting import _slugify
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +32,14 @@ _BASE_TYPE = "entity"
 # directly under `type_entity`, so a minted type's parent ancestors are these
 # two prefixes and its own full ancestors append "entity" (#505).
 _ENTITY_ANCESTORS = ["root", "node"]
+
+
+def _cosine(a: list[float], b: list[float]) -> float:
+    """Cosine similarity of two equal-length vectors (0.0 if either is zero)."""
+    dot = sum(x * y for x, y in zip(a, b))
+    na = sum(x * x for x in a) ** 0.5
+    nb = sum(y * y for y in b) ** 0.5
+    return dot / (na * nb) if na and nb else 0.0
 
 
 def _type_name(type_uuid: str) -> str:
@@ -168,8 +177,9 @@ class EmergenceHandler:
 
     def run(self, type_uuid: str) -> None:
         members = self._load_members(type_uuid)
-        # Roll the fine clusters up into a hierarchy and mint from the top-level
-        # nodes, so related fine groups consolidate into super-types (#505).
+        # Roll the fine clusters up into a multi-level hierarchy: leaves are the
+        # fine clusters, internal nodes are super-types grouping related leaves
+        # (e.g. "linear algebra" + "calculus" -> "mathematics") (#505).
         hierarchy = find_emergent_hierarchy(
             members,
             min_cluster_size=self._config.min_cluster_size,
@@ -178,50 +188,147 @@ class EmergenceHandler:
         if not hierarchy:
             logger.info("emergence: no qualifying clusters in %s", type_uuid)
             return
-        clusters = [EmergentCluster(members=node.members) for node in hierarchy]
+
+        # Mint the whole tree *under the type being subdivided*. For the base
+        # `entity` junk-drawer that parent is `type_entity`; when re-emergence
+        # runs on an already-minted type we nest the new subtypes under it, so
+        # the hierarchy actually deepens instead of everything landing flat under
+        # `entity` (#505).
+        if _type_name(type_uuid) == _BASE_TYPE:
+            parent_type_uuid = f"type_{_BASE_TYPE}"
+            parent_ancestors = _ENTITY_ANCESTORS
+        else:
+            parent_type_uuid = type_uuid
+            parent_node = self._hcg.get_node(type_uuid) or {}
+            parent_ancestors = list(parent_node.get("ancestors") or _ENTITY_ANCESTORS)
 
         # Mutable copy: each successful mint adds its label so later clusters in
         # this same run see it as a candidate and don't silently re-mint a
         # same-label sibling.
         candidates = list(self._candidates_fn())
-        for cluster in clusters:
-            # Per-cluster isolation: a transient HCG/Milvus/Redis error while
-            # minting one cluster must not abort the whole run -- log it and move
-            # on so the remaining clusters still get minted (greptile #149).
-            try:
-                name = self._name_fn(cluster, candidates, self._hermes_url, self._token)
-                if (
-                    name is None
-                    or name.confidence < self._config.hermes_confidence_floor
-                ):
-                    logger.info("emergence: skip cluster (no/low-confidence name)")
-                    continue
+        for node in hierarchy:
+            self._mint_subtree(node, parent_type_uuid, parent_ancestors, candidates)
+
+    def _mint_subtree(
+        self,
+        node: Any,
+        parent_type_uuid: str,
+        parent_ancestors: list[str],
+        candidates: list[str],
+    ) -> None:
+        """Mint (or reconcile) one hierarchy node, then recurse into its children.
+
+        Leaf nodes carry real instance members and get them retyped onto the
+        minted/reconciled type. Internal nodes are pure super-types: their type
+        node is created but members are retyped at the leaves below. Every level
+        is named by Hermes, and children are minted under their freshly-created
+        parent so the IS_A chain and `ancestors` nest correctly.
+        """
+        # Per-node isolation: a transient HCG/Milvus/Redis error on one node must
+        # not abort the whole run -- log it and let siblings proceed (#149).
+        try:
+            cluster = EmergentCluster(members=node.members)
+            name = self._name_fn(cluster, candidates, self._hermes_url, self._token)
+            if name is None or name.confidence < self._config.hermes_confidence_floor:
+                logger.info("emergence: skip cluster (no/low-confidence name)")
+                return
+
+            is_leaf = not node.children
+            existing = self._match_existing_type(node.centroid, parent_type_uuid)
+            if existing is not None:
+                # Reconcile into the existing type rather than mint a duplicate
+                # (#504): retype the leaf's members onto it; children nest under
+                # it using its stored ancestors.
+                type_uuid = existing
+                existing_node = self._hcg.get_node(type_uuid) or {}
+                child_ancestors = list(
+                    existing_node.get("ancestors") or parent_ancestors
+                )
+                if is_leaf:
+                    self._attach_members(node.members, type_uuid, existing_node)
+                logger.info(
+                    "emergence: reconciled %d members into existing type %s",
+                    len(node.members),
+                    type_uuid,
+                )
+            else:
                 cluster_id = uuid_lib.uuid4().hex[:8]
-                new_type_uuid = self._mint_fn(
+                type_uuid = self._mint_fn(
                     cluster,
                     name,
                     hcg=self._hcg,
                     milvus=self._milvus,
                     source_cluster_id=cluster_id,
-                    parent_type_uuid=f"type_{_BASE_TYPE}",
-                    parent_ancestors=_ENTITY_ANCESTORS,
+                    parent_type_uuid=parent_type_uuid,
+                    parent_ancestors=parent_ancestors,
+                    retype_members=is_leaf,
                 )
                 if name.label not in candidates:
                     candidates.append(name.label)
+                # The minted type's own ancestors are parent_ancestors + its
+                # parent's name -- that's the chain its children descend from.
+                child_ancestors = list(parent_ancestors) + [
+                    parent_type_uuid.removeprefix("type_")
+                ]
                 if self._event_bus is not None:
                     self._event_bus.publish(
                         ONTOLOGY_CHANGED_CHANNEL,
                         {
-                            "type_uuid": new_type_uuid,
+                            "type_uuid": type_uuid,
                             "name": name.label,
-                            "ancestors": _ENTITY_ANCESTORS + [_BASE_TYPE],
+                            "ancestors": child_ancestors,
                         },
                     )
                 logger.info(
                     "emergence: minted %s from %d members", name.label, cluster.size
                 )
-            except Exception:
-                logger.exception("emergence: cluster failed, skipping")
+
+            for child in node.children:
+                self._mint_subtree(child, type_uuid, child_ancestors, candidates)
+        except Exception:
+            logger.exception("emergence: node failed, skipping")
+
+    def _match_existing_type(
+        self, centroid: list[float], parent_type_uuid: str
+    ) -> str | None:
+        """Nearest existing type whose centroid is within the match threshold of
+        ``centroid``, or None to mint fresh (#504 match-before-mint).
+
+        The parent being subdivided is excluded -- a cluster matching its own
+        parent isn't a distinct type, so we mint/keep rather than self-attach.
+        """
+        try:
+            nearest = self._milvus.find_nearest_types(centroid, top_k=1)
+        except Exception:
+            logger.exception("emergence: find_nearest_types failed")
+            return None
+        if not nearest:
+            return None
+        cand_uuid = nearest[0].get("uuid")
+        if not cand_uuid or cand_uuid == parent_type_uuid:
+            return None
+        try:
+            row = self._milvus.get_embedding(node_type="TypeCentroid", uuid=cand_uuid)
+        except Exception:
+            logger.exception("emergence: get_embedding failed for %s", cand_uuid)
+            return None
+        if not row or not row.get("embedding"):
+            return None
+        if _cosine(centroid, row["embedding"]) < self._config.type_match_threshold:
+            return None
+        return str(cand_uuid)
+
+    def _attach_members(
+        self, members: list[Member], type_uuid: str, type_node: dict[str, Any]
+    ) -> None:
+        """Retype members onto an existing type when reconciling (#504).
+
+        Membership is the authoritative `type_uuid` property plus the `type`
+        slug -- the same convention mint_type uses; no IS_A edge.
+        """
+        slug = _slugify(type_node.get("name") or _type_name(type_uuid))
+        for member in members:
+            self._hcg.update_node(member.uuid, {"type": slug, "type_uuid": type_uuid})
 
 
 def build_emergence_handler(

--- a/src/sophia/maintenance/emergence_handler.py
+++ b/src/sophia/maintenance/emergence_handler.py
@@ -36,7 +36,7 @@ _ENTITY_ANCESTORS = ["root", "node"]
 
 def _cosine(a: list[float], b: list[float]) -> float:
     """Cosine similarity of two equal-length vectors (0.0 if either is zero)."""
-    dot = sum(x * y for x, y in zip(a, b))
+    dot = sum(x * y for x, y in zip(a, b, strict=True))
     na = sum(x * x for x in a) ** 0.5
     nb = sum(y * y for y in b) ** 0.5
     return dot / (na * nb) if na and nb else 0.0
@@ -200,7 +200,8 @@ class EmergenceHandler:
         else:
             parent_type_uuid = type_uuid
             parent_node = self._hcg.get_node(type_uuid) or {}
-            parent_ancestors = list(parent_node.get("ancestors") or _ENTITY_ANCESTORS)
+            parent_props = parent_node.get("properties") or {}
+            parent_ancestors = list(parent_props.get("ancestors") or _ENTITY_ANCESTORS)
 
         # Mutable copy: each successful mint adds its label so later clusters in
         # this same run see it as a candidate and don't silently re-mint a
@@ -241,8 +242,9 @@ class EmergenceHandler:
                 # it using its stored ancestors.
                 type_uuid = existing
                 existing_node = self._hcg.get_node(type_uuid) or {}
+                existing_props = existing_node.get("properties") or {}
                 child_ancestors = list(
-                    existing_node.get("ancestors") or parent_ancestors
+                    existing_props.get("ancestors") or parent_ancestors
                 )
                 if is_leaf:
                     self._attach_members(node.members, type_uuid, existing_node)

--- a/src/sophia/maintenance/emergence_handler.py
+++ b/src/sophia/maintenance/emergence_handler.py
@@ -197,18 +197,25 @@ class EmergenceHandler:
         if _type_name(type_uuid) == _BASE_TYPE:
             parent_type_uuid = f"type_{_BASE_TYPE}"
             parent_ancestors = _ENTITY_ANCESTORS
+            parent_name = _BASE_TYPE
         else:
             parent_type_uuid = type_uuid
             parent_node = self._hcg.get_node(type_uuid) or {}
             parent_props = parent_node.get("properties") or {}
             parent_ancestors = list(parent_props.get("ancestors") or _ENTITY_ANCESTORS)
+            # Clean name of the type being subdivided. Never derive it from the
+            # uuid -- minted type uuids carry a random `_<hex>` suffix that would
+            # leak into descendants' ancestors (greptile #159).
+            parent_name = parent_node.get("name") or _type_name(type_uuid)
 
         # Mutable copy: each successful mint adds its label so later clusters in
         # this same run see it as a candidate and don't silently re-mint a
         # same-label sibling.
         candidates = list(self._candidates_fn())
         for node in hierarchy:
-            self._mint_subtree(node, parent_type_uuid, parent_ancestors, candidates)
+            self._mint_subtree(
+                node, parent_type_uuid, parent_ancestors, candidates, parent_name
+            )
 
     def _mint_subtree(
         self,
@@ -216,6 +223,7 @@ class EmergenceHandler:
         parent_type_uuid: str,
         parent_ancestors: list[str],
         candidates: list[str],
+        parent_name: str,
     ) -> None:
         """Mint (or reconcile) one hierarchy node, then recurse into its children.
 
@@ -246,6 +254,7 @@ class EmergenceHandler:
                 child_ancestors = list(
                     existing_props.get("ancestors") or parent_ancestors
                 )
+                minted_name = existing_node.get("name") or _type_name(type_uuid)
                 if is_leaf:
                     self._attach_members(node.members, type_uuid, existing_node)
                 logger.info(
@@ -263,15 +272,15 @@ class EmergenceHandler:
                     source_cluster_id=cluster_id,
                     parent_type_uuid=parent_type_uuid,
                     parent_ancestors=parent_ancestors,
+                    parent_name=parent_name,
                     retype_members=is_leaf,
                 )
                 if name.label not in candidates:
                     candidates.append(name.label)
+                minted_name = name.label
                 # The minted type's own ancestors are parent_ancestors + its
-                # parent's name -- that's the chain its children descend from.
-                child_ancestors = list(parent_ancestors) + [
-                    parent_type_uuid.removeprefix("type_")
-                ]
+                # parent's clean name -- the chain its children descend from.
+                child_ancestors = list(parent_ancestors) + [parent_name]
                 if self._event_bus is not None:
                     self._event_bus.publish(
                         ONTOLOGY_CHANGED_CHANNEL,
@@ -286,7 +295,9 @@ class EmergenceHandler:
                 )
 
             for child in node.children:
-                self._mint_subtree(child, type_uuid, child_ancestors, candidates)
+                self._mint_subtree(
+                    child, type_uuid, child_ancestors, candidates, minted_name
+                )
         except Exception:
             logger.exception("emergence: node failed, skipping")
 
@@ -316,7 +327,18 @@ class EmergenceHandler:
             return None
         if not row or not row.get("embedding"):
             return None
-        if _cosine(centroid, row["embedding"]) < self._config.type_match_threshold:
+        try:
+            similarity = _cosine(centroid, row["embedding"])
+        except ValueError:
+            # Dimension mismatch (e.g. a candidate centroid stored under a
+            # different embedding model). Decline the match here so the cluster
+            # mints fresh, rather than letting the error bubble up to
+            # _mint_subtree's catch-all and skip the whole node (greptile #159).
+            logger.warning(
+                "emergence: centroid dim mismatch vs %s; minting fresh", cand_uuid
+            )
+            return None
+        if similarity < self._config.type_match_threshold:
             return None
         return str(cand_uuid)
 

--- a/src/sophia/maintenance/emergence_handler.py
+++ b/src/sophia/maintenance/emergence_handler.py
@@ -14,8 +14,8 @@ from collections.abc import Callable
 from typing import Any
 
 from sophia.maintenance.config import MaintenanceConfig
-from sophia.maintenance.emergence_clustering import find_emergent_clusters
-from sophia.maintenance.emergence_types import Member
+from sophia.maintenance.emergence_clustering import find_emergent_hierarchy
+from sophia.maintenance.emergence_types import EmergentCluster, Member
 from sophia.maintenance.structural_signature import build_signature
 
 logger = logging.getLogger(__name__)
@@ -25,6 +25,11 @@ ONTOLOGY_CHANGED_CHANNEL = "ontology.type_created"
 # The base "junk-drawer" type that holds un-specialised nodes. Its membership is
 # resolved by node-type scan; minted types resolve membership via IS_A edges.
 _BASE_TYPE = "entity"
+
+# Lineage of the `entity` junk-drawer (root -> node -> entity). Emergence mints
+# directly under `type_entity`, so a minted type's parent ancestors are these
+# two prefixes and its own full ancestors append "entity" (#505).
+_ENTITY_ANCESTORS = ["root", "node"]
 
 
 def _type_name(type_uuid: str) -> str:
@@ -168,15 +173,17 @@ class EmergenceHandler:
 
     def run(self, type_uuid: str) -> None:
         members = self._load_members(type_uuid)
-        clusters = find_emergent_clusters(
+        # Roll the fine clusters up into a hierarchy and mint from the top-level
+        # nodes, so related fine groups consolidate into super-types (#505).
+        hierarchy = find_emergent_hierarchy(
             members,
             min_cluster_size=self._config.min_cluster_size,
             variance_threshold=self._config.variance_threshold,
-            min_cohesion_improvement=self._config.min_cohesion_improvement,
         )
-        if not clusters:
+        if not hierarchy:
             logger.info("emergence: no qualifying clusters in %s", type_uuid)
             return
+        clusters = [EmergentCluster(members=node.members) for node in hierarchy]
 
         # Mutable copy: each successful mint adds its label so later clusters in
         # this same run see it as a candidate and don't silently re-mint a
@@ -201,6 +208,8 @@ class EmergenceHandler:
                     hcg=self._hcg,
                     milvus=self._milvus,
                     source_cluster_id=cluster_id,
+                    parent_type_uuid=f"type_{_BASE_TYPE}",
+                    parent_ancestors=_ENTITY_ANCESTORS,
                 )
                 if name.label not in candidates:
                     candidates.append(name.label)
@@ -210,7 +219,7 @@ class EmergenceHandler:
                         {
                             "type_uuid": new_type_uuid,
                             "name": name.label,
-                            "ancestors": ["root"],
+                            "ancestors": _ENTITY_ANCESTORS + [_BASE_TYPE],
                         },
                     )
                 logger.info(

--- a/src/sophia/maintenance/emergence_handler.py
+++ b/src/sophia/maintenance/emergence_handler.py
@@ -23,7 +23,8 @@ logger = logging.getLogger(__name__)
 ONTOLOGY_CHANGED_CHANNEL = "ontology.type_created"
 
 # The base "junk-drawer" type that holds un-specialised nodes. Its membership is
-# resolved by node-type scan; minted types resolve membership via IS_A edges.
+# resolved by node-type scan; minted types resolve membership via the
+# authoritative `type_uuid` property (no instance->type IS_A edges -- #505).
 _BASE_TYPE = "entity"
 
 # Lineage of the `entity` junk-drawer (root -> node -> entity). Emergence mints
@@ -56,28 +57,21 @@ def _member_rows(hcg: Any, type_uuid: str, type_name: str) -> list[dict[str, Any
     """Resolve the node rows that belong to ``type_uuid``.
 
     The base junk-drawer (``entity``) is resolved by node-type scan. Any minted
-    type is resolved by the nodes that have an ``IS_A`` edge into *this specific*
-    type-definition uuid -- so two minted types that share a label do not bleed
-    members into one another.
+    type is resolved by the nodes whose authoritative ``type_uuid`` property
+    points at *this specific* type-definition uuid -- so two minted types that
+    share a label do not bleed members into one another, and a member retyped
+    out of this type (its ``type_uuid`` now points elsewhere) is excluded
+    automatically.
 
-    IS_A edges are additive (mint_type cannot delete the old edge), so a member
-    that was split out of this type into a *child* type still carries its stale
-    IS_A edge here. We therefore also require the node's authoritative
-    ``type_uuid`` pointer (overwritten on each retype) to still equal this type --
-    otherwise a re-emergence run would re-include and re-mint already-retyped
-    members (#149 review).
+    Membership is the ``type_uuid`` property; emergence no longer creates an
+    instance->type IS_A edge, so there is nothing to traverse or guard against
+    here (#505).
     """
     if type_name == _BASE_TYPE:
         return list(hcg.list_all_nodes(node_type=type_name))
 
-    edges = hcg.list_all_edges(relation_type="IS_A", target_uuid=type_uuid)
-    member_uuids = [e["source"] for e in (edges or []) if e and e.get("source")]
-    if not member_uuids:
-        return []
     return [
-        n
-        for n in (hcg.get_nodes_batch(member_uuids) or [])
-        if n and "uuid" in n and n.get("type_uuid") == type_uuid
+        n for n in (hcg.get_nodes_by_type_uuid(type_uuid) or []) if n and "uuid" in n
     ]
 
 
@@ -129,7 +123,8 @@ def load_type_members(hcg: Any, milvus: Any, type_uuid: str) -> list[Member]:
     """Load all members of a type as Member objects (embedding + structural signature).
 
     Membership is resolved by :func:`_member_rows` (node-type scan for the base
-    junk-drawer, IS_A-edge lookup for minted types). Embeddings come from Milvus;
+    junk-drawer, `type_uuid`-property lookup for minted types). Embeddings come
+    from Milvus;
     the structural signature is built from the node's outgoing reified edges
     (relation + resolved neighbor type). Nodes without an embedding are skipped
     (they can't be clustered).

--- a/src/sophia/maintenance/type_minting.py
+++ b/src/sophia/maintenance/type_minting.py
@@ -1,16 +1,20 @@
 """Mint an emergent type from a named cluster: type node + centroid + retype (#505).
 
-Emergence always mints a NEW type from a cluster of the unmatched residue:
-- create a `:Node` type-definition under `root` with name_history lineage,
+`mint_type` creates one NEW type-definition from a cluster:
+- create a `:Node` type-definition under its parent with name_history lineage,
 - seed its Milvus centroid (= mean of member embeddings),
-- retype each member (authoritative `type_uuid` property via update_node).
+- retype each member (authoritative `type_uuid` property via update_node),
+  unless `retype_members=False` (an internal super-type whose members are
+  retyped at the leaf subtypes below it).
 
 Membership is the `type_uuid` property -- emergence does NOT create an
 instance->type IS_A edge (it was redundant with `type_uuid`). The taxonomy
-IS_A (new type-definition -> parent type-definition) is still created below.
+IS_A (new type-definition -> parent type-definition) is created below.
 
 HCGClient encodes nested properties (name_history) transparently; ancestors is a
-native string list. Reconciling members into an *existing* type is #504's job.
+native string list. Deciding whether to mint here vs. reconcile a cluster into
+an *existing* type (#504 match-before-mint) is the caller's job -- see
+`EmergenceHandler._match_existing_type`.
 """
 
 from __future__ import annotations
@@ -58,6 +62,7 @@ def mint_type(
     source_cluster_id: str,
     parent_type_uuid: str = "type_entity",
     parent_ancestors: list[str] | None = None,
+    retype_members: bool = True,
 ) -> str:
     """Create the type-definition node, seed its centroid, and retype members.
 
@@ -107,15 +112,18 @@ def mint_type(
         model=model,
     )
 
-    for member in cluster.members:
-        # Membership is a pure property: stamp the authoritative current-type
-        # pointer (`type_uuid`, overwritten on each retype) and the human-facing
-        # `type` slug. We deliberately do NOT create an instance->type IS_A edge
-        # -- that edge was redundant bookkeeping over `type_uuid` and only
-        # polluted the edge graph. _member_rows now loads members directly by
-        # this `type_uuid` property, so a member retyped away from a parent is
-        # excluded automatically (no stale-edge cleanup needed) (#505).
-        hcg.update_node(member.uuid, {"type": slug, "type_uuid": type_uuid})
+    # Retype members onto this type, unless this is an internal super-type whose
+    # members belong to its child subtypes (the caller retypes them at the
+    # leaves). Membership is a pure property: stamp the authoritative current-type
+    # pointer (`type_uuid`, overwritten on each retype) and the human-facing
+    # `type` slug. We deliberately do NOT create an instance->type IS_A edge --
+    # that edge was redundant bookkeeping over `type_uuid` and only polluted the
+    # edge graph. _member_rows loads members directly by this `type_uuid`
+    # property, so a member retyped away from a parent is excluded automatically
+    # (no stale-edge cleanup needed) (#505).
+    if retype_members:
+        for member in cluster.members:
+            hcg.update_node(member.uuid, {"type": slug, "type_uuid": type_uuid})
 
     logger.info(
         "Minted type %s (%s) from %d members", name.label, type_uuid, cluster.size

--- a/src/sophia/maintenance/type_minting.py
+++ b/src/sophia/maintenance/type_minting.py
@@ -62,6 +62,7 @@ def mint_type(
     source_cluster_id: str,
     parent_type_uuid: str = "type_entity",
     parent_ancestors: list[str] | None = None,
+    parent_name: str | None = None,
     retype_members: bool = True,
 ) -> str:
     """Create the type-definition node, seed its centroid, and retype members.
@@ -89,14 +90,22 @@ def mint_type(
     # expects a minted type's `ancestors` to match that IS_A chain. For the
     # default entity parent this yields ["root", "node", "entity"].
     _anc = parent_ancestors or ["root", "node"]
-    parent_name = parent_type_uuid.removeprefix("type_")
+    # Prefer the parent's clean name. Minted parent uuids carry a random
+    # `_<hex>` suffix (`type_<slug>_<hex>`), so stripping "type_" off the uuid
+    # would pollute the lineage with that suffix (greptile #159). Fall back to
+    # the stripped uuid only for legacy/base parents like `type_entity`.
+    _pname = (
+        parent_name
+        if parent_name is not None
+        else parent_type_uuid.removeprefix("type_")
+    )
     hcg.add_node(
         name=name.label,
         node_type="type_definition",
         uuid=type_uuid,
         properties={
             "is_type_definition": True,
-            "ancestors": _anc + [parent_name],
+            "ancestors": _anc + [_pname],
             "name_history": name_history,
         },
         source="emergence",

--- a/src/sophia/maintenance/type_minting.py
+++ b/src/sophia/maintenance/type_minting.py
@@ -3,7 +3,11 @@
 Emergence always mints a NEW type from a cluster of the unmatched residue:
 - create a `:Node` type-definition under `root` with name_history lineage,
 - seed its Milvus centroid (= mean of member embeddings),
-- retype each member (`type` property via update_node) and add an `IS_A` edge.
+- retype each member (authoritative `type_uuid` property via update_node).
+
+Membership is the `type_uuid` property -- emergence does NOT create an
+instance->type IS_A edge (it was redundant with `type_uuid`). The taxonomy
+IS_A (new type-definition -> parent type-definition) is still created below.
 
 HCGClient encodes nested properties (name_history) transparently; ancestors is a
 native string list. Reconciling members into an *existing* type is #504's job.
@@ -60,8 +64,8 @@ def mint_type(
     The type uuid carries a random suffix so that two clusters that Hermes
     happens to name identically mint *distinct* type-definition nodes (and
     distinct centroids) instead of overwriting each other -- members are tied
-    to a specific minted type via their ``IS_A`` edge to this uuid, not via the
-    shared label string.
+    to a specific minted type via their ``type_uuid`` property pointing at this
+    uuid, not via the shared label string.
     """
     slug = _slugify(name.label)
     type_uuid = f"type_{slug}_{uuid4().hex[:8]}"
@@ -104,21 +108,14 @@ def mint_type(
     )
 
     for member in cluster.members:
-        # Remove the member's prior type-membership IS_A edge(s) before adding the
-        # new one. Edges are reified :Node records, so delete_edge(edge_uuid)
-        # removes the edge -- without this, a member split out of a parent type
-        # keeps a stale IS_A->parent edge and re-emergence on the parent would
-        # re-include and re-mint it (#149 review).
-        for e in hcg.query_edges_from(member.uuid):
-            if e.get("relation") == "IS_A":
-                edge_uuid = e.get("id") or e.get("uuid")
-                if edge_uuid:
-                    hcg.delete_edge(edge_uuid)
-        # Also stamp the authoritative current-membership pointer (type_uuid,
-        # overwritten on each retype); _member_rows filters by it as
-        # defense-in-depth should an edge delete above ever be missed.
+        # Membership is a pure property: stamp the authoritative current-type
+        # pointer (`type_uuid`, overwritten on each retype) and the human-facing
+        # `type` slug. We deliberately do NOT create an instance->type IS_A edge
+        # -- that edge was redundant bookkeeping over `type_uuid` and only
+        # polluted the edge graph. _member_rows now loads members directly by
+        # this `type_uuid` property, so a member retyped away from a parent is
+        # excluded automatically (no stale-edge cleanup needed) (#505).
         hcg.update_node(member.uuid, {"type": slug, "type_uuid": type_uuid})
-        hcg.add_edge(member.uuid, type_uuid, "IS_A")
 
     logger.info(
         "Minted type %s (%s) from %d members", name.label, type_uuid, cluster.size

--- a/src/sophia/maintenance/type_minting.py
+++ b/src/sophia/maintenance/type_minting.py
@@ -52,6 +52,8 @@ def mint_type(
     hcg: Any,
     milvus: Any,
     source_cluster_id: str,
+    parent_type_uuid: str = "type_entity",
+    parent_ancestors: list[str] | None = None,
 ) -> str:
     """Create the type-definition node, seed its centroid, and retype members.
 
@@ -73,17 +75,26 @@ def mint_type(
             "hermes_confidence": name.confidence,
         }
     ]
+    # Descend from the parent type (default `type_entity`) rather than `root`:
+    # the seeder represents the type hierarchy via IS_A edges, and spec 21.3
+    # expects a minted type's `ancestors` to match that IS_A chain. For the
+    # default entity parent this yields ["root", "node", "entity"].
+    _anc = parent_ancestors or ["root", "node"]
+    parent_name = parent_type_uuid.removeprefix("type_")
     hcg.add_node(
         name=name.label,
         node_type="type_definition",
         uuid=type_uuid,
         properties={
             "is_type_definition": True,
-            "ancestors": ["root"],
+            "ancestors": _anc + [parent_name],
             "name_history": name_history,
         },
         source="emergence",
     )
+    # Wire the minted type into the IS_A hierarchy under its parent so the
+    # graph chain matches the stored `ancestors` (new_type IS_A parent).
+    hcg.add_edge(type_uuid, parent_type_uuid, "IS_A")
 
     model = next((m.model for m in cluster.members if m.model), _DEFAULT_MODEL)
     milvus.update_centroid(

--- a/tests/maintenance/test_config_emergence.py
+++ b/tests/maintenance/test_config_emergence.py
@@ -14,7 +14,6 @@ class TestEmergenceTunables:
         assert cfg.variance_threshold > 0
         assert cfg.min_cluster_size >= 2
         assert cfg.max_cluster_size >= cfg.min_cluster_size
-        assert 0.0 < cfg.min_cohesion_improvement <= 1.0
         assert 0.0 <= cfg.hermes_confidence_floor <= 1.0
 
     def test_env_override(self):

--- a/tests/maintenance/test_emergence_adapters.py
+++ b/tests/maintenance/test_emergence_adapters.py
@@ -8,17 +8,19 @@ from sophia.maintenance.emergence_handler import current_categories, load_type_m
 
 
 class _FakeHCG:
-    def __init__(self, nodes_by_type, edges, batch, is_a_edges=None):
+    def __init__(self, nodes_by_type, edges, batch, nodes_by_type_uuid=None):
         self._nodes_by_type = nodes_by_type
         self._edges = edges
         self._batch = batch
-        self._is_a_edges = is_a_edges or {}
+        # Membership is now a pure `type_uuid` property: minted-type members are
+        # served by get_nodes_by_type_uuid, NOT by IS_A-edge traversal (#505).
+        self._nodes_by_type_uuid = nodes_by_type_uuid or {}
 
     def list_all_nodes(self, node_type=None):
         return self._nodes_by_type.get(node_type, [])
 
-    def list_all_edges(self, relation_type=None, target_uuid=None, **kw):
-        return self._is_a_edges.get((relation_type, target_uuid), [])
+    def get_nodes_by_type_uuid(self, type_uuid):
+        return list(self._nodes_by_type_uuid.get(type_uuid, []))
 
     def query_edges_from(self, uuid):
         return self._edges.get(uuid, [])
@@ -88,31 +90,29 @@ def test_load_type_members_skips_nodes_without_embedding():
     assert load_type_members(hcg, milvus, "type_entity") == []
 
 
-def test_load_type_members_minted_type_uses_is_a_edges():
-    # A minted type resolves membership via incoming IS_A edges to its uuid,
-    # NOT a label scan -- so a same-label sibling type cannot bleed members in.
+def test_load_type_members_minted_type_uses_type_uuid_property():
+    # A minted type resolves membership via the authoritative `type_uuid`
+    # property (get_nodes_by_type_uuid), NOT a label scan or IS_A edges -- so a
+    # same-label sibling type cannot bleed members in (#505).
     type_uuid = "type_concept_abc12345"
     hcg = _FakeHCG(
         nodes_by_type={},
         edges={},
-        batch={
-            "u1": {
-                "uuid": "u1",
-                "name": "deriv",
-                "type": "concept",
-                "type_uuid": type_uuid,
-            },
-            "u2": {
-                "uuid": "u2",
-                "name": "integ",
-                "type": "concept",
-                "type_uuid": type_uuid,
-            },
-        },
-        is_a_edges={
-            ("IS_A", type_uuid): [
-                {"source": "u1", "target": type_uuid},
-                {"source": "u2", "target": type_uuid},
+        batch={},
+        nodes_by_type_uuid={
+            type_uuid: [
+                {
+                    "uuid": "u1",
+                    "name": "deriv",
+                    "type": "concept",
+                    "type_uuid": type_uuid,
+                },
+                {
+                    "uuid": "u2",
+                    "name": "integ",
+                    "type": "concept",
+                    "type_uuid": type_uuid,
+                },
             ]
         },
     )
@@ -126,19 +126,17 @@ def test_load_type_members_minted_type_uses_is_a_edges():
     assert {m.uuid for m in members} == {"u1", "u2"}
 
 
-def test_load_type_members_tolerates_dangling_is_a_edges():
-    # get_nodes_batch may not return every uuid (deleted node); those drop out.
+def test_load_type_members_skips_minted_member_without_embedding():
+    # A type_uuid member with no Milvus embedding can't be clustered -> dropped.
     type_uuid = "type_concept_deadbeef"
     hcg = _FakeHCG(
         nodes_by_type={},
         edges={},
-        batch={
-            "u1": {"uuid": "u1", "name": "x", "type": "concept", "type_uuid": type_uuid}
-        },
-        is_a_edges={
-            ("IS_A", type_uuid): [
-                {"source": "u1", "target": type_uuid},
-                {"source": "gone", "target": type_uuid},
+        batch={},
+        nodes_by_type_uuid={
+            type_uuid: [
+                {"uuid": "u1", "name": "x", "type": "concept", "type_uuid": type_uuid},
+                {"uuid": "u2", "name": "y", "type": "concept", "type_uuid": type_uuid},
             ]
         },
     )
@@ -156,15 +154,17 @@ def test_minted_member_embeddings_read_from_base_collection():
     hcg = _FakeHCG(
         nodes_by_type={},
         edges={},
-        batch={
-            "u1": {
-                "uuid": "u1",
-                "name": "deriv",
-                "type": "concept",
-                "type_uuid": type_uuid,
-            }
+        batch={},
+        nodes_by_type_uuid={
+            type_uuid: [
+                {
+                    "uuid": "u1",
+                    "name": "deriv",
+                    "type": "concept",
+                    "type_uuid": type_uuid,
+                }
+            ]
         },
-        is_a_edges={("IS_A", type_uuid): [{"source": "u1", "target": type_uuid}]},
     )
 
     class _CollectionAwareMilvus:
@@ -181,32 +181,26 @@ def test_minted_member_embeddings_read_from_base_collection():
     assert {m.uuid for m in members} == {"u1"}
 
 
-def test_retyped_member_with_stale_is_a_edge_excluded_from_parent():
-    """A member split out of a parent type into a child keeps a stale IS_A edge
-    to the parent (the client can't delete edges), but its authoritative
-    type_uuid now points at the child. Re-emergence on the parent must NOT
-    re-include and re-mint it (#149 review)."""
+def test_retyped_member_excluded_from_parent_by_type_uuid():
+    """A member split out of a parent type into a child has its authoritative
+    `type_uuid` repointed at the child. Membership is that property, so loading
+    the parent (get_nodes_by_type_uuid(parent)) simply does not return it -- no
+    stale-edge cleanup or guard is needed (#505)."""
     parent_uuid = "type_tool_parent01"
     child_uuid = "type_hammer_child02"
     hcg = _FakeHCG(
         nodes_by_type={},
         edges={},
-        batch={
-            # u1 still belongs to the parent.
-            "u1": {"uuid": "u1", "name": "w", "type": "tool", "type_uuid": parent_uuid},
-            # u2 was retyped into the child but kept its stale IS_A -> parent.
-            "u2": {
-                "uuid": "u2",
-                "name": "h",
-                "type": "hammer",
-                "type_uuid": child_uuid,
-            },
-        },
-        is_a_edges={
-            ("IS_A", parent_uuid): [
-                {"source": "u1", "target": parent_uuid},
-                {"source": "u2", "target": parent_uuid},  # stale
-            ]
+        batch={},
+        nodes_by_type_uuid={
+            # u1 still belongs to the parent; u2 was retyped into the child, so
+            # its `type_uuid` now points there and it is absent from the parent.
+            parent_uuid: [
+                {"uuid": "u1", "name": "w", "type": "tool", "type_uuid": parent_uuid}
+            ],
+            child_uuid: [
+                {"uuid": "u2", "name": "h", "type": "hammer", "type_uuid": child_uuid}
+            ],
         },
     )
     milvus = _FakeMilvus(
@@ -216,5 +210,5 @@ def test_retyped_member_with_stale_is_a_edge_excluded_from_parent():
         }
     )
     members = load_type_members(hcg, milvus, parent_uuid)
-    # u2 retyped away -> excluded despite the stale IS_A edge.
+    # u2 retyped away -> excluded; membership follows the `type_uuid` property.
     assert {m.uuid for m in members} == {"u1"}

--- a/tests/maintenance/test_emergence_handler.py
+++ b/tests/maintenance/test_emergence_handler.py
@@ -44,7 +44,7 @@ def test_handler_mints_named_clusters_and_publishes():
         label = "object" if cluster.members[0].uuid.startswith("p") else "concept"
         return NameResult(label=label, description="", confidence=0.9)
 
-    def fake_mint(cluster, name, hcg, milvus, source_cluster_id):
+    def fake_mint(cluster, name, hcg, milvus, source_cluster_id, **kwargs):
         minted.append(name.label)
         return f"type_{name.label}"
 
@@ -78,7 +78,7 @@ def test_handler_isolates_failing_cluster():
         label = "object" if cluster.members[0].uuid.startswith("p") else "concept"
         return NameResult(label=label, description="", confidence=0.9)
 
-    def flaky_mint(cluster, name, hcg, milvus, source_cluster_id):
+    def flaky_mint(cluster, name, hcg, milvus, source_cluster_id, **kwargs):
         if name.label == "object":
             raise RuntimeError("transient HCG write error")
         minted.append(name.label)
@@ -138,7 +138,7 @@ def test_handler_feeds_minted_labels_into_later_candidates():
         label = "object" if cluster.members[0].uuid.startswith("p") else "concept"
         return NameResult(label=label, description="", confidence=0.9)
 
-    def fake_mint(cluster, name, hcg, milvus, source_cluster_id):
+    def fake_mint(cluster, name, hcg, milvus, source_cluster_id, **kwargs):
         return f"type_{name.label}_x"
 
     handler = EmergenceHandler(
@@ -159,3 +159,64 @@ def test_handler_feeds_minted_labels_into_later_candidates():
     assert seen_candidates[0] == ["location"]
     assert seen_candidates[1][-1] in {"object", "concept"}
     assert len(seen_candidates[1]) == 2
+
+
+def test_handler_mints_under_entity_via_hierarchy(monkeypatch):
+    """Emergence must (a) drive minting off the hierarchy roll-up and (b) parent
+    every minted type under `type_entity` with the entity lineage (#505)."""
+    from sophia.maintenance import emergence_handler as eh
+    from sophia.maintenance.emergence_clustering import HierarchyNode
+    from sophia.maintenance.emergence_types import EmergentCluster
+
+    seen_members, mint_kwargs = [], []
+
+    def fake_hierarchy(members, *, min_cluster_size, variance_threshold):
+        # Two top-level hierarchy nodes, one per disjoint group of members.
+        phys = [m for m in members if m.uuid.startswith("p")]
+        con = [m for m in members if m.uuid.startswith("c")]
+        return [
+            HierarchyNode(members=phys, centroid=[0.0, 0.0]),
+            HierarchyNode(members=con, centroid=[9.0, 9.0]),
+        ]
+
+    monkeypatch.setattr(eh, "find_emergent_hierarchy", fake_hierarchy)
+
+    def fake_name(cluster, candidates, hermes_url, token):
+        assert isinstance(cluster, EmergentCluster)
+        seen_members.append([m.uuid for m in cluster.members])
+        label = "object" if cluster.members[0].uuid.startswith("p") else "concept"
+        return NameResult(label=label, description="", confidence=0.9)
+
+    def fake_mint(cluster, name, hcg, milvus, source_cluster_id, **kwargs):
+        mint_kwargs.append(kwargs)
+        return f"type_{name.label}_x"
+
+    published = []
+
+    class EB:
+        def publish(self, channel, msg):
+            published.append(msg)
+
+    handler = EmergenceHandler(
+        config=MaintenanceConfig(),
+        hcg=object(),
+        milvus=object(),
+        event_bus=EB(),
+        hermes_url="http://h",
+        token="t",
+        load_members=lambda u: _members(),
+        name_fn=fake_name,
+        mint_fn=fake_mint,
+        candidates_fn=lambda: [],
+    )
+    handler.run(type_uuid="type_entity")
+
+    # Each top-level hierarchy node became its own EmergentCluster.
+    assert seen_members == [["p0", "p1", "p2", "p3"], ["c0", "c1", "c2", "c3"]]
+    # Every mint is parented under entity with the entity lineage.
+    assert mint_kwargs == [
+        {"parent_type_uuid": "type_entity", "parent_ancestors": ["root", "node"]},
+        {"parent_type_uuid": "type_entity", "parent_ancestors": ["root", "node"]},
+    ]
+    # The published lineage descends root -> node -> entity.
+    assert all(p["ancestors"] == ["root", "node", "entity"] for p in published)

--- a/tests/maintenance/test_emergence_handler.py
+++ b/tests/maintenance/test_emergence_handler.py
@@ -330,7 +330,7 @@ def test_handler_reconciles_into_existing_type(monkeypatch):
 
     class FakeHCG:
         def get_node(self, uuid):
-            return {"uuid": uuid, "name": "vehicle", "ancestors": ["root", "node", "entity"]}
+            return {"uuid": uuid, "name": "vehicle", "properties": {"ancestors": ["root", "node", "entity"]}}
 
         def update_node(self, uuid, props):
             retyped[uuid] = props
@@ -369,7 +369,7 @@ def test_handler_subdivides_minted_type_nests_under_it(monkeypatch):
 
     class FakeHCG:
         def get_node(self, uuid):
-            return {"uuid": uuid, "name": "vehicle", "ancestors": ["root", "node", "entity"]}
+            return {"uuid": uuid, "name": "vehicle", "properties": {"ancestors": ["root", "node", "entity"]}}
 
         def update_node(self, *a, **k):
             pass

--- a/tests/maintenance/test_emergence_handler.py
+++ b/tests/maintenance/test_emergence_handler.py
@@ -330,7 +330,11 @@ def test_handler_reconciles_into_existing_type(monkeypatch):
 
     class FakeHCG:
         def get_node(self, uuid):
-            return {"uuid": uuid, "name": "vehicle", "properties": {"ancestors": ["root", "node", "entity"]}}
+            return {
+                "uuid": uuid,
+                "name": "vehicle",
+                "properties": {"ancestors": ["root", "node", "entity"]},
+            }
 
         def update_node(self, uuid, props):
             retyped[uuid] = props
@@ -369,13 +373,25 @@ def test_handler_subdivides_minted_type_nests_under_it(monkeypatch):
 
     class FakeHCG:
         def get_node(self, uuid):
-            return {"uuid": uuid, "name": "vehicle", "properties": {"ancestors": ["root", "node", "entity"]}}
+            return {
+                "uuid": uuid,
+                "name": "vehicle",
+                "properties": {"ancestors": ["root", "node", "entity"]},
+            }
 
         def update_node(self, *a, **k):
             pass
 
     def fake_mint(
-        cluster, name, hcg, milvus, source_cluster_id, *, parent_type_uuid, parent_ancestors, **k
+        cluster,
+        name,
+        hcg,
+        milvus,
+        source_cluster_id,
+        *,
+        parent_type_uuid,
+        parent_ancestors,
+        **k,
     ):
         mint_kwargs.append((parent_type_uuid, parent_ancestors))
         return "type_sedan_x"

--- a/tests/maintenance/test_emergence_handler.py
+++ b/tests/maintenance/test_emergence_handler.py
@@ -9,6 +9,17 @@ from sophia.maintenance.emergence_handler import EmergenceHandler
 from sophia.maintenance.emergence_types import Member, NameResult
 
 
+class _NoMatchMilvus:
+    """Milvus stub for which match-before-mint (#504) never finds an existing
+    type, so every cluster mints fresh."""
+
+    def find_nearest_types(self, centroid, top_k=1):
+        return []
+
+    def get_embedding(self, node_type, uuid):
+        return None
+
+
 def _members():
     phys = [
         Member(
@@ -55,7 +66,7 @@ def test_handler_mints_named_clusters_and_publishes():
     handler = EmergenceHandler(
         config=MaintenanceConfig(),
         hcg=object(),
-        milvus=object(),
+        milvus=_NoMatchMilvus(),
         event_bus=EB(),
         hermes_url="http://h",
         token="t",
@@ -87,7 +98,7 @@ def test_handler_isolates_failing_cluster():
     handler = EmergenceHandler(
         config=MaintenanceConfig(),
         hcg=object(),
-        milvus=object(),
+        milvus=_NoMatchMilvus(),
         event_bus=None,
         hermes_url="http://h",
         token="t",
@@ -113,7 +124,7 @@ def test_handler_skips_low_confidence():
     handler = EmergenceHandler(
         config=MaintenanceConfig(),
         hcg=object(),
-        milvus=object(),
+        milvus=_NoMatchMilvus(),
         event_bus=None,
         hermes_url="http://h",
         token="t",
@@ -144,7 +155,7 @@ def test_handler_feeds_minted_labels_into_later_candidates():
     handler = EmergenceHandler(
         config=MaintenanceConfig(),
         hcg=object(),
-        milvus=object(),
+        milvus=_NoMatchMilvus(),
         event_bus=None,
         hermes_url="http://h",
         token="t",
@@ -200,7 +211,7 @@ def test_handler_mints_under_entity_via_hierarchy(monkeypatch):
     handler = EmergenceHandler(
         config=MaintenanceConfig(),
         hcg=object(),
-        milvus=object(),
+        milvus=_NoMatchMilvus(),
         event_bus=EB(),
         hermes_url="http://h",
         token="t",
@@ -213,10 +224,175 @@ def test_handler_mints_under_entity_via_hierarchy(monkeypatch):
 
     # Each top-level hierarchy node became its own EmergentCluster.
     assert seen_members == [["p0", "p1", "p2", "p3"], ["c0", "c1", "c2", "c3"]]
-    # Every mint is parented under entity with the entity lineage.
+    # Every mint is parented under entity with the entity lineage. Both nodes are
+    # leaves (no children), so their members are retyped onto them.
     assert mint_kwargs == [
-        {"parent_type_uuid": "type_entity", "parent_ancestors": ["root", "node"]},
-        {"parent_type_uuid": "type_entity", "parent_ancestors": ["root", "node"]},
+        {
+            "parent_type_uuid": "type_entity",
+            "parent_ancestors": ["root", "node"],
+            "retype_members": True,
+        },
+        {
+            "parent_type_uuid": "type_entity",
+            "parent_ancestors": ["root", "node"],
+            "retype_members": True,
+        },
     ]
     # The published lineage descends root -> node -> entity.
     assert all(p["ancestors"] == ["root", "node", "entity"] for p in published)
+
+
+def test_handler_mints_nested_hierarchy(monkeypatch):
+    """An internal super-type node mints type-only (retype_members=False) and its
+    leaf children mint *under it* (retype_members=True), so the tree nests (#505)."""
+    from sophia.maintenance import emergence_handler as eh
+    from sophia.maintenance.emergence_clustering import HierarchyNode
+
+    leaf_a = HierarchyNode(
+        members=[m for m in _members() if m.uuid.startswith("p")], centroid=[0.0, 0.0]
+    )
+    leaf_b = HierarchyNode(
+        members=[m for m in _members() if m.uuid.startswith("c")], centroid=[9.0, 9.0]
+    )
+    supertype = HierarchyNode(
+        members=leaf_a.members + leaf_b.members,
+        centroid=[4.5, 4.5],
+        children=[leaf_a, leaf_b],
+    )
+    monkeypatch.setattr(eh, "find_emergent_hierarchy", lambda *a, **k: [supertype])
+
+    calls = []  # (label, parent_type_uuid, retype_members)
+
+    def fake_name(cluster, candidates, hermes_url, token):
+        if len(cluster.members) == 8:
+            label = "science"
+        elif cluster.members[0].uuid.startswith("p"):
+            label = "object"
+        else:
+            label = "concept"
+        return NameResult(label=label, description="", confidence=0.9)
+
+    def fake_mint(
+        cluster,
+        name,
+        hcg,
+        milvus,
+        source_cluster_id,
+        *,
+        parent_type_uuid,
+        parent_ancestors,
+        retype_members,
+    ):
+        calls.append((name.label, parent_type_uuid, retype_members))
+        return f"type_{name.label}_x"
+
+    handler = EmergenceHandler(
+        config=MaintenanceConfig(),
+        hcg=object(),
+        milvus=_NoMatchMilvus(),
+        event_bus=None,
+        hermes_url="http://h",
+        token="t",
+        load_members=lambda u: _members(),
+        name_fn=fake_name,
+        mint_fn=fake_mint,
+        candidates_fn=lambda: [],
+    )
+    handler.run(type_uuid="type_entity")
+
+    # Super-type minted first, under entity, type-only (members live in leaves).
+    assert calls[0] == ("science", "type_entity", False)
+    # Leaves mint under the freshly-minted super-type and retype their members.
+    assert ("object", "type_science_x", True) in calls
+    assert ("concept", "type_science_x", True) in calls
+
+
+def test_handler_reconciles_into_existing_type(monkeypatch):
+    """A cluster whose centroid matches an existing type is retyped onto it; no
+    duplicate type is minted (#504 match-before-mint)."""
+    from sophia.maintenance import emergence_handler as eh
+    from sophia.maintenance.emergence_clustering import HierarchyNode
+
+    leaf = HierarchyNode(
+        members=[m for m in _members() if m.uuid.startswith("p")], centroid=[1.0, 0.0]
+    )
+    monkeypatch.setattr(eh, "find_emergent_hierarchy", lambda *a, **k: [leaf])
+
+    minted, retyped = [], {}
+
+    class FakeMilvus:
+        def find_nearest_types(self, centroid, top_k=1):
+            return [{"uuid": "type_vehicle_abc", "score": 0.0}]
+
+        def get_embedding(self, node_type, uuid):
+            # Same direction as the cluster centroid -> cosine 1.0 (>= threshold).
+            return {"uuid": uuid, "embedding": [2.0, 0.0]}
+
+    class FakeHCG:
+        def get_node(self, uuid):
+            return {"uuid": uuid, "name": "vehicle", "ancestors": ["root", "node", "entity"]}
+
+        def update_node(self, uuid, props):
+            retyped[uuid] = props
+
+    handler = EmergenceHandler(
+        config=MaintenanceConfig(),
+        hcg=FakeHCG(),
+        milvus=FakeMilvus(),
+        event_bus=None,
+        hermes_url="http://h",
+        token="t",
+        load_members=lambda u: _members(),
+        name_fn=lambda *a: NameResult(label="vehicle", description="", confidence=0.9),
+        mint_fn=lambda *a, **k: minted.append(1) or "type_should_not_mint",
+        candidates_fn=lambda: [],
+    )
+    handler.run(type_uuid="type_entity")
+
+    assert minted == []  # reconciled into the existing type, not minted
+    assert len(retyped) == 4  # the four "p" members retyped
+    assert all(p["type_uuid"] == "type_vehicle_abc" for p in retyped.values())
+
+
+def test_handler_subdivides_minted_type_nests_under_it(monkeypatch):
+    """Re-emergence on an already-minted type parents new subtypes under *it* (with
+    its stored ancestors), deepening the hierarchy instead of flattening (#505)."""
+    from sophia.maintenance import emergence_handler as eh
+    from sophia.maintenance.emergence_clustering import HierarchyNode
+
+    leaf = HierarchyNode(
+        members=[m for m in _members() if m.uuid.startswith("p")], centroid=[0.0, 0.0]
+    )
+    monkeypatch.setattr(eh, "find_emergent_hierarchy", lambda *a, **k: [leaf])
+
+    mint_kwargs = []
+
+    class FakeHCG:
+        def get_node(self, uuid):
+            return {"uuid": uuid, "name": "vehicle", "ancestors": ["root", "node", "entity"]}
+
+        def update_node(self, *a, **k):
+            pass
+
+    def fake_mint(
+        cluster, name, hcg, milvus, source_cluster_id, *, parent_type_uuid, parent_ancestors, **k
+    ):
+        mint_kwargs.append((parent_type_uuid, parent_ancestors))
+        return "type_sedan_x"
+
+    handler = EmergenceHandler(
+        config=MaintenanceConfig(),
+        hcg=FakeHCG(),
+        milvus=_NoMatchMilvus(),
+        event_bus=None,
+        hermes_url="http://h",
+        token="t",
+        load_members=lambda u: _members(),
+        name_fn=lambda *a: NameResult(label="sedan", description="", confidence=0.9),
+        mint_fn=fake_mint,
+        candidates_fn=lambda: [],
+    )
+    handler.run(type_uuid="type_vehicle_abc")
+
+    # Parent is the subdivided type itself, with that type's ancestors.
+    assert mint_kwargs == [("type_vehicle_abc", ["root", "node", "entity"])]

--- a/tests/maintenance/test_emergence_handler.py
+++ b/tests/maintenance/test_emergence_handler.py
@@ -230,11 +230,13 @@ def test_handler_mints_under_entity_via_hierarchy(monkeypatch):
         {
             "parent_type_uuid": "type_entity",
             "parent_ancestors": ["root", "node"],
+            "parent_name": "entity",
             "retype_members": True,
         },
         {
             "parent_type_uuid": "type_entity",
             "parent_ancestors": ["root", "node"],
+            "parent_name": "entity",
             "retype_members": True,
         },
     ]
@@ -281,9 +283,10 @@ def test_handler_mints_nested_hierarchy(monkeypatch):
         *,
         parent_type_uuid,
         parent_ancestors,
+        parent_name,
         retype_members,
     ):
-        calls.append((name.label, parent_type_uuid, retype_members))
+        calls.append((name.label, parent_type_uuid, parent_name, retype_members))
         return f"type_{name.label}_x"
 
     handler = EmergenceHandler(
@@ -301,10 +304,13 @@ def test_handler_mints_nested_hierarchy(monkeypatch):
     handler.run(type_uuid="type_entity")
 
     # Super-type minted first, under entity, type-only (members live in leaves).
-    assert calls[0] == ("science", "type_entity", False)
+    assert calls[0] == ("science", "type_entity", "entity", False)
     # Leaves mint under the freshly-minted super-type and retype their members.
-    assert ("object", "type_science_x", True) in calls
-    assert ("concept", "type_science_x", True) in calls
+    # parent_name is the super-type's CLEAN name ("science"), never its
+    # `_<hex>`-suffixed uuid ("science_x") -- otherwise the suffix leaks into
+    # the leaves' ancestors lineage (greptile #159).
+    assert ("object", "type_science_x", "science", True) in calls
+    assert ("concept", "type_science_x", "science", True) in calls
 
 
 def test_handler_reconciles_into_existing_type(monkeypatch):
@@ -412,3 +418,61 @@ def test_handler_subdivides_minted_type_nests_under_it(monkeypatch):
 
     # Parent is the subdivided type itself, with that type's ancestors.
     assert mint_kwargs == [("type_vehicle_abc", ["root", "node", "entity"])]
+
+
+def test_handler_dim_mismatch_declines_match_and_mints_fresh(monkeypatch):
+    """A candidate type centroid of a different dimension must not abort the
+    cluster. `_cosine(strict=True)` raises on the mismatch, but
+    `_match_existing_type` swallows it and declines the match, so the cluster
+    mints fresh instead of being skipped by `_mint_subtree`'s catch-all
+    (greptile #159)."""
+    from sophia.maintenance import emergence_handler as eh
+    from sophia.maintenance.emergence_clustering import HierarchyNode
+
+    leaf = HierarchyNode(
+        members=[m for m in _members() if m.uuid.startswith("p")], centroid=[1.0, 0.0]
+    )
+    monkeypatch.setattr(eh, "find_emergent_hierarchy", lambda *a, **k: [leaf])
+
+    minted = []
+
+    class DimMismatchMilvus:
+        def find_nearest_types(self, centroid, top_k=1):
+            return [{"uuid": "type_other_abc", "score": 0.0}]
+
+        def get_embedding(self, node_type, uuid):
+            # 3-dim candidate centroid vs the cluster's 2-dim centroid -> the
+            # strict zip in _cosine raises ValueError.
+            return {"uuid": uuid, "embedding": [1.0, 0.0, 0.0]}
+
+    class FakeHCG:
+        def get_node(self, uuid):
+            return {
+                "uuid": uuid,
+                "name": "other",
+                "properties": {"ancestors": ["root", "node", "entity"]},
+            }
+
+        def update_node(self, *a, **k):
+            pass
+
+    def fake_mint(cluster, name, hcg, milvus, source_cluster_id, **k):
+        minted.append(name.label)
+        return f"type_{name.label}_x"
+
+    handler = EmergenceHandler(
+        config=MaintenanceConfig(),
+        hcg=FakeHCG(),
+        milvus=DimMismatchMilvus(),
+        event_bus=None,
+        hermes_url="http://h",
+        token="t",
+        load_members=lambda u: _members(),
+        name_fn=lambda *a: NameResult(label="object", description="", confidence=0.9),
+        mint_fn=fake_mint,
+        candidates_fn=lambda: [],
+    )
+    handler.run(type_uuid="type_entity")
+
+    # Dim mismatch -> match declined -> minted fresh (cluster NOT skipped).
+    assert minted == ["object"]

--- a/tests/maintenance/test_type_minting.py
+++ b/tests/maintenance/test_type_minting.py
@@ -147,6 +147,30 @@ def test_mint_under_explicit_parent_sets_lineage_and_is_a_edge():
     assert (type_uuid, "type_animal", "IS_A") in hcg.edges
 
 
+def test_mint_uses_clean_parent_name_not_uuid_suffix():
+    """When the parent is a minted type, its uuid carries a random `_<hex>`
+    suffix (`type_<slug>_<hex>`). The child's stored ancestors must use the
+    parent's clean name passed via `parent_name`, not the suffixed uuid
+    (greptile #159)."""
+    hcg, milvus = FakeHCG(), FakeMilvus()
+    name = NameResult(label="sedan", description="", confidence=0.8)
+
+    mint_type(
+        _cluster(),
+        name,
+        hcg=hcg,
+        milvus=milvus,
+        source_cluster_id="cl1",
+        parent_type_uuid="type_vehicle_a1b2c3d4",
+        parent_ancestors=["root", "node", "entity"],
+        parent_name="vehicle",
+    )
+
+    tdef = [n for n in hcg.added_nodes if n["node_type"] == "type_definition"]
+    # Clean "vehicle" -- NOT "vehicle_a1b2c3d4".
+    assert tdef[0]["properties"]["ancestors"] == ["root", "node", "entity", "vehicle"]
+
+
 def test_same_label_mints_are_distinct_no_overwrite():
     """Two clusters Hermes names identically must not collide on uuid/centroid."""
     hcg, milvus = FakeHCG(), FakeMilvus()

--- a/tests/maintenance/test_type_minting.py
+++ b/tests/maintenance/test_type_minting.py
@@ -220,3 +220,27 @@ def test_mint_does_not_touch_member_is_a_edges():
     # Human-readable label preserved for display/lineage.
     tdef = [n for n in hcg.added_nodes if n["node_type"] == "type_definition"]
     assert tdef[0]["properties"]["name_history"][0]["name"] == "hammer"
+
+
+def test_mint_type_only_skips_member_retype_for_super_types():
+    """An internal super-type mints with retype_members=False: the type node,
+    centroid and IS_A edge are created, but no member is retyped (its members
+    belong to the leaf subtypes below it) (#505)."""
+    hcg, milvus = FakeHCG(), FakeMilvus()
+    name = NameResult(label="mathematics", description="", confidence=0.8)
+
+    type_uuid = mint_type(
+        _cluster(),
+        name,
+        hcg=hcg,
+        milvus=milvus,
+        source_cluster_id="cl",
+        retype_members=False,
+    )
+
+    # No members were retyped.
+    assert hcg.updated == []
+    # But the type node, its centroid and the taxonomy IS_A edge still exist.
+    assert any(n["uuid"] == type_uuid for n in hcg.added_nodes)
+    assert type_uuid in milvus.centroids
+    assert (type_uuid, "type_entity", "IS_A") in hcg.edges

--- a/tests/maintenance/test_type_minting.py
+++ b/tests/maintenance/test_type_minting.py
@@ -97,7 +97,7 @@ def test_mint_creates_type_node_centroid_and_retypes():
     assert len(tdef) == 1
     props = tdef[0]["properties"]
     assert props["is_type_definition"] is True
-    assert props["ancestors"] == ["root"]
+    assert props["ancestors"] == ["root", "node", "entity"]
     assert props["name_history"][0]["name"] == "concept"
     assert props["name_history"][0]["hermes_confidence"] == 0.8
 
@@ -111,6 +111,36 @@ def test_mint_creates_type_node_centroid_and_retypes():
     assert ("u2", {"type": "concept", "type_uuid": type_uuid}) in hcg.updated
     assert ("u1", type_uuid, "IS_A") in hcg.edges
     assert ("u2", type_uuid, "IS_A") in hcg.edges
+
+    # The minted type IS_A its default parent (type_entity), mirroring the
+    # seeder IS_A type-hierarchy chain so ancestors match the graph (#505).
+    assert (type_uuid, "type_entity", "IS_A") in hcg.edges
+
+
+def test_mint_under_explicit_parent_sets_lineage_and_is_a_edge():
+    """An explicit parent_type_uuid / parent_ancestors must drive both the
+    stored ancestors list and the IS_A edge to that parent (#505)."""
+    hcg, milvus = FakeHCG(), FakeMilvus()
+    name = NameResult(label="mammal", description="", confidence=0.8)
+
+    type_uuid = mint_type(
+        _cluster(),
+        name,
+        hcg=hcg,
+        milvus=milvus,
+        source_cluster_id="cl1",
+        parent_type_uuid="type_animal",
+        parent_ancestors=["root", "node", "entity"],
+    )
+
+    tdef = [n for n in hcg.added_nodes if n["node_type"] == "type_definition"]
+    assert tdef[0]["properties"]["ancestors"] == [
+        "root",
+        "node",
+        "entity",
+        "animal",
+    ]
+    assert (type_uuid, "type_animal", "IS_A") in hcg.edges
 
 
 def test_same_label_mints_are_distinct_no_overwrite():

--- a/tests/maintenance/test_type_minting.py
+++ b/tests/maintenance/test_type_minting.py
@@ -106,14 +106,18 @@ def test_mint_creates_type_node_centroid_and_retypes():
     assert centroid == [1.0, 1.0]
     assert model == "all-MiniLM-L6-v2"
 
-    # members retyped + IS_A edges to the new (unique) type uuid
+    # members retyped via the authoritative `type_uuid` property (membership is
+    # the property -- emergence no longer creates instance->type IS_A edges).
     assert ("u1", {"type": "concept", "type_uuid": type_uuid}) in hcg.updated
     assert ("u2", {"type": "concept", "type_uuid": type_uuid}) in hcg.updated
-    assert ("u1", type_uuid, "IS_A") in hcg.edges
-    assert ("u2", type_uuid, "IS_A") in hcg.edges
+    # No member->type IS_A edge is created (#505).
+    assert ("u1", type_uuid, "IS_A") not in hcg.edges
+    assert ("u2", type_uuid, "IS_A") not in hcg.edges
+    assert not any(src in {"u1", "u2"} for src, _tgt, _rel in hcg.edges)
 
     # The minted type IS_A its default parent (type_entity), mirroring the
-    # seeder IS_A type-hierarchy chain so ancestors match the graph (#505).
+    # seeder IS_A type-hierarchy chain so ancestors match the graph -- this
+    # taxonomy edge (type-definition -> parent type-definition) is KEPT (#505).
     assert (type_uuid, "type_entity", "IS_A") in hcg.edges
 
 
@@ -155,8 +159,14 @@ def test_same_label_mints_are_distinct_no_overwrite():
     assert uuid_a.startswith("type_concept_")
     assert uuid_b.startswith("type_concept_")
     assert uuid_a in milvus.centroids and uuid_b in milvus.centroids
-    assert ("u1", uuid_a, "IS_A") in hcg.edges
-    assert ("u1", uuid_b, "IS_A") in hcg.edges
+    # Members are tied to each distinct mint via their `type_uuid` property
+    # (overwritten on each retype), not via instance->type IS_A edges (#505).
+    assert ("u1", {"type": "concept", "type_uuid": uuid_a}) in hcg.updated
+    assert ("u1", {"type": "concept", "type_uuid": uuid_b}) in hcg.updated
+    # Only taxonomy IS_A edges (minted type -> parent) exist; no member edges.
+    assert (uuid_a, "type_entity", "IS_A") in hcg.edges
+    assert (uuid_b, "type_entity", "IS_A") in hcg.edges
+    assert not any(src in {"u1", "u2"} for src, _tgt, _rel in hcg.edges)
 
 
 def test_messy_label_is_slugified_into_identifiers():
@@ -177,9 +187,11 @@ def test_messy_label_is_slugified_into_identifiers():
     assert ("u2", {"type": "living_thing", "type_uuid": type_uuid}) in hcg.updated
 
 
-def test_mint_removes_stale_is_a_edge_before_adding_new():
-    """Retyping a member deletes its prior IS_A edge (a reified edge node) so
-    re-emergence on the old parent no longer re-includes it (#149 review)."""
+def test_mint_does_not_touch_member_is_a_edges():
+    """Membership is the `type_uuid` property, so mint creates NO member->type
+    IS_A edge and does NOT delete a member's prior IS_A edges. A member split
+    out of a parent is excluded from the parent at load time purely because its
+    `type_uuid` now points at the new type (#505)."""
     parent = "type_tool_parent01"
     hcg = FakeHCG(
         existing_edges={
@@ -197,10 +209,14 @@ def test_mint_removes_stale_is_a_edge_before_adding_new():
         _cluster(), name, hcg=hcg, milvus=FakeMilvus(), source_cluster_id="cl"
     )
 
-    # Stale IS_A edge nodes deleted; fresh IS_A edge points at the new type.
-    assert "e_old1" in hcg.deleted and "e_old2" in hcg.deleted
-    assert ("u1", new_uuid, "IS_A") in hcg.edges
-    assert ("u2", new_uuid, "IS_A") in hcg.edges
+    # No member IS_A edges are deleted (nothing to clean up) or created.
+    assert hcg.deleted == []
+    assert not any(src in {"u1", "u2"} for src, _tgt, _rel in hcg.edges)
+    # Membership is recorded purely via the `type_uuid` property.
+    assert ("u1", {"type": "hammer", "type_uuid": new_uuid}) in hcg.updated
+    assert ("u2", {"type": "hammer", "type_uuid": new_uuid}) in hcg.updated
+    # Only the taxonomy IS_A (new type -> parent) is created.
+    assert (new_uuid, "type_entity", "IS_A") in hcg.edges
     # Human-readable label preserved for display/lineage.
     tdef = [n for n in hcg.added_nodes if n["node_type"] == "type_definition"]
     assert tdef[0]["properties"]["name_history"][0]["name"] == "hammer"

--- a/tests/unit/ingestion/test_proposal_processor.py
+++ b/tests/unit/ingestion/test_proposal_processor.py
@@ -745,16 +745,19 @@ class TestProposalProcessor:
 
         assert len(result["stored_node_ids"]) == 3
 
-        # get_node should be called exactly once for the type_uuid during centroid flush
-        # (not 3 times -- once per node as in the old code)
+        # get_node("type_entity") is called once per node by the classifier
+        # (resolving the type's clean label) plus once by the batched centroid
+        # flush -> 3 + 1 for this 3-node proposal. The flush itself stays batched
+        # regardless: that guarantee is asserted via the single update_node call
+        # (and final member_count) below, not via the get_node count.
         type_get_calls = [
             c
             for c in mock_hcg.get_node.call_args_list
             if c.args == ("type_entity",) or c.kwargs.get("uuid") == "type_entity"
         ]
         assert (
-            len(type_get_calls) == 1
-        ), f"Expected 1 get_node call for type_entity, got {len(type_get_calls)}"
+            len(type_get_calls) == 4
+        ), f"Expected 4 get_node calls for type_entity, got {len(type_get_calls)}"
 
         # update_node for the type should be called once with the final member_count
         type_update_calls = [

--- a/tests/unit/ingestion/test_type_classifier.py
+++ b/tests/unit/ingestion/test_type_classifier.py
@@ -9,9 +9,15 @@ class TestTypeClassifier:
     """Test suite for TypeClassifier."""
 
     def _make_classifier(self, milvus=None, hcg=None):
+        if hcg is None:
+            hcg = MagicMock()
+            # Type-defs carry a clean `name`; default it to the uuid minus
+            # "type_" so existing assertions hold while still exercising the
+            # get_node lookup the classifier now performs.
+            hcg.get_node.side_effect = lambda uuid: {"name": uuid.removeprefix("type_")}
         return TypeClassifier(
             milvus=milvus or MagicMock(),
-            hcg=hcg or MagicMock(),
+            hcg=hcg,
         )
 
     def test_classify_high_confidence(self):
@@ -29,6 +35,36 @@ class TestTypeClassifier:
         assert result.type_name == "location"
         assert result.confidence > 0.8
         assert result.needs_reclassification is False
+
+    def test_classify_uses_type_def_clean_name_not_uuid(self):
+        """A minted type's hex-suffixed uuid must not leak into the name; the
+        type-definition's clean `name` is used (#505 suffixed-name fix)."""
+        mock_milvus = MagicMock()
+        mock_milvus.find_nearest_types.return_value = [
+            {"uuid": "type_organism_7ea1d37c", "score": 0.05},
+        ]
+        mock_hcg = MagicMock()
+        mock_hcg.get_node.return_value = {"name": "organism"}
+        classifier = self._make_classifier(milvus=mock_milvus, hcg=mock_hcg)
+
+        result = classifier.classify([0.1] * 384)
+
+        assert result.type_uuid == "type_organism_7ea1d37c"
+        assert result.type_name == "organism"  # NOT "organism_7ea1d37c"
+
+    def test_classify_falls_back_to_stripped_uuid_when_node_missing(self):
+        """If the type-def node can't be read, fall back to the stripped uuid."""
+        mock_milvus = MagicMock()
+        mock_milvus.find_nearest_types.return_value = [
+            {"uuid": "type_object", "score": 0.05},
+        ]
+        mock_hcg = MagicMock()
+        mock_hcg.get_node.return_value = None
+        classifier = self._make_classifier(milvus=mock_milvus, hcg=mock_hcg)
+
+        result = classifier.classify([0.1] * 384)
+
+        assert result.type_name == "object"
 
     def test_classify_low_confidence_ambiguous(self):
         """Between two centroids => low confidence, flagged."""


### PR DESCRIPTION
## Summary
Makes emergence build an actual **type hierarchy** instead of a flat layer of duplicates. Three commits:

1. `826ec3b` — mint emergent types under `entity` with lineage (`ancestors`) + taxonomy `IS_A`, and roll fine clusters up into super-types via `find_emergent_hierarchy`.
2. `8355924` — membership is the authoritative `type_uuid` property; drop redundant instance→type `IS_A` edges. `IS_A` is now **taxonomy-only** (type→parent subtype).
3. `e0d74cd` — finish the hierarchy and add match-before-mint (this PR's main fixes).

## What `e0d74cd` fixes
Two issues observed in the graph: every emergent type hung flat off `entity` (no subtypes), and the same concept was re-minted as `transportation_<hex>` duplicates.

**Nested subtypes (#505).** `EmergenceHandler.run()` now mints the whole `HierarchyNode` tree, not just the top layer — `_mint_subtree` recurses: each level is named by Hermes and minted, then its children are minted *under it*, so the `IS_A` chain and `ancestors` nest. Minting parents under the **type being subdivided** rather than a hardcoded `type_entity`, so re-emergence on a minted type deepens the tree instead of flattening. Internal super-types mint type-only (`mint_type(retype_members=False)`); members are retyped at the leaves.

**Match-before-mint (#504).** Before minting, `_match_existing_type` runs the cluster centroid through `milvus.find_nearest_types`, fetches the candidate centroid, and if cosine ≥ `type_match_threshold` reconciles the members onto the existing type (`type_uuid` property) instead of minting a duplicate. The parent being subdivided is excluded from matching.

## Config
New `MaintenanceConfig.type_match_threshold` (default `0.9`), env-overridable as `SOPHIA_MAINTENANCE_TYPE_MATCH_THRESHOLD` — tune live against observed mint/reconcile behavior (lower = more reconciling, higher = more distinct types).

## Provenance
`ancestors` is a real root→parent lineage chain (e.g. `["root","node","entity"]`), and the type→parent `IS_A` edge mirrors it in the graph — both readable by Sophia without a code consumer.

## Tests
`ruff` + `mypy` clean, **69 maintenance tests pass**. New coverage: nested minting (super-type type-only + leaves under it), reconcile into existing type (no mint, members retyped), subdividing a minted type nests under it, and `mint_type(retype_members=False)`.

Implements #505, brings #504 (match-before-mint) forward.