### PR TITLE
feat(#505/#160/#504): emergent type lineage, type-rollup, and reclassification flag

### DIFF
--- a/docs/plans/2026-06-04-reset-and-structural-correction-plan.md
+++ b/docs/plans/2026-06-04-reset-and-structural-correction-plan.md
@@ -1,0 +1,107 @@
+# Reset + Non-Linguistic Type Correction — Plan (2026-06-04)
+
+## Why we're here
+
+The live graph became too chaotic for *any* type-correction signal to bootstrap.
+Four signals were tested empirically and all failed:
+
+| signal | result |
+|---|---|
+| embedding distance | circular (it already placed the node) + noisy: `cue → innate_immune_barrier` |
+| raw structural-signature overlap | cosine 0.04–0.15, wrong: `mammal → avian_taxon` |
+| SVD/PCA latent factorization | top-128 components capture **5.7%** variance → no low-rank structure |
+| dominant (highest-IDF) edge | every node's rarest edge is a `df=1` noise one-off (`DOMINANT_UNTIL`, `HAS_UNDESCRIBED_SPECIES_OF`) |
+
+**Root cause:** the relational structure is noise *at the source* — Hermes over-extracting
+idiosyncratic one-off predicates, junk/duplicate type names, fragmented features. There is no
+signal to recover from this graph.
+
+**But the design is sound.** The non-linguistic structural corrector was validated end-to-end on
+a clean toy: `osteosarcoma` (mistyped `location`, embedding leaning `location` so distance can't
+fix it) is corrected to `disease` purely from its wiring (`PRONE_TO`/`TREATED_BY`/`AFFECTS`), and
+the ascend-to-cohesion step lands it at the right granularity. So: **reset to a clean baseline with
+the improved pipeline, then build the validated corrector.**
+
+## Phase 1 — Land outstanding PRs (in progress)
+
+- **sophia#161** — #505 lineage + #160 rollup + #504 ternary `needs_reclassification`. Membership
+  orphaning bug fixed (`type_uuid` must be `classification.type_uuid`, not name-rebuilt) + regression
+  test. Review hardening: batch chunking, tie-guard/rollup-defer clarifications.
+- **apollo#186** — explorer semantic layout. Review fix: scope the high snapshot limit to the
+  explorer (shared hook default back to 200), camera `near:1` for depth precision.
+- **hermes#116** — NER value/unit + `/name-cluster` + reasoning-model support. Review fix:
+  `reasoning_effort` default `"none"` is invalid → `"low"`, omit on `"none"`.
+- Merge once the review bots settle. Remaining red CI is **infra, not code**: the `sync-status`
+  workflow 404s on every repo; hermes `Python lint & tests` red is pre-existing flaky JEPA tests
+  (weights/env).
+
+## Phase 2 — Reset (wipe + re-ingest)
+
+1. ✅ Stash the abandoned v1 *distance* corrector so a fresh Sophia won't run it.
+2. **Stop** Hermes + Sophia (via `run_apollo.sh`). Required: the running services are pre-#160 /
+   pre-NER; the restart is the only way the improved pipeline goes live.
+3. **Wipe** Neo4j + Milvus. Order matters — stop *before* wipe to avoid the stale-Milvus-handle bug.
+4. **Start** Hermes + Sophia on the merged/branch code (improved NER, #160 rollup, ternary flag).
+5. **Re-ingest a smallish, focused corpus** (a handful of coherent topics, ~50–100 blocks) for a
+   clean, *measurable* baseline — not a huge dump. Scale up only once it looks clean.
+
+## Phase 3 — Evaluate the fresh graph
+
+Measure: relation noise (one-off junk predicates), neighbor-type quality, duplicate/junk type names,
+isolated-node %, hierarchy depth. **The bet:** the improved NER cuts the relation-noise that poisoned
+every correction signal. If relations + neighbor-types are clean enough, structural correction
+becomes viable. **Caveat:** the emergence junk-*naming* gate is still unsolved, so expect some junk
+type names regardless.
+
+## Phase 4 — Build the non-linguistic structural corrector (logos#504)
+
+Reuse the v1 scaffolding (queue, budget, batch-settle, scheduler loop, config) but replace `_decide`
+with the validated structural design. **No Hermes** — correction is Sophia's non-linguistic job.
+
+- **Detector** — `closer-to-another-centroid` (embedding) only *flags* suspects; it never decides.
+- **Corrector** — the node's type-defining `IS_A`/`INSTANCE_OF` **parent** (identity anchor) +
+  its `(relation, neighbor-type)` **structural signature** matched against per-type signature
+  profiles (reuse `structural_signature.build_signature`; include both edge directions).
+- **Confidence-gated granularity** — if the wiring is too confused for a confident fine type,
+  **ascend the `IS_A` chain** (the #160 hierarchy) to the single *sufficient* parent where it
+  coheres; precision below comes from **subtypes (depth)**, never parallel parents.
+- **Multiple parent categories = a trigger** to resolve to single sufficiency (don't arbitrate-and-drop).
+- **Homeless nodes** (no usable anchor, nowhere to ascend) — resolve **top-down**: compare to the
+  top-level super-types below `entity`/`concept`; **slot** where it fits or **seed a new type** at
+  that level. **Never dump at `entity`/`root`** (that's a regression).
+- **Representation** — raw signature overlap was fragmented on the messy graph; if the fresh graph is
+  still fragmented, build the type×`(relation,neighbor-type)` **matrix**, TF-IDF, and **factorize**
+  to latent structural embeddings (cosine in latent space). On a clean graph the direct signature
+  match may suffice — *validate first* (this is exactly what the live experiments measured).
+- **Governance** — budget-bounded per run (the governor); **confidence informs the response**
+  (whether/how precisely to act); the **curiosity budget** (spec §13.3) governs how much correction
+  Sophia does (bounded, reward-shaped). `needs_reclassification` is the work queue: `True` = needs
+  reclassifying, `False` = nowhere better (only #504 writes it), `None` = a type-cycle Hermes flagged
+  for Sophia.
+- **Validate on the fresh graph** before enabling unattended runs.
+
+## Phase 5 — Co-evolution (ongoing)
+
+Correction, rollup, and emergence tighten each other: the rollup deepens the chain to climb,
+emergence mints the level that's missing, correction places nodes into what exists. The corrector's
+effectiveness grows as the hierarchy matures.
+
+## Open risks
+
+- **Emergence junk-naming gate** is the genuinely-unsolved frontier (embedding variance doesn't
+  discriminate in 3072-dim; Hermes confidence is not trusted; retain-don't-drop means junk is kept,
+  not rejected). The structural corrector needs clean-enough neighbor-types to bite — that's the
+  reset's bet.
+- Bootstrapping on a near-flat fresh graph (ascend/homeless paths need *some* hierarchy to exist).
+
+## Reference — design memories (vault: 10-projects/LOGOS/sophia/.memory/)
+
+`reclassification-flag-semantics`, `type-correction-needs-structure-not-distance`,
+`type-correction-is-non-linguistic-sophia-job`, `correction-ascends-to-cohesion-when-confused`,
+`single-sufficient-parent-multi-is-trigger`, `correction-never-dumps-to-entity`,
+`homeless-nodes-slot-or-seed-at-top-level`, `structural-correction-needs-latent-matrix-not-raw-overlap`,
+`all-correction-signals-fail-on-current-graph`, `structural-corrector-validated-on-clean-toy`,
+`confidence-informs-queue-response`, `curiosity-budget-governs-reclamation`,
+`favorite-spot-can-be-orphan-connection`, `sophia-reclamation-north-star`,
+`never-destroy-information-flag-and-defer`, `no-reliance-on-hermes-confidence`,
+`retain-ambiguous-types-not-discard`, `type-cycle-null-is-pragmatic-handoff`.

--- a/src/sophia/api/app.py
+++ b/src/sophia/api/app.py
@@ -571,9 +571,23 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
                         len(node_uuids),
                     )
 
+                from sophia.maintenance.type_rollup_handler import (
+                    build_type_rollup_handler,
+                )
+
+                _rollup_run = build_type_rollup_handler(
+                    config=_maintenance_config,
+                    hcg=_hcg_client,
+                    milvus=_milvus_sync,
+                    event_bus=_event_bus,
+                    hermes_url=feedback_config.hermes_url,
+                    token=get_env_value("SOPHIA_API_TOKEN") or "",
+                )
+
                 _handlers = {
                     "type_emergence": _handle_type_emergence,
                     "relationship_discovery": _handle_relationship_discovery,
+                    "type_rollup": _rollup_run,
                 }
 
             if not _handlers:
@@ -1904,8 +1918,9 @@ def create_app() -> FastAPI:
         limit: int = Query(
             default=1000,
             ge=1,
-            le=10000,
-            description="Maximum number of entities/edges to return",
+            le=100000,
+            description="Maximum number of entities/edges to return. Soft cap: "
+            "with include_embeddings the payload is ~3072 floats/node.",
         ),
     ) -> HCGGraphSnapshotResponse:
         """Get a snapshot of the entire HCG graph for visualization.

--- a/src/sophia/api/app.py
+++ b/src/sophia/api/app.py
@@ -1919,8 +1919,9 @@ def create_app() -> FastAPI:
             default=1000,
             ge=1,
             le=100000,
-            description="Maximum number of entities/edges to return. Soft cap: "
-            "with include_embeddings the payload is ~3072 floats/node.",
+            description="Maximum number of entities/edges to return. This "
+            "endpoint returns node/edge metadata only (no embedding vectors), "
+            "so the payload stays modest even at the cap.",
         ),
     ) -> HCGGraphSnapshotResponse:
         """Get a snapshot of the entire HCG graph for visualization.

--- a/src/sophia/hcg_client/client.py
+++ b/src/sophia/hcg_client/client.py
@@ -881,10 +881,17 @@ class HCGClient(LogosHCGClient):
         uuid -- e.g. an edge persisted without one. :meth:`add_edge` MERGEs on
         exactly this triple, so at most one edge normally matches. Returns the
         number of edge nodes removed.
+
+        Reified edges share the ``:Node`` label with content nodes, so we keep
+        the ``relation IS NOT NULL`` discriminator used by every other
+        edge-selecting query (e.g. :meth:`query_edges_from`). It is redundant
+        while ``$relation`` is non-null but enforces the house invariant and
+        guards a future caller that might pass ``None``.
         """
         query = """
         MATCH (edge:Node)
-        WHERE edge.source = $source
+        WHERE edge.relation IS NOT NULL
+          AND edge.source = $source
           AND edge.target = $target
           AND edge.relation = $relation
         DETACH DELETE edge

--- a/src/sophia/hcg_client/client.py
+++ b/src/sophia/hcg_client/client.py
@@ -872,6 +872,31 @@ class HCGClient(LogosHCGClient):
         """
         return self.delete_node(edge_uuid)
 
+    def delete_edges_between(
+        self, source_uuid: str, target_uuid: str, relation: str
+    ) -> int:
+        """Delete every reified edge matching (source, target, relation).
+
+        A fallback for callers that must drop a specific edge but lack its
+        uuid -- e.g. an edge persisted without one. :meth:`add_edge` MERGEs on
+        exactly this triple, so at most one edge normally matches. Returns the
+        number of edge nodes removed.
+        """
+        query = """
+        MATCH (edge:Node)
+        WHERE edge.source = $source
+          AND edge.target = $target
+          AND edge.relation = $relation
+        DETACH DELETE edge
+        RETURN count(edge) AS deleted
+        """
+        records = self._execute_query(
+            query,
+            {"source": source_uuid, "target": target_uuid, "relation": relation},
+        )
+        deleted = records[0]["deleted"] if records else 0
+        return int(deleted)
+
     def clear_all(self) -> None:
         """Remove all nodes/edges from the graph."""
         self._execute_query("MATCH (n) DETACH DELETE n")

--- a/src/sophia/ingestion/proposal_processor.py
+++ b/src/sophia/ingestion/proposal_processor.py
@@ -379,9 +379,13 @@ class ProposalProcessor:
                         }
                         if classification:
                             node_props["type_confidence"] = classification.confidence
-                            node_props["needs_reclassification"] = (
-                                classification.needs_reclassification
-                            )
+                            # Ternary flag: only persist an explicit True/False.
+                            # None ("who knows") is left unset -> absent property
+                            # reads as null, the honest uncertain default.
+                            if classification.needs_reclassification is not None:
+                                node_props["needs_reclassification"] = (
+                                    classification.needs_reclassification
+                                )
 
                         # Preserve Hermes' initial NER type pick as provenance / a
                         # weak prior for emergence (#505); the authoritative `type`

--- a/src/sophia/ingestion/proposal_processor.py
+++ b/src/sophia/ingestion/proposal_processor.py
@@ -397,7 +397,18 @@ class ProposalProcessor:
                         # replaces the old instance->type IS_A edge (redundant
                         # bookkeeping over `type_uuid` that only polluted the edge
                         # graph); emergence loads members by this property (#505).
-                        type_def_uuid = f"type_{node_type}"
+                        #
+                        # Use the AUTHORITATIVE uuid from classification: emergent
+                        # types carry a hex suffix (`type_organism_a1b2c3`), so
+                        # rebuilding it from the clean name would stamp a ghost
+                        # `type_organism`, orphaning the node from its real type-def
+                        # and breaking the membership the rollup loads by. Only the
+                        # no-embedding fallback (a base type) builds it from name.
+                        type_def_uuid = (
+                            classification.type_uuid
+                            if classification
+                            else f"type_{node_type}"
+                        )
                         node_props["type_uuid"] = type_def_uuid
 
                         node_uuid = self._hcg.add_node(

--- a/src/sophia/ingestion/type_classifier.py
+++ b/src/sophia/ingestion/type_classifier.py
@@ -6,7 +6,7 @@ Sophia owns the type vocabulary — Hermes type hints are ignored.
 
 import logging
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -28,7 +28,17 @@ class TypeAssignment:
     type_uuid: str
     type_name: str
     confidence: float
-    needs_reclassification: bool
+    # Ternary work-queue flag for #504 type correction:
+    #   True  = needs reclassifying (the routine queue). First-pass placement is
+    #           provisional, so every freshly ingested node starts True.
+    #   False = nowhere better to put it right now -- #504 considered it and had
+    #           no better home. NOT "settled"; revisitable as the vocab grows.
+    #   None  = has a problem that needs fixing -- #504 hit a cycle / something
+    #           unusual it couldn't resolve, and flagged it for resolution (the
+    #           node-level cousin of an AMBIGUOUS_SUBSUMPTION cycle).
+    # First-pass classification only ever yields True; False and None are written
+    # only by #504.
+    needs_reclassification: Optional[bool]
 
 
 class TypeClassifier:
@@ -94,17 +104,19 @@ class TypeClassifier:
         else:
             confidence = 1.0 - (best_distance / MAX_DISTANCE)
 
-        # Ambiguity check: if runner-up is close, lower confidence
-        needs_reclass = False
+        # Ambiguity check: if the runner-up is close, lower confidence.
         if len(results) >= 2:
             runner_up_distance = results[1]["score"]
             gap = max(runner_up_distance - best_distance, 0.0)
             if gap < AMBIGUITY_RATIO * best_distance:
                 confidence *= 0.5
-                needs_reclass = True
 
-        if confidence < 0.5:
-            needs_reclass = True
+        # needs_reclassification (see TypeAssignment): first-pass placement is
+        # provisional, so it always flags True ("needs reclassifying") and joins
+        # the #504 correction queue. False ("nowhere better right now") and None
+        # ("a cycle / something unusual was hit -- flag for resolution") are only
+        # ever written by #504, never on first pass.
+        needs_reclass: Optional[bool] = True
 
         return TypeAssignment(
             type_uuid=best_uuid,

--- a/src/sophia/maintenance/config.py
+++ b/src/sophia/maintenance/config.py
@@ -56,6 +56,21 @@ class MaintenanceConfig(BaseSettings):
         le=1.0,
         description="Discard Hermes cluster names below this confidence.",
     )
+    rollup_enabled: bool = Field(
+        default=True,
+        description="Run the periodic type-level rollup that groups the flat "
+        "layer of emergent types into super-types (#160).",
+    )
+    rollup_interval_seconds: int = Field(
+        default=600,
+        description="How often the type_rollup pass trolls the type layer.",
+    )
+    rollup_min_cluster_size: int = Field(
+        default=2, ge=2, description="Min types in a leaf group during rollup."
+    )
+    rollup_min_supercluster_size: int = Field(
+        default=2, ge=2, description="Min child groups needed to mint a super-type."
+    )
     type_match_threshold: float = Field(
         default=0.9,
         ge=0,

--- a/src/sophia/maintenance/scheduler.py
+++ b/src/sophia/maintenance/scheduler.py
@@ -275,7 +275,10 @@ class MaintenanceScheduler:
 
         Decoupled from the per-type emergence cadence: the rollup is idempotent,
         so a plain timer is enough -- if there are new types to organise it does,
-        otherwise it is a cheap no-op.
+        otherwise it is a cheap no-op. Unlike _periodic_loop it sleeps BEFORE the
+        first pass by design: there is nothing to roll up until ingestion and
+        emergence have populated the type layer, so an immediate fire would be a
+        guaranteed no-op (greptile #161).
         """
         interval = self._config.rollup_interval_seconds
         while self._running:

--- a/src/sophia/maintenance/scheduler.py
+++ b/src/sophia/maintenance/scheduler.py
@@ -178,6 +178,8 @@ class MaintenanceScheduler:
         tasks = [asyncio.create_task(self._dispatch_loop())]
         if self._config.periodic_enabled:
             tasks.append(asyncio.create_task(self._periodic_loop()))
+        if self._config.rollup_enabled:
+            tasks.append(asyncio.create_task(self._rollup_loop()))
 
         await asyncio.gather(*tasks)
 
@@ -266,6 +268,29 @@ class MaintenanceScheduler:
             except Exception:
                 if self._running:
                     logger.exception("Error in periodic loop")
+                    await asyncio.sleep(1)
+
+    async def _rollup_loop(self) -> None:
+        """Periodically troll the type layer and enqueue a type_rollup pass (#160).
+
+        Decoupled from the per-type emergence cadence: the rollup is idempotent,
+        so a plain timer is enough -- if there are new types to organise it does,
+        otherwise it is a cheap no-op.
+        """
+        interval = self._config.rollup_interval_seconds
+        while self._running:
+            await asyncio.sleep(interval)
+            if not self._running:
+                break
+            try:
+                if "type_rollup" in self._handlers:
+                    logger.info("Type-rollup scan triggered")
+                    self._queue.enqueue(
+                        job_type="type_rollup", priority="low", params={}
+                    )
+            except Exception:
+                if self._running:
+                    logger.exception("Error in rollup loop")
                     await asyncio.sleep(1)
 
     async def _dispatch_job(self, job: MaintenanceJob) -> None:

--- a/src/sophia/maintenance/type_rollup_handler.py
+++ b/src/sophia/maintenance/type_rollup_handler.py
@@ -309,7 +309,14 @@ class TypeRollupHandler:
             if name is None or name.confidence < self._config.hermes_confidence_floor:
                 logger.info("type_rollup: skip super-type (no/low-confidence name)")
                 return
-            super_uuid = self._match_existing_type(node.centroid, parent_type_uuid)
+            # A cluster member must never be selected as the super-type of its
+            # own peers (greptile #161): that yields peer-as-parent IS_A edges
+            # and cascaded ancestor chains. Exclude the members from BOTH the
+            # centroid match and the name reconcile below.
+            member_uuids = {m.uuid for m in node.members}
+            super_uuid = self._match_existing_type(
+                node.centroid, parent_type_uuid, exclude=member_uuids
+            )
             if super_uuid is None:
                 # Name-based reconcile before minting: never create a second
                 # type-def with a name that already exists (the duplicate
@@ -317,7 +324,6 @@ class TypeRollupHandler:
                 # Hermes named identically; an exact name is a strong reconcile
                 # signal. Skip if it is the parent or a member of this very
                 # cluster (reusing those would just re-introduce a cycle).
-                member_uuids = {m.uuid for m in node.members}
                 by_name = self._uuid_by_name.get(name.label)
                 if (
                     by_name
@@ -546,35 +552,43 @@ class TypeRollupHandler:
         return None, None
 
     def _match_existing_type(
-        self, centroid: list[float], parent_type_uuid: str
+        self,
+        centroid: list[float],
+        parent_type_uuid: str,
+        exclude: frozenset[str] | set[str] = frozenset(),
     ) -> str | None:
         """Nearest existing type within the match threshold (idempotency anchor),
-        excluding the parent. Mirrors EmergenceHandler._match_existing_type."""
+        excluding the parent AND the cluster's own members. A member must never be
+        selected as the super-type of its peers: a cluster centroid is the mean of
+        its members, so its nearest type is often a member -- reconciling to it
+        would persist a peer-as-parent IS_A edge + a wrong ancestor cascade
+        (greptile #161). We therefore scan beyond the top hit so a real super-type
+        past the excluded members can still match."""
         if not centroid:
             return None
         try:
-            nearest = self._milvus.find_nearest_types(centroid, top_k=1)
+            nearest = self._milvus.find_nearest_types(centroid, top_k=10)
         except Exception:
             logger.exception("type_rollup: find_nearest_types failed")
             return None
-        if not nearest:
-            return None
-        cand = nearest[0].get("uuid")
-        if not cand or cand == parent_type_uuid:
-            return None
-        try:
-            row = self._milvus.get_embedding(node_type="TypeCentroid", uuid=cand)
-        except Exception:
-            logger.exception("type_rollup: get_embedding failed for %s", cand)
-            return None
-        if not row or not row.get("embedding"):
-            return None
-        try:
-            if _cosine(centroid, row["embedding"]) < self._config.type_match_threshold:
-                return None
-        except ValueError:
-            return None
-        return str(cand)
+        for hit in nearest or []:
+            cand = hit.get("uuid")
+            if not cand or cand == parent_type_uuid or cand in exclude:
+                continue
+            try:
+                row = self._milvus.get_embedding(node_type="TypeCentroid", uuid=cand)
+            except Exception:
+                logger.exception("type_rollup: get_embedding failed for %s", cand)
+                continue
+            emb = (row or {}).get("embedding")
+            if not emb:
+                continue
+            try:
+                if _cosine(centroid, emb) >= self._config.type_match_threshold:
+                    return str(cand)
+            except ValueError:
+                continue
+        return None
 
 
 def build_type_rollup_handler(

--- a/src/sophia/maintenance/type_rollup_handler.py
+++ b/src/sophia/maintenance/type_rollup_handler.py
@@ -206,7 +206,12 @@ class TypeRollupHandler:
             p_row = next((r for r in rows if r["uuid"] == parent), None)
             if p_row is None:
                 continue
-            # Guard against a 2-cycle (A parent-of B and B parent-of A): keep the heavier.
+            # Guard against a 2-cycle (A parent-of B and B parent-of A): keep the
+            # heavier direction. On an exact tie the strict `>` deliberately lets
+            # both through -- the second reparent then hits the structural cycle
+            # guard in _reparent_one and is recorded as AMBIGUOUS_SUBSUMPTION
+            # rather than silently dropped. Do NOT change to `>=`, which would lose
+            # that ambiguity signal (gemini #161).
             if votes.get(parent, Counter()).get(child, 0) > parent_counter.get(
                 parent, 0
             ):
@@ -221,18 +226,22 @@ class TypeRollupHandler:
         return explicit_children
 
     def _type_uuid_map(self, node_uuids: list[str]) -> dict[str, str]:
+        # Resolve in chunks: a single get_nodes_batch over every member uuid can
+        # exceed query-size/timeout limits on a large graph (gemini #161).
         out: dict[str, str] = {}
-        try:
-            nodes = self._hcg.get_nodes_batch(node_uuids) or []
-        except Exception:
-            logger.exception("type_rollup: get_nodes_batch failed")
-            return out
-        for n in nodes:
-            if not n or "uuid" not in n:
+        chunk = 500
+        for i in range(0, len(node_uuids), chunk):
+            try:
+                nodes = self._hcg.get_nodes_batch(node_uuids[i : i + chunk]) or []
+            except Exception:
+                logger.exception("type_rollup: get_nodes_batch failed")
                 continue
-            tu = n.get("type_uuid") or (n.get("properties") or {}).get("type_uuid")
-            if tu:
-                out[n["uuid"]] = tu
+            for n in nodes:
+                if not n or "uuid" not in n:
+                    continue
+                tu = n.get("type_uuid") or (n.get("properties") or {}).get("type_uuid")
+                if tu:
+                    out[n["uuid"]] = tu
         return out
 
     # ------------------------------------------------------------ tier 2

--- a/src/sophia/maintenance/type_rollup_handler.py
+++ b/src/sophia/maintenance/type_rollup_handler.py
@@ -424,14 +424,20 @@ class TypeRollupHandler:
         if cur_parent == new_parent_uuid and cur_anc == target_ancestors:
             return  # already correct -> true no-op
         # 1. swing the IS_A edge
-        if cur_parent is not None and cur_parent != new_parent_uuid and cur_edge:
+        if cur_parent is not None and cur_parent != new_parent_uuid:
             try:
-                self._hcg.delete_edge(cur_edge)
-                (
-                    self._children_of.get(cur_parent, []).remove(child_uuid)
-                    if child_uuid in self._children_of.get(cur_parent, [])
-                    else None
-                )
+                # Drop the stale parent edge by its own id when we have one;
+                # fall back to a (source, target, relation) match when the edge
+                # was persisted without an id/uuid. delete_edge(None) would
+                # silently no-op and leave the old IS_A in place, so the child
+                # would end up with two IS_A parents (greptile #161).
+                if cur_edge:
+                    self._hcg.delete_edge(cur_edge)
+                else:
+                    self._hcg.delete_edges_between(child_uuid, cur_parent, "IS_A")
+                siblings = self._children_of.get(cur_parent)
+                if siblings and child_uuid in siblings:
+                    siblings.remove(child_uuid)
             except Exception:
                 logger.exception(
                     "type_rollup: delete stale IS_A failed for %s", child_uuid

--- a/src/sophia/maintenance/type_rollup_handler.py
+++ b/src/sophia/maintenance/type_rollup_handler.py
@@ -1,0 +1,600 @@
+"""Type-level rollup: build hierarchy over the flat shelf of emergent types (#160).
+
+A slow-cadence maintenance pass. Emergence mints a wide flat layer of leaf
+type-definitions under `entity` and never revisits it, so the ontology stays
+flat. This pass groups those *types* into super-types. It RE-PARENTS existing
+type-definitions (sets `ancestors` + a single `type->parent IS_A` edge); it never
+retypes instance members.
+
+Two tiers, run in order:
+  1. **Explicit subsumption lift** -- member relations already cross type
+     boundaries with meaningful labels (`HAS_PART`/`INCLUDES`/`COMPOSED_OF` =>
+     parent->child, `PART_OF` => child->parent, `ALSO_KNOWN_AS` => synonym).
+     Aggregate them into a type-type graph and lift the directed ones into
+     type-level IS_A; alias synonyms under a canonical.
+  2. **Residual clustering** -- types with no explicit subsumption edge are
+     clustered recursively into super-types via the same `find_emergent_hierarchy`
+     used for entity emergence, but with type centroids as the points.
+
+Idempotent: `_reparent_one` change-detects and is a no-op when the type already
+has the right parent/ancestors; super-types reconcile (match-before-mint) so a
+re-run does not duplicate them. Safe to fire on a plain periodic trigger.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid as uuid_lib
+from collections import Counter, defaultdict
+from collections.abc import Callable
+from typing import Any
+
+from sophia.maintenance.config import MaintenanceConfig
+from sophia.maintenance.emergence_clustering import find_emergent_hierarchy
+from sophia.maintenance.emergence_handler import _cosine, _type_name
+from sophia.maintenance.emergence_types import EmergentCluster, Member
+
+logger = logging.getLogger(__name__)
+
+_BASE_TYPE = "entity"
+_ENTITY_ANCESTORS = ["root", "node"]
+_DEFAULT_MODEL = "all-MiniLM-L6-v2"
+
+# Member-relation labels that imply a type-level relationship.
+_PARENT_REL = {"HAS_PART", "INCLUDES", "COMPOSED_OF"}  # source-type is the PARENT
+_CHILD_REL = {"PART_OF"}  # source-type is the CHILD (invert)
+_SYNONYM_REL = {"ALSO_KNOWN_AS"}  # undirected synonymy -> alias
+_ALL_RELS = _PARENT_REL | _CHILD_REL | _SYNONYM_REL
+_BIG = 100_000
+
+
+def _is_rollup_candidate(td: dict) -> bool:
+    """A minted, non-reserved entity-side type-def eligible for rollup."""
+    name = (td.get("name") or "").strip()
+    uuid = td.get("uuid") or ""
+    if not name or not uuid.startswith("type_"):
+        return False
+    if name in (_BASE_TYPE, "node", "concept", "cognition") or name.startswith(
+        "reserved_"
+    ):
+        return False
+    props = td.get("properties") or {}
+    anc = props.get("ancestors")
+    if (
+        isinstance(anc, list) and "edge_type" in anc
+    ):  # edge-type-defs are not entity types
+        return False
+    return bool(props.get("is_type_definition"))
+
+
+class TypeRollupHandler:
+    """Groups the flat layer of emergent type-defs into super-types (#160)."""
+
+    def __init__(
+        self,
+        *,
+        config: MaintenanceConfig,
+        hcg: Any,
+        milvus: Any,
+        event_bus: Any,
+        hermes_url: str,
+        token: str,
+        name_fn: Any,
+        mint_fn: Any,
+    ) -> None:
+        self._config = config
+        self._hcg = hcg
+        self._milvus = milvus
+        self._event_bus = event_bus
+        self._hermes_url = hermes_url
+        self._token = token
+        self._name_fn = name_fn
+        self._mint_fn = mint_fn
+        # Per-pass scratch (rebuilt each run()).
+        self._children_of: dict[str, list[str]] = {}
+        self._name_of: dict[str, str] = {}
+        self._uuid_by_name: dict[str, str] = {}
+
+    # ------------------------------------------------------------------ pass
+    def run(self) -> None:
+        rows = self._load_type_layer()
+        if len(rows) < 2:
+            logger.info(
+                "type_rollup: %d candidate types, nothing to roll up", len(rows)
+            )
+            return
+        self._build_is_a_adjacency()
+        self._name_of = {r["uuid"]: r["name"] for r in rows}
+        # name -> uuid, for name-based reconcile (no duplicate-named type-defs).
+        self._uuid_by_name = {r["name"]: r["uuid"] for r in rows}
+
+        candidates = list({r["name"] for r in rows})
+        # Tier 1: explicit subsumption + synonyms.
+        explicit_children = self._tier1_explicit(rows)
+        # Tier 2: cluster only the *flat leaves* -- types still directly under
+        # `entity` (ancestor depth <= 3) that are not already a super-type (no
+        # IS_A children). Types already lifted into a hierarchy, and the
+        # super-types built by a prior pass, are left in place, so a re-run never
+        # re-clusters established structure. That is the idempotency anchor: no
+        # new layers and no duplicate super-types on repeated runs.
+        residual = [
+            r
+            for r in rows
+            if r["uuid"] not in explicit_children
+            and r.get("centroid")
+            and len(r["ancestors"]) <= 3
+            and not self._children_of.get(r["uuid"])
+        ]
+        self._tier2_residual(residual, candidates)
+
+    # ------------------------------------------------------------------ load
+    def _load_type_layer(self) -> list[dict]:
+        try:
+            type_defs = self._hcg.get_all_type_definitions()
+        except Exception:
+            logger.exception("type_rollup: failed to list type definitions")
+            return []
+        rows: list[dict] = []
+        for td in type_defs or []:
+            if not _is_rollup_candidate(td):
+                continue
+            uuid = td["uuid"]
+            props = td.get("properties") or {}
+            centroid = None
+            model = _DEFAULT_MODEL
+            try:
+                emb = self._milvus.get_embedding(node_type="TypeCentroid", uuid=uuid)
+                if emb and emb.get("embedding"):
+                    centroid = emb["embedding"]
+                    model = emb.get("embedding_model") or _DEFAULT_MODEL
+            except Exception:
+                logger.debug("type_rollup: no centroid for %s", uuid)
+            rows.append(
+                {
+                    "uuid": uuid,
+                    "name": td.get("name") or _type_name(uuid),
+                    "ancestors": list(props.get("ancestors") or _ENTITY_ANCESTORS),
+                    "centroid": centroid,
+                    "model": model,
+                }
+            )
+        return rows
+
+    # ------------------------------------------------------------ tier 1
+    def _tier1_explicit(self, rows: list[dict]) -> set[str]:
+        """Lift explicit member subsumption into type-level IS_A. Returns the set
+        of child type uuids that received an explicit parent (excluded from tier 2)."""
+        type_uuids = {r["uuid"] for r in rows}
+        # weight[(src_type, rel, tgt_type)] = count of member edges
+        weights: Counter[tuple[str, str, str]] = Counter()
+        for rel in _ALL_RELS:
+            try:
+                edges = self._hcg.list_all_edges(relation_type=rel, limit=_BIG)
+            except Exception:
+                logger.exception("type_rollup: list_all_edges(%s) failed", rel)
+                continue
+            endpoints = {e["source"] for e in edges or []} | {
+                e["target"] for e in edges or []
+            }
+            type_of = self._type_uuid_map(list(endpoints))
+            for e in edges or []:
+                st, tt = type_of.get(e["source"]), type_of.get(e["target"])
+                if not st or not tt or st == tt:
+                    continue
+                if st not in type_uuids or tt not in type_uuids:
+                    continue
+                weights[(st, rel, tt)] += 1
+
+        # Resolve a single best parent per child type.
+        # parent candidates: (child, parent, weight)
+        votes: dict[str, Counter[str]] = defaultdict(Counter)
+        for (st, rel, tt), w in weights.items():
+            if rel in _PARENT_REL:
+                votes[tt][st] += w  # tt (child) <- st (parent)
+            elif rel in _CHILD_REL:
+                votes[st][tt] += w  # st (child) <- tt (parent)
+            elif rel in _SYNONYM_REL:
+                # Alias the lexicographically-later uuid under the earlier (stable canonical).
+                child, parent = (st, tt) if st > tt else (tt, st)
+                votes[child][parent] += w
+
+        explicit_children: set[str] = set()
+        for child, parent_counter in votes.items():
+            parent, _ = parent_counter.most_common(1)[0]
+            if parent == child:
+                continue
+            p_row = next((r for r in rows if r["uuid"] == parent), None)
+            if p_row is None:
+                continue
+            # Guard against a 2-cycle (A parent-of B and B parent-of A): keep the heavier.
+            if votes.get(parent, Counter()).get(child, 0) > parent_counter.get(
+                parent, 0
+            ):
+                continue
+            self._reparent_one(child, parent, p_row["ancestors"], p_row["name"])
+            explicit_children.add(child)
+        if explicit_children:
+            logger.info(
+                "type_rollup: tier-1 lifted %d explicit subsumptions",
+                len(explicit_children),
+            )
+        return explicit_children
+
+    def _type_uuid_map(self, node_uuids: list[str]) -> dict[str, str]:
+        out: dict[str, str] = {}
+        try:
+            nodes = self._hcg.get_nodes_batch(node_uuids) or []
+        except Exception:
+            logger.exception("type_rollup: get_nodes_batch failed")
+            return out
+        for n in nodes:
+            if not n or "uuid" not in n:
+                continue
+            tu = n.get("type_uuid") or (n.get("properties") or {}).get("type_uuid")
+            if tu:
+                out[n["uuid"]] = tu
+        return out
+
+    # ------------------------------------------------------------ tier 2
+    def _tier2_residual(self, residual: list[dict], candidates: list[str]) -> None:
+        if len(residual) < self._config.rollup_min_supercluster_size:
+            logger.info(
+                "type_rollup: %d residual types, below supercluster floor",
+                len(residual),
+            )
+            return
+        members = [
+            Member(
+                uuid=r["uuid"],
+                name=r["name"],
+                embedding=r["centroid"],
+                signature=Counter(),
+                current_type="type_definition",
+                hermes_type_hint=None,
+                neighbors=[],
+                model=r["model"],
+            )
+            for r in residual
+        ]
+        hierarchy = find_emergent_hierarchy(
+            members,
+            min_cluster_size=self._config.rollup_min_cluster_size,
+            variance_threshold=0.0,  # no junk-drawer cohesion gate at the type layer
+            min_supercluster_size=self._config.rollup_min_supercluster_size,
+        )
+        if not hierarchy:
+            logger.info(
+                "type_rollup: no super-structure in %d residual types", len(residual)
+            )
+            return
+        for node in hierarchy:
+            self._reparent_subtree(
+                node, "type_entity", _ENTITY_ANCESTORS, _BASE_TYPE, candidates
+            )
+
+    def _reparent_subtree(
+        self,
+        node: Any,
+        parent_type_uuid: str,
+        parent_ancestors: list[str],
+        parent_name: str,
+        candidates: list[str],
+    ) -> None:
+        """Internal nodes => mint/reuse a super-type; leaves => re-parent the
+        existing type-defs (a leaf Member's uuid IS a type_uuid)."""
+        try:
+            if not node.children:
+                # Leaf: each member is an existing type-def; re-parent it directly.
+                for m in node.members:
+                    self._reparent_one(
+                        m.uuid, parent_type_uuid, parent_ancestors, parent_name
+                    )
+                return
+            # Internal node => a super-type over its children.
+            name = self._name_fn(
+                EmergentCluster(members=node.members),
+                candidates,
+                self._hermes_url,
+                self._token,
+            )
+            if name is None or name.confidence < self._config.hermes_confidence_floor:
+                logger.info("type_rollup: skip super-type (no/low-confidence name)")
+                return
+            super_uuid = self._match_existing_type(node.centroid, parent_type_uuid)
+            if super_uuid is None:
+                # Name-based reconcile before minting: never create a second
+                # type-def with a name that already exists (the duplicate
+                # `name`_hex problem). The centroid match can miss two clusters
+                # Hermes named identically; an exact name is a strong reconcile
+                # signal. Skip if it is the parent or a member of this very
+                # cluster (reusing those would just re-introduce a cycle).
+                member_uuids = {m.uuid for m in node.members}
+                by_name = self._uuid_by_name.get(name.label)
+                if (
+                    by_name
+                    and by_name != parent_type_uuid
+                    and by_name not in member_uuids
+                ):
+                    super_uuid = by_name
+                    logger.info(
+                        "type_rollup: reusing existing type '%s' (%s) by name "
+                        "instead of minting a duplicate",
+                        name.label,
+                        by_name,
+                    )
+            if super_uuid is None:
+                cid = uuid_lib.uuid4().hex[:8]
+                super_uuid = self._mint_fn(
+                    EmergentCluster(members=node.members),
+                    name,
+                    hcg=self._hcg,
+                    milvus=self._milvus,
+                    source_cluster_id=cid,
+                    parent_type_uuid=parent_type_uuid,
+                    parent_ancestors=parent_ancestors,
+                    parent_name=parent_name,
+                    retype_members=False,  # super-type owns no instances
+                )
+                if name.label not in candidates:
+                    candidates.append(name.label)
+                super_name = name.label
+                self._name_of[super_uuid] = super_name
+                self._uuid_by_name[super_name] = super_uuid
+                if self._event_bus is not None:
+                    try:
+                        self._event_bus.publish(
+                            "ontology.type_created",
+                            {
+                                "type_uuid": super_uuid,
+                                "name": super_name,
+                                "ancestors": list(parent_ancestors) + [parent_name],
+                            },
+                        )
+                    except Exception:
+                        logger.exception("type_rollup: event publish failed")
+                logger.info(
+                    "type_rollup: minted super-type %s over %d children",
+                    super_name,
+                    len(node.children),
+                )
+                # mint_fn wrote the super's IS_A edge to the graph; mirror it in
+                # the in-memory adjacency so the cycle guard sees it this pass.
+                self._children_of.setdefault(parent_type_uuid, [])
+                if super_uuid not in self._children_of[parent_type_uuid]:
+                    self._children_of[parent_type_uuid].append(super_uuid)
+            else:
+                super_name = (self._hcg.get_node(super_uuid) or {}).get(
+                    "name"
+                ) or _type_name(super_uuid)
+                # The super was REUSED (centroid- or name-match), not minted, so
+                # nothing has placed it under this parent. mint_fn does that for
+                # fresh supers; the reuse paths must do it explicitly or the
+                # super keeps its old position while its new children get
+                # ancestors for the intended one (divergence). Idempotent no-op
+                # when already correct; cycle-guarded if it would loop.
+                self._reparent_one(
+                    super_uuid, parent_type_uuid, parent_ancestors, parent_name
+                )
+            super_ancestors = list(parent_ancestors) + [parent_name]
+            for child in node.children:
+                self._reparent_subtree(
+                    child, super_uuid, super_ancestors, super_name, candidates
+                )
+        except Exception:
+            logger.exception("type_rollup: subtree failed, skipping")
+
+    # ----------------------------------------------------- reparent + cascade
+    def _reparent_one(
+        self,
+        child_uuid: str,
+        new_parent_uuid: str,
+        new_parent_ancestors: list[str],
+        new_parent_name: str,
+    ) -> None:
+        """Idempotent re-parent of one type-def + ancestor cascade. No-op when the
+        type already has the right parent and ancestors (the convergence anchor)."""
+        if child_uuid == new_parent_uuid:
+            return
+        if self._creates_cycle(child_uuid, new_parent_uuid):
+            # A cycle means we've claimed subsumption in both directions: the two
+            # types are too alike to order into parent/child. Don't force a
+            # (false) IS_A -- record the pair as a misunderstood, unresolved
+            # relationship so Sophia keeps the signal instead of dropping it.
+            self._record_ambiguous(child_uuid, new_parent_uuid)
+            return
+        target_ancestors = list(new_parent_ancestors) + [new_parent_name]
+        cur = self._hcg.get_node(child_uuid) or {}
+        cur_anc = list((cur.get("properties") or {}).get("ancestors") or [])
+        cur_parent, cur_edge = self._current_is_a(child_uuid)
+        if cur_parent == new_parent_uuid and cur_anc == target_ancestors:
+            return  # already correct -> true no-op
+        # 1. swing the IS_A edge
+        if cur_parent is not None and cur_parent != new_parent_uuid and cur_edge:
+            try:
+                self._hcg.delete_edge(cur_edge)
+                (
+                    self._children_of.get(cur_parent, []).remove(child_uuid)
+                    if child_uuid in self._children_of.get(cur_parent, [])
+                    else None
+                )
+            except Exception:
+                logger.exception(
+                    "type_rollup: delete stale IS_A failed for %s", child_uuid
+                )
+        if cur_parent != new_parent_uuid:
+            try:
+                self._hcg.add_edge(
+                    child_uuid, new_parent_uuid, "IS_A"
+                )  # MERGE -> idempotent
+                self._children_of.setdefault(new_parent_uuid, [])
+                if child_uuid not in self._children_of[new_parent_uuid]:
+                    self._children_of[new_parent_uuid].append(child_uuid)
+            except Exception:
+                logger.exception("type_rollup: add IS_A failed for %s", child_uuid)
+        # 2. set ancestors
+        if cur_anc != target_ancestors:
+            try:
+                self._hcg.update_node(child_uuid, {"ancestors": target_ancestors})
+            except Exception:
+                logger.exception(
+                    "type_rollup: update ancestors failed for %s", child_uuid
+                )
+        # 3. cascade to descendants
+        child_name = (
+            cur.get("name") or self._name_of.get(child_uuid) or _type_name(child_uuid)
+        )
+        self._cascade_descendants(child_uuid, target_ancestors + [child_name], set())
+
+    def _cascade_descendants(
+        self, node_uuid: str, childrens_ancestors: list[str], seen: set[str]
+    ) -> None:
+        """Top-down recompute of each descendant's ancestors. `childrens_ancestors`
+        is what a direct child of `node_uuid` must have."""
+        if node_uuid in seen:
+            return
+        seen.add(node_uuid)
+        for child in list(self._children_of.get(node_uuid, [])):
+            cn = self._hcg.get_node(child) or {}
+            cur = list((cn.get("properties") or {}).get("ancestors") or [])
+            if cur != childrens_ancestors:
+                try:
+                    self._hcg.update_node(child, {"ancestors": childrens_ancestors})
+                except Exception:
+                    logger.exception("type_rollup: cascade update failed for %s", child)
+            cname = cn.get("name") or self._name_of.get(child) or _type_name(child)
+            self._cascade_descendants(child, childrens_ancestors + [cname], seen)
+
+    # ----------------------------------------------------------- helpers
+    def _creates_cycle(self, child_uuid: str, new_parent_uuid: str) -> bool:
+        """True if ``new_parent_uuid`` already sits in ``child_uuid``'s descendant
+        subtree -- making it the parent would close an IS_A loop. Walks the live
+        ``_children_of`` adjacency with a visited guard so it terminates even if
+        the adjacency is already corrupt."""
+        stack = [child_uuid]
+        seen: set[str] = set()
+        while stack:
+            node = stack.pop()
+            if node == new_parent_uuid:
+                return True
+            if node in seen:
+                continue
+            seen.add(node)
+            stack.extend(self._children_of.get(node, []))
+        return False
+
+    def _record_ambiguous(self, a_uuid: str, b_uuid: str) -> None:
+        """Record a would-be-cyclic subsumption as an unresolved relationship.
+
+        A 2-cycle (A IS_A B *and* B IS_A A) is the rollup telling us the two
+        types are too similar to order -- a *misunderstood* relationship, not a
+        hierarchy. We persist a single bidirectional ``AMBIGUOUS_SUBSUMPTION``
+        edge (MERGEd on source/target/relation, with a canonical endpoint order
+        -> idempotent) so the signal survives for later resolution, rather than
+        silently dropping it. tier 1 ignores this relation, so it never feeds
+        back into IS_A."""
+        lo, hi = sorted((a_uuid, b_uuid))
+        try:
+            self._hcg.add_edge(
+                lo,
+                hi,
+                "AMBIGUOUS_SUBSUMPTION",
+                bidirectional=True,
+                properties={"reason": "is_a_cycle", "detected_by": "type_rollup"},
+            )
+            logger.info(
+                "type_rollup: ambiguous subsumption recorded %s <-> %s "
+                "(types too alike to order)",
+                lo,
+                hi,
+            )
+        except Exception:
+            logger.exception(
+                "type_rollup: failed to record ambiguity %s <-> %s", a_uuid, b_uuid
+            )
+
+    def _build_is_a_adjacency(self) -> None:
+        """parent_uuid -> [child_uuid], from all IS_A edges (child IS_A parent)."""
+        self._children_of = defaultdict(list)
+        try:
+            for e in self._hcg.list_all_edges(relation_type="IS_A", limit=_BIG) or []:
+                src, tgt = e.get("source"), e.get("target")
+                # Type-level hierarchy only. IS_A also carries instance taxonomy
+                # (e.g. `fish IS_A natural_resource`); walking those would let the
+                # cascade and cycle-check wander out of the type layer and report
+                # spurious cycles between unrelated types.
+                if src and tgt and src.startswith("type_") and tgt.startswith("type_"):
+                    self._children_of[tgt].append(src)
+        except Exception:
+            logger.exception("type_rollup: build IS_A adjacency failed")
+
+    def _current_is_a(self, child_uuid: str) -> tuple[str | None, str | None]:
+        try:
+            for e in self._hcg.query_edges_from(child_uuid) or []:
+                if e.get("relation") == "IS_A":
+                    return e.get("target"), (e.get("id") or e.get("uuid"))
+        except Exception:
+            logger.exception("type_rollup: query_edges_from failed for %s", child_uuid)
+        return None, None
+
+    def _match_existing_type(
+        self, centroid: list[float], parent_type_uuid: str
+    ) -> str | None:
+        """Nearest existing type within the match threshold (idempotency anchor),
+        excluding the parent. Mirrors EmergenceHandler._match_existing_type."""
+        if not centroid:
+            return None
+        try:
+            nearest = self._milvus.find_nearest_types(centroid, top_k=1)
+        except Exception:
+            logger.exception("type_rollup: find_nearest_types failed")
+            return None
+        if not nearest:
+            return None
+        cand = nearest[0].get("uuid")
+        if not cand or cand == parent_type_uuid:
+            return None
+        try:
+            row = self._milvus.get_embedding(node_type="TypeCentroid", uuid=cand)
+        except Exception:
+            logger.exception("type_rollup: get_embedding failed for %s", cand)
+            return None
+        if not row or not row.get("embedding"):
+            return None
+        try:
+            if _cosine(centroid, row["embedding"]) < self._config.type_match_threshold:
+                return None
+        except ValueError:
+            return None
+        return str(cand)
+
+
+def build_type_rollup_handler(
+    *,
+    config: MaintenanceConfig,
+    hcg: Any,
+    milvus: Any,
+    event_bus: Any,
+    hermes_url: str,
+    token: str,
+) -> Callable[[], None]:
+    """Return the callable registered as handlers['type_rollup']."""
+    from sophia.maintenance.hermes_naming import name_cluster
+    from sophia.maintenance.type_minting import mint_type
+
+    handler = TypeRollupHandler(
+        config=config,
+        hcg=hcg,
+        milvus=milvus,
+        event_bus=event_bus,
+        hermes_url=hermes_url,
+        token=token,
+        name_fn=lambda c, cand, url, tok: name_cluster(
+            c,
+            candidates=cand,
+            hermes_url=url,
+            token=tok,
+            max_members=config.max_cluster_size,
+        ),
+        mint_fn=mint_type,
+    )
+    return lambda: handler.run()

--- a/tests/ingestion/test_type_classifier_ternary.py
+++ b/tests/ingestion/test_type_classifier_ternary.py
@@ -1,0 +1,65 @@
+"""needs_reclassification is a work-queue flag for #504 type correction.
+
+First-pass classify() only ever yields True ("needs reclassifying") -- the
+placement is provisional. False ("nowhere better right now") and None ("hit a
+cycle / something unusual -> flag for resolution") are written only by #504.
+"""
+
+from __future__ import annotations
+
+from sophia.ingestion.type_classifier import MAX_DISTANCE, TypeClassifier
+
+
+class _Milvus:
+    def __init__(self, results):
+        self._results = results
+
+    def find_nearest_types(self, query_embedding, top_k):
+        return list(self._results)
+
+
+def _classify(results):
+    return TypeClassifier(milvus=_Milvus(results), hcg=None).classify([0.1, 0.2])
+
+
+def test_confident_match_still_flags_true():
+    # Even a confident placement is provisional on first pass -> True.
+    a = _classify([{"uuid": "type_dog_aa", "score": 0.2}])
+    assert a.needs_reclassification is True
+    assert a.confidence >= 0.5
+
+
+def test_low_confidence_flags_true():
+    a = _classify([{"uuid": "type_dog_aa", "score": 1.4}])
+    assert a.needs_reclassification is True
+
+
+def test_ambiguous_runner_up_flags_true():
+    a = _classify(
+        [
+            {"uuid": "type_dog_aa", "score": 0.40},
+            {"uuid": "type_wolf_bb", "score": 0.45},
+        ]
+    )
+    assert a.needs_reclassification is True
+
+
+def test_beyond_max_distance_flags_true():
+    a = _classify([{"uuid": "type_dog_aa", "score": MAX_DISTANCE + 0.5}])
+    assert a.needs_reclassification is True
+
+
+def test_no_candidates_flags_true_and_falls_back_to_entity():
+    a = _classify([])
+    assert a.needs_reclassification is True
+    assert a.type_name == "entity"
+
+
+def test_first_pass_never_writes_false_or_none():
+    # The other two ternary values are #504's to write, never first-pass.
+    for results in (
+        [{"uuid": "type_x", "score": 0.1}],
+        [{"uuid": "type_x", "score": 1.9}],
+        [],
+    ):
+        assert _classify(results).needs_reclassification is True

--- a/tests/maintenance/test_type_rollup.py
+++ b/tests/maintenance/test_type_rollup.py
@@ -60,9 +60,24 @@ class FakeHCG:
         return eid
 
     def delete_edge(self, edge_uuid):
-        self.edges = [e for e in self.edges if e["id"] != edge_uuid]
+        self.edges = [e for e in self.edges if e.get("id") != edge_uuid]
         self.writes.append(("delete_edge", edge_uuid))
         return True
+
+    def delete_edges_between(self, source, target, relation):
+        before = len(self.edges)
+        self.edges = [
+            e
+            for e in self.edges
+            if not (
+                e["source"] == source
+                and e["target"] == target
+                and e["relation"] == relation
+            )
+        ]
+        removed = before - len(self.edges)
+        self.writes.append(("delete_edges_between", source, target, relation))
+        return removed
 
     def update_node(self, uuid, properties=None):
         self.nodes.setdefault(uuid, {"uuid": uuid, "properties": {}})
@@ -709,3 +724,39 @@ def test_centroid_match_never_selects_a_cluster_member_as_its_own_super(monkeypa
             and e["relation"] == "IS_A"
             for e in hcg.edges
         )
+
+
+def test_reparent_drops_stale_is_a_even_without_edge_id():
+    """A type must never end up with two IS_A parents. When the stale edge was
+    persisted without an id/uuid, _current_is_a returns a parent but no edge
+    handle; delete_edge(None) would silently no-op. _reparent_one must fall
+    back to a (source, target, relation) delete so the old parent is removed
+    before the new IS_A is added (greptile #161)."""
+    tds = [_td("type_child_aa", "child", ["root", "node", "entity"])]
+    # Pre-existing IS_A edge to an OLD parent, persisted WITHOUT an id.
+    stale = [
+        {"source": "type_child_aa", "target": "type_oldparent_xx", "relation": "IS_A"}
+    ]
+    hcg = FakeHCG(tds, is_a=stale)
+    milvus = FakeMilvus({"type_child_aa": [1.0, 0.0]})
+    handler = _handler(hcg, milvus)
+    # Mirror what run() would build: the child sits under the old parent.
+    handler._children_of = {"type_oldparent_xx": ["type_child_aa"]}
+    handler._name_of = {"type_child_aa": "child"}
+
+    handler._reparent_one(
+        "type_child_aa", "type_newparent_bb", ["root", "node", "entity"], "newparent"
+    )
+
+    is_a_targets = [
+        e["target"]
+        for e in hcg.edges
+        if e["source"] == "type_child_aa" and e["relation"] == "IS_A"
+    ]
+    # Exactly one IS_A parent, and it is the new one (stale edge removed).
+    assert is_a_targets == ["type_newparent_bb"]
+    assert "type_oldparent_xx" not in is_a_targets
+    # The id-less stale edge was removed via the triple-delete fallback.
+    assert ("delete_edges_between", "type_child_aa", "type_oldparent_xx", "IS_A") in (
+        hcg.writes
+    )

--- a/tests/maintenance/test_type_rollup.py
+++ b/tests/maintenance/test_type_rollup.py
@@ -1,0 +1,609 @@
+"""Tests for the type-level rollup handler (sophia#160)."""
+
+from __future__ import annotations
+
+from collections import Counter
+
+from sophia.maintenance.config import MaintenanceConfig
+from sophia.maintenance.emergence_clustering import HierarchyNode
+from sophia.maintenance.emergence_types import Member, NameResult
+from sophia.maintenance.type_rollup_handler import TypeRollupHandler
+
+
+class FakeHCG:
+    """In-memory type-def graph: nodes + reified IS_A edges, recording writes."""
+
+    def __init__(self, type_defs, members=None, is_a=None, other_edges=None):
+        # type_defs: list of {uuid,name,properties{ancestors,is_type_definition}}
+        self.nodes = {td["uuid"]: td for td in type_defs}
+        for m in members or []:  # entity members carry a type_uuid
+            self.nodes[m["uuid"]] = m
+        # edges: list of {id, source, target, relation}
+        self.edges = list(is_a or []) + list(other_edges or [])
+        self._eid = 0
+        self.writes = []  # (op, *args)
+
+    def get_all_type_definitions(self):
+        return [
+            n
+            for n in self.nodes.values()
+            if (n.get("properties") or {}).get("is_type_definition")
+        ]
+
+    def get_node(self, uuid):
+        return self.nodes.get(uuid)
+
+    def get_nodes_batch(self, uuids):
+        return [self.nodes[u] for u in uuids if u in self.nodes]
+
+    def list_all_edges(self, relation_type=None, limit=1000):
+        return [
+            e
+            for e in self.edges
+            if relation_type is None or e["relation"] == relation_type
+        ]
+
+    def query_edges_from(self, uuid):
+        return [e for e in self.edges if e["source"] == uuid]
+
+    def add_edge(self, source, target, relation, **kw):
+        # MERGE semantics: dedupe on (source,target,relation)
+        for e in self.edges:
+            if (e["source"], e["target"], e["relation"]) == (source, target, relation):
+                return e["id"]
+        self._eid += 1
+        eid = f"edge{self._eid}"
+        self.edges.append(
+            {"id": eid, "source": source, "target": target, "relation": relation}
+        )
+        self.writes.append(("add_edge", source, target, relation))
+        return eid
+
+    def delete_edge(self, edge_uuid):
+        self.edges = [e for e in self.edges if e["id"] != edge_uuid]
+        self.writes.append(("delete_edge", edge_uuid))
+        return True
+
+    def update_node(self, uuid, properties=None):
+        self.nodes.setdefault(uuid, {"uuid": uuid, "properties": {}})
+        self.nodes[uuid].setdefault("properties", {}).update(properties or {})
+        self.writes.append(("update_node", uuid, dict(properties or {})))
+        return uuid
+
+
+class FakeMilvus:
+    def __init__(self, centroids):  # {uuid: vector}
+        self.centroids = dict(centroids)
+
+    def get_embedding(self, node_type, uuid):
+        v = self.centroids.get(str(uuid))
+        return {"uuid": uuid, "embedding": v, "embedding_model": "m"} if v else None
+
+    def find_nearest_types(self, query_embedding, top_k=1):
+        return []  # no pre-existing super-types -> always mint
+
+    def update_centroid(self, type_uuid, centroid, model):
+        self.centroids[type_uuid] = centroid
+
+
+def _td(uuid, name, ancestors):
+    return {
+        "uuid": uuid,
+        "name": name,
+        "properties": {"is_type_definition": True, "ancestors": ancestors},
+    }
+
+
+def _cfg():
+    return MaintenanceConfig()
+
+
+def _handler(hcg, milvus, mint_calls=None, name_label="mathematics"):
+    def name_fn(cluster, candidates, url, tok):
+        return NameResult(label=name_label, description="", confidence=0.9)
+
+    def mint_fn(
+        cluster,
+        name,
+        *,
+        hcg,
+        milvus,
+        source_cluster_id,
+        parent_type_uuid,
+        parent_ancestors,
+        parent_name,
+        retype_members,
+    ):
+        uuid = f"type_{name.label}_super01"
+        hcg.nodes[uuid] = {
+            "uuid": uuid,
+            "name": name.label,
+            "properties": {
+                "is_type_definition": True,
+                "ancestors": list(parent_ancestors) + [parent_name],
+            },
+        }
+        hcg.add_edge(uuid, parent_type_uuid, "IS_A")
+        milvus.update_centroid(uuid, cluster.embeddings[0], "m")
+        if mint_calls is not None:
+            mint_calls.append((name.label, parent_type_uuid, retype_members))
+        return uuid
+
+    return TypeRollupHandler(
+        config=_cfg(),
+        hcg=hcg,
+        milvus=milvus,
+        event_bus=None,
+        hermes_url="http://h",
+        token="t",
+        name_fn=name_fn,
+        mint_fn=mint_fn,
+    )
+
+
+def test_tier1_lifts_explicit_subsumption(monkeypatch):
+    """A HAS_PART member edge between two types lifts child under parent as IS_A."""
+    import sophia.maintenance.type_rollup_handler as tr
+
+    # two leaf types, each flat under entity; one entity member each
+    tds = [
+        _td("type_anatomy_aa", "anatomy", ["root", "node", "entity"]),
+        _td("type_insect_part_bb", "insect part", ["root", "node", "entity"]),
+    ]
+    members = [
+        {"uuid": "e1", "type_uuid": "type_anatomy_aa"},
+        {"uuid": "e2", "type_uuid": "type_insect_part_bb"},
+    ]
+    edges = [{"id": "r1", "source": "e1", "target": "e2", "relation": "HAS_PART"}]
+    hcg = FakeHCG(tds, members=members, other_edges=edges)
+    milvus = FakeMilvus(
+        {"type_anatomy_aa": [1.0, 0.0], "type_insect_part_bb": [0.0, 1.0]}
+    )
+    monkeypatch.setattr(tr, "find_emergent_hierarchy", lambda *a, **k: [])  # tier 2 off
+    _handler(hcg, milvus).run()
+    # insect part (e2's type, the TARGET of HAS_PART) is the child of anatomy (e1's type)
+    assert any(
+        e["source"] == "type_insect_part_bb"
+        and e["target"] == "type_anatomy_aa"
+        and e["relation"] == "IS_A"
+        for e in hcg.edges
+    )
+    assert hcg.nodes["type_insect_part_bb"]["properties"]["ancestors"] == [
+        "root",
+        "node",
+        "entity",
+        "anatomy",
+    ]
+
+
+def test_tier2_mints_supertype_and_reparents(monkeypatch):
+    """Residual types cluster into a super-type; leaves re-parent under it."""
+    import sophia.maintenance.type_rollup_handler as tr
+
+    tds = [
+        _td("type_calculus_aa", "calculus", ["root", "node", "entity"]),
+        _td("type_algebra_bb", "algebra", ["root", "node", "entity"]),
+    ]
+    hcg = FakeHCG(tds)
+    milvus = FakeMilvus({"type_calculus_aa": [1.0, 0.0], "type_algebra_bb": [0.9, 0.1]})
+    # mock hierarchy: one super-node over the two leaves
+    leaf = HierarchyNode(
+        members=[
+            Member(
+                "type_calculus_aa",
+                "calculus",
+                [1.0, 0.0],
+                Counter(),
+                "type_definition",
+                None,
+                [],
+                "m",
+            ),
+            Member(
+                "type_algebra_bb",
+                "algebra",
+                [0.9, 0.1],
+                Counter(),
+                "type_definition",
+                None,
+                [],
+                "m",
+            ),
+        ],
+        centroid=[0.95, 0.05],
+        children=[
+            HierarchyNode(
+                members=[
+                    Member(
+                        "type_calculus_aa",
+                        "calculus",
+                        [1.0, 0.0],
+                        Counter(),
+                        "type_definition",
+                        None,
+                        [],
+                        "m",
+                    )
+                ],
+                centroid=[1.0, 0.0],
+            ),
+            HierarchyNode(
+                members=[
+                    Member(
+                        "type_algebra_bb",
+                        "algebra",
+                        [0.9, 0.1],
+                        Counter(),
+                        "type_definition",
+                        None,
+                        [],
+                        "m",
+                    )
+                ],
+                centroid=[0.9, 0.1],
+            ),
+        ],
+    )
+    monkeypatch.setattr(tr, "find_emergent_hierarchy", lambda *a, **k: [leaf])
+    mint_calls = []
+    _handler(hcg, milvus, mint_calls=mint_calls).run()
+    # a super-type was minted (type-only) and both leaves now sit under it
+    assert mint_calls == [("mathematics", "type_entity", False)]
+    super_uuid = "type_mathematics_super01"
+    for leaf_uuid in ("type_calculus_aa", "type_algebra_bb"):
+        assert any(
+            e["source"] == leaf_uuid
+            and e["target"] == super_uuid
+            and e["relation"] == "IS_A"
+            for e in hcg.edges
+        )
+        assert hcg.nodes[leaf_uuid]["properties"]["ancestors"] == [
+            "root",
+            "node",
+            "entity",
+            "mathematics",
+        ]
+
+
+def test_rollup_is_idempotent(monkeypatch):
+    """Second run with no structural change writes nothing (the convergence anchor)."""
+    import sophia.maintenance.type_rollup_handler as tr
+
+    tds = [
+        _td("type_calculus_aa", "calculus", ["root", "node", "entity"]),
+        _td("type_algebra_bb", "algebra", ["root", "node", "entity"]),
+    ]
+    hcg = FakeHCG(tds)
+    milvus = FakeMilvus({"type_calculus_aa": [1.0, 0.0], "type_algebra_bb": [0.9, 0.1]})
+    leaf = HierarchyNode(
+        members=[
+            Member(
+                "type_calculus_aa",
+                "calculus",
+                [1.0, 0.0],
+                Counter(),
+                "type_definition",
+                None,
+                [],
+                "m",
+            ),
+            Member(
+                "type_algebra_bb",
+                "algebra",
+                [0.9, 0.1],
+                Counter(),
+                "type_definition",
+                None,
+                [],
+                "m",
+            ),
+        ],
+        centroid=[0.95, 0.05],
+        children=[
+            HierarchyNode(
+                members=[
+                    Member(
+                        "type_calculus_aa",
+                        "calculus",
+                        [1.0, 0.0],
+                        Counter(),
+                        "type_definition",
+                        None,
+                        [],
+                        "m",
+                    )
+                ],
+                centroid=[1.0, 0.0],
+            ),
+            HierarchyNode(
+                members=[
+                    Member(
+                        "type_algebra_bb",
+                        "algebra",
+                        [0.9, 0.1],
+                        Counter(),
+                        "type_definition",
+                        None,
+                        [],
+                        "m",
+                    )
+                ],
+                centroid=[0.9, 0.1],
+            ),
+        ],
+    )
+    monkeypatch.setattr(tr, "find_emergent_hierarchy", lambda *a, **k: [leaf])
+    # First run: existing super-type so no mint; FakeMilvus.find_nearest_types must return it 2nd time
+    h = _handler(hcg, milvus)
+    h.run()
+    # After run 1, make find_nearest_types return the minted super-type so run 2 reconciles (no new mint)
+    super_uuid = "type_mathematics_super01"
+    milvus.find_nearest_types = lambda q, top_k=1: [{"uuid": super_uuid, "score": 0.0}]
+    hcg.writes.clear()
+    _handler(hcg, milvus).run()  # second pass
+    # idempotent: re-parent is a no-op, only allowed write is the (idempotent) add_edge MERGE which returns existing
+    assert all(
+        op != "update_node" for op, *_ in hcg.writes
+    ), f"unexpected writes: {hcg.writes}"
+
+
+def test_cycle_is_recorded_as_ambiguous_not_minted_as_edge():
+    """A reparent that would close an IS_A cycle records AMBIGUOUS_SUBSUMPTION
+    instead of the (false) IS_A edge -- the 'misunderstood relationship' rule (#160)."""
+    # b IS_A a already exists -> b is a descendant of a.
+    tds = [
+        _td("type_a_aa", "a", ["root", "node", "entity"]),
+        _td("type_b_bb", "b", ["root", "node", "entity", "a"]),
+    ]
+    is_a = [
+        {"id": "r1", "source": "type_b_bb", "target": "type_a_aa", "relation": "IS_A"}
+    ]
+    hcg = FakeHCG(tds, is_a=is_a)
+    milvus = FakeMilvus({"type_a_aa": [1.0, 0.0], "type_b_bb": [0.9, 0.1]})
+    h = _handler(hcg, milvus)
+    h._build_is_a_adjacency()
+    # Try to make b the parent of a -> would close the 2-cycle a->b->a.
+    h._reparent_one("type_a_aa", "type_b_bb", ["root", "node", "entity"], "b")
+    # No cyclic IS_A edge a->b was created.
+    assert not any(
+        e["source"] == "type_a_aa"
+        and e["target"] == "type_b_bb"
+        and e["relation"] == "IS_A"
+        for e in hcg.edges
+    )
+    # The pair is recorded as a misunderstood/ambiguous relationship (canonical order).
+    lo, hi = sorted(("type_a_aa", "type_b_bb"))
+    assert any(
+        e["source"] == lo
+        and e["target"] == hi
+        and e["relation"] == "AMBIGUOUS_SUBSUMPTION"
+        for e in hcg.edges
+    )
+
+
+def test_adjacency_ignores_instance_taxonomy():
+    """_build_is_a_adjacency keeps only type-def<->type-def IS_A, so the cascade
+    and cycle-check never walk into instance taxonomy (#160 Fix C)."""
+    tds = [_td("type_x_aa", "x", ["root", "node", "entity"])]
+    # one type-def IS_A and one instance-taxonomy IS_A (raw uuids, no type_ prefix)
+    is_a = [
+        {
+            "id": "r1",
+            "source": "type_x_aa",
+            "target": "type_entity",
+            "relation": "IS_A",
+        },
+        {
+            "id": "r2",
+            "source": "fish_inst",
+            "target": "natural_resource_inst",
+            "relation": "IS_A",
+        },
+    ]
+    hcg = FakeHCG(tds, is_a=is_a)
+    h = _handler(hcg, FakeMilvus({}))
+    h._build_is_a_adjacency()
+    assert h._children_of.get("type_entity") == ["type_x_aa"]
+    assert "natural_resource_inst" not in h._children_of  # instance edge excluded
+
+
+def test_name_reconcile_reuses_existing_type(monkeypatch):
+    """Minting a super whose coined name already exists reuses that type-def
+    rather than minting a duplicate-named one (#160 Fix D)."""
+    import sophia.maintenance.type_rollup_handler as tr
+
+    # An existing 'mathematics' type-def plus two leaves to cluster under it.
+    tds = [
+        _td("type_mathematics_existing", "mathematics", ["root", "node", "entity"]),
+        _td("type_calculus_aa", "calculus", ["root", "node", "entity"]),
+        _td("type_algebra_bb", "algebra", ["root", "node", "entity"]),
+    ]
+    hcg = FakeHCG(tds)
+    milvus = FakeMilvus(
+        {
+            "type_mathematics_existing": [0.5, 0.5],
+            "type_calculus_aa": [1.0, 0.0],
+            "type_algebra_bb": [0.9, 0.1],
+        }
+    )
+    leaf = HierarchyNode(
+        members=[
+            Member(
+                "type_calculus_aa",
+                "calculus",
+                [1.0, 0.0],
+                Counter(),
+                "type_definition",
+                None,
+                [],
+                "m",
+            ),
+            Member(
+                "type_algebra_bb",
+                "algebra",
+                [0.9, 0.1],
+                Counter(),
+                "type_definition",
+                None,
+                [],
+                "m",
+            ),
+        ],
+        centroid=[0.95, 0.05],
+        children=[
+            HierarchyNode(
+                members=[
+                    Member(
+                        "type_calculus_aa",
+                        "calculus",
+                        [1.0, 0.0],
+                        Counter(),
+                        "type_definition",
+                        None,
+                        [],
+                        "m",
+                    )
+                ],
+                centroid=[1.0, 0.0],
+            ),
+            HierarchyNode(
+                members=[
+                    Member(
+                        "type_algebra_bb",
+                        "algebra",
+                        [0.9, 0.1],
+                        Counter(),
+                        "type_definition",
+                        None,
+                        [],
+                        "m",
+                    )
+                ],
+                centroid=[0.9, 0.1],
+            ),
+        ],
+    )
+    monkeypatch.setattr(tr, "find_emergent_hierarchy", lambda *a, **k: [leaf])
+    mint_calls = []
+    # name_fn coins 'mathematics' -> collides with the existing type-def.
+    _handler(hcg, milvus, mint_calls=mint_calls, name_label="mathematics").run()
+    # No new super minted; the existing type-def is reused as the parent.
+    assert mint_calls == []
+    for leaf_uuid in ("type_calculus_aa", "type_algebra_bb"):
+        assert any(
+            e["source"] == leaf_uuid
+            and e["target"] == "type_mathematics_existing"
+            and e["relation"] == "IS_A"
+            for e in hcg.edges
+        )
+
+
+def test_reused_super_is_reparented_to_intended_parent(monkeypatch):
+    """A super reused (by name) as a NESTED node must be re-parented to its
+    intended parent, not left at its old position (#160 review must-fix)."""
+    import sophia.maintenance.type_rollup_handler as tr
+
+    # 'geometry' exists flat under entity; it will be reused as a nested super
+    # under a freshly-minted 'mathematics'. 'trig'/'calculus' are leaves.
+    tds = [
+        _td("type_geometry_existing", "geometry", ["root", "node", "entity"]),
+        _td("type_trig_aa", "trig", ["root", "node", "entity"]),
+        _td("type_calculus_bb", "calculus", ["root", "node", "entity"]),
+    ]
+    hcg = FakeHCG(tds)
+    milvus = FakeMilvus(
+        {
+            "type_geometry_existing": [0.5, 0.5],
+            "type_trig_aa": [0.4, 0.6],
+            "type_calculus_bb": [1.0, 0.0],
+        }
+    )
+
+    def _m(uuid, name, vec):
+        return Member(uuid, name, vec, Counter(), "type_definition", None, [], "m")
+
+    trig, calc = _m("type_trig_aa", "trig", [0.4, 0.6]), _m(
+        "type_calculus_bb", "calculus", [1.0, 0.0]
+    )
+    top = HierarchyNode(
+        members=[trig, calc],
+        centroid=[0.6, 0.4],
+        children=[
+            HierarchyNode(  # internal -> will reuse 'geometry' by name
+                members=[trig],
+                centroid=[0.4, 0.6],
+                children=[HierarchyNode(members=[trig], centroid=[0.4, 0.6])],
+            ),
+            HierarchyNode(members=[calc], centroid=[1.0, 0.0]),  # leaf
+        ],
+    )
+    monkeypatch.setattr(tr, "find_emergent_hierarchy", lambda *a, **k: [top])
+
+    def name_fn(cluster, candidates, url, tok):
+        names = {m.name for m in cluster.members}
+        label = "mathematics" if "calculus" in names else "geometry"
+        return NameResult(label=label, description="", confidence=0.9)
+
+    mint_calls = []
+
+    def mint_fn(
+        cluster,
+        name,
+        *,
+        hcg,
+        milvus,
+        source_cluster_id,
+        parent_type_uuid,
+        parent_ancestors,
+        parent_name,
+        retype_members,
+    ):
+        uuid = f"type_{name.label}_super01"
+        hcg.nodes[uuid] = {
+            "uuid": uuid,
+            "name": name.label,
+            "properties": {
+                "is_type_definition": True,
+                "ancestors": list(parent_ancestors) + [parent_name],
+            },
+        }
+        hcg.add_edge(uuid, parent_type_uuid, "IS_A")
+        milvus.update_centroid(uuid, cluster.embeddings[0], "m")
+        mint_calls.append(name.label)
+        return uuid
+
+    TypeRollupHandler(
+        config=_cfg(),
+        hcg=hcg,
+        milvus=milvus,
+        event_bus=None,
+        hermes_url="http://h",
+        token="t",
+        name_fn=name_fn,
+        mint_fn=mint_fn,
+    ).run()
+
+    # only 'mathematics' minted; 'geometry' was reused, not duplicated
+    assert mint_calls == ["mathematics"]
+    math_uuid = "type_mathematics_super01"
+    # the REUSED 'geometry' is now under 'mathematics' (not still under entity)
+    assert any(
+        e["source"] == "type_geometry_existing"
+        and e["target"] == math_uuid
+        and e["relation"] == "IS_A"
+        for e in hcg.edges
+    )
+    assert hcg.nodes["type_geometry_existing"]["properties"]["ancestors"] == [
+        "root",
+        "node",
+        "entity",
+        "mathematics",
+    ]
+    # and trig sits under geometry with the full chain
+    assert hcg.nodes["type_trig_aa"]["properties"]["ancestors"] == [
+        "root",
+        "node",
+        "entity",
+        "mathematics",
+        "geometry",
+    ]

--- a/tests/maintenance/test_type_rollup.py
+++ b/tests/maintenance/test_type_rollup.py
@@ -607,3 +607,105 @@ def test_reused_super_is_reparented_to_intended_parent(monkeypatch):
         "mathematics",
         "geometry",
     ]
+
+
+def test_centroid_match_never_selects_a_cluster_member_as_its_own_super(monkeypatch):
+    """A cluster centroid is the mean of its members, so its nearest existing
+    type is frequently one of those members. Reusing a member as the cluster's
+    super-type persists a peer-as-parent IS_A edge (member-of-X IS_A
+    sibling-member-of-X) and a wrong ancestor cascade. The member-exclusion in
+    `_match_existing_type` must skip such hits and mint a fresh super instead
+    (greptile #161)."""
+    import sophia.maintenance.type_rollup_handler as tr
+
+    tds = [
+        _td("type_calculus_aa", "calculus", ["root", "node", "entity"]),
+        _td("type_algebra_bb", "algebra", ["root", "node", "entity"]),
+    ]
+    hcg = FakeHCG(tds)
+    milvus = FakeMilvus({"type_calculus_aa": [1.0, 0.0], "type_algebra_bb": [0.9, 0.1]})
+    # The cluster centroid [0.95, 0.05] is nearest to its OWN member
+    # type_calculus_aa (cosine ~0.999, well above the 0.9 match threshold).
+    # Without exclusion the handler would reuse that member as the super-type.
+    milvus.find_nearest_types = lambda q, top_k=1: [
+        {"uuid": "type_calculus_aa", "score": 0.0}
+    ]
+    leaf = HierarchyNode(
+        members=[
+            Member(
+                "type_calculus_aa",
+                "calculus",
+                [1.0, 0.0],
+                Counter(),
+                "type_definition",
+                None,
+                [],
+                "m",
+            ),
+            Member(
+                "type_algebra_bb",
+                "algebra",
+                [0.9, 0.1],
+                Counter(),
+                "type_definition",
+                None,
+                [],
+                "m",
+            ),
+        ],
+        centroid=[0.95, 0.05],
+        children=[
+            HierarchyNode(
+                members=[
+                    Member(
+                        "type_calculus_aa",
+                        "calculus",
+                        [1.0, 0.0],
+                        Counter(),
+                        "type_definition",
+                        None,
+                        [],
+                        "m",
+                    )
+                ],
+                centroid=[1.0, 0.0],
+            ),
+            HierarchyNode(
+                members=[
+                    Member(
+                        "type_algebra_bb",
+                        "algebra",
+                        [0.9, 0.1],
+                        Counter(),
+                        "type_definition",
+                        None,
+                        [],
+                        "m",
+                    )
+                ],
+                centroid=[0.9, 0.1],
+            ),
+        ],
+    )
+    monkeypatch.setattr(tr, "find_emergent_hierarchy", lambda *a, **k: [leaf])
+    mint_calls = []
+    _handler(hcg, milvus, mint_calls=mint_calls).run()
+
+    # A fresh super-type was minted (the member was NOT reused as the parent).
+    assert mint_calls == [("mathematics", "type_entity", False)]
+    super_uuid = "type_mathematics_super01"
+    # No peer-as-parent edge: a member must never become its sibling's parent.
+    assert not any(
+        e["source"] == "type_algebra_bb"
+        and e["target"] == "type_calculus_aa"
+        and e["relation"] == "IS_A"
+        for e in hcg.edges
+    )
+    # Both leaves sit under the freshly minted super-type instead.
+    for leaf_uuid in ("type_calculus_aa", "type_algebra_bb"):
+        assert any(
+            e["source"] == leaf_uuid
+            and e["target"] == super_uuid
+            and e["relation"] == "IS_A"
+            for e in hcg.edges
+        )

--- a/tests/unit/hcg_client/test_client_wrapper.py
+++ b/tests/unit/hcg_client/test_client_wrapper.py
@@ -446,3 +446,31 @@ def test_get_subgraph_fetches_nodes_and_edges(
     assert len(calls) == 2
     assert len(result["nodes"]) == 1
     assert result["nodes"][0]["uuid"] == "a"
+
+
+def test_delete_edges_between_matches_triple_and_returns_count(
+    monkeypatch: pytest.MonkeyPatch, client: HCGClient
+) -> None:
+    """delete_edges_between removes edges by (source, target, relation) -- the
+    fallback used when a stale edge has no id -- and returns the count removed."""
+    execute = MagicMock(return_value=[{"deleted": 2}])
+    monkeypatch.setattr(client, "_execute_query", execute)
+
+    removed = client.delete_edges_between("src-1", "tgt-1", "IS_A")
+
+    assert removed == 2
+    execute.assert_called_once()
+    query, params = execute.call_args[0][0], execute.call_args[0][1]
+    assert "edge.source = $source" in query
+    assert "edge.target = $target" in query
+    assert "edge.relation = $relation" in query
+    assert "DETACH DELETE edge" in query
+    assert params == {"source": "src-1", "target": "tgt-1", "relation": "IS_A"}
+
+
+def test_delete_edges_between_returns_zero_when_no_match(
+    monkeypatch: pytest.MonkeyPatch, client: HCGClient
+) -> None:
+    """No matching edge -> zero removed (empty result is handled)."""
+    monkeypatch.setattr(client, "_execute_query", MagicMock(return_value=[]))
+    assert client.delete_edges_between("src", "tgt", "IS_A") == 0

--- a/tests/unit/ingestion/test_proposal_processor.py
+++ b/tests/unit/ingestion/test_proposal_processor.py
@@ -50,6 +50,64 @@ class TestProposalProcessor:
         mock_milvus.upsert_embedding.assert_not_called()
         mock_milvus.batch_upsert_embeddings.assert_called()
 
+    def test_emergent_hex_type_stamps_authoritative_type_uuid(self):
+        """A node classified to a hex-suffixed emergent type is stamped with that
+        exact type_uuid (and the type-def is registered under it) -- not a ghost
+        uuid rebuilt from the clean name, which would orphan it from its type-def
+        and break the membership the rollup loads by (greptile #161)."""
+        from sophia.ingestion.proposal_processor import ProposalProcessor
+
+        HEX = "type_organism_a1b2c3"
+        mock_hcg = MagicMock()
+        mock_hcg.add_node.return_value = "new-uuid"
+        # the classifier resolves the clean name via get_node (post-af0ab36)
+        mock_hcg.get_node.return_value = {"uuid": HEX, "name": "organism"}
+        mock_milvus = MagicMock()
+        mock_milvus.search_similar.return_value = []
+        mock_milvus.find_nearest_types.return_value = [{"uuid": HEX, "score": 0.1}]
+
+        processor = ProposalProcessor(hcg_client=mock_hcg, milvus_sync=mock_milvus)
+        processor.process(
+            {
+                "proposal_id": "p1",
+                "proposed_nodes": [
+                    {
+                        "name": "Rex",
+                        "type": "ANIMAL",
+                        "embedding": [0.1] * 384,
+                        "embedding_id": "emb-1",
+                        "dimension": 384,
+                        "model": "all-MiniLM-L6-v2",
+                        "properties": {},
+                    }
+                ],
+                "document_embedding": {
+                    "embedding": [0.5] * 384,
+                    "embedding_id": "doc-1",
+                    "dimension": 384,
+                    "model": "all-MiniLM-L6-v2",
+                },
+                "raw_text": "Rex",
+                "source_service": "hermes",
+                "confidence": 0.7,
+                "metadata": {},
+            }
+        )
+
+        calls = mock_hcg.add_node.call_args_list
+        entity_calls = [
+            c for c in calls if c.kwargs.get("node_type") != "type_definition"
+        ]
+        td_calls = [c for c in calls if c.kwargs.get("node_type") == "type_definition"]
+        assert entity_calls, "no entity node was created"
+        assert entity_calls[0].kwargs["properties"]["type_uuid"] == HEX, (
+            "node membership must point at the authoritative hex type_uuid, "
+            f"got {entity_calls[0].kwargs['properties'].get('type_uuid')!r}"
+        )
+        assert (
+            td_calls and td_calls[0].kwargs["uuid"] == HEX
+        ), "type-def must be registered under the authoritative hex uuid (no ghost)"
+
     def test_returns_relevant_context(self):
         from sophia.ingestion.proposal_processor import ProposalProcessor
 

--- a/tests/unit/ingestion/test_type_classifier.py
+++ b/tests/unit/ingestion/test_type_classifier.py
@@ -34,7 +34,9 @@ class TestTypeClassifier:
         assert result.type_uuid == "type_location"
         assert result.type_name == "location"
         assert result.confidence > 0.8
-        assert result.needs_reclassification is False
+        # First-pass placement is provisional, so it flags True ("needs
+        # reclassifying") even when confident; #504 may later settle it to False.
+        assert result.needs_reclassification is True
 
     def test_classify_uses_type_def_clean_name_not_uuid(self):
         """A minted type's hex-suffixed uuid must not leak into the name; the
@@ -67,7 +69,12 @@ class TestTypeClassifier:
         assert result.type_name == "object"
 
     def test_classify_low_confidence_ambiguous(self):
-        """Between two centroids => low confidence, flagged."""
+        """Between two centroids => low confidence, still flags True on first pass.
+
+        Ternary semantics: first-pass placement is provisional, so it always
+        flags True ("needs reclassifying"). None ("hit a cycle / problem to fix")
+        and False ("nowhere better") are written only by #504, never first-pass.
+        """
         mock_milvus = MagicMock()
         mock_milvus.find_nearest_types.return_value = [
             {"uuid": "type_location", "score": 0.45},


### PR DESCRIPTION
Branches together the emergent-ontology maintenance work.

## #505 — emergent type lineage
Mint emergent types under `entity` with lineage + IS_A; membership is the `type_uuid` property (dropped redundant instance IS_A edges, kept taxonomy IS_A); nest subtypes under their real parent; match-before-mint reconcile; classifier uses the type-def's clean name (no hex-suffix leakage).

## #160 — periodic type-level rollup
A slow-cadence maintenance pass grouping the flat emergent shelf into super-types. Tier 1 lifts explicit member subsumption into type-level IS_A; tier 2 clusters residual flat leaves. **Cycles are recorded as `AMBIGUOUS_SUBSUMPTION`** ("misunderstood relationship"), never a false IS_A. **Idempotent** (flat-leaves-only residual; reused supers reparented; type-def-only adjacency; name-based reconcile). Validated live: depth holds across runs, 0 cycles, 0 duplicate supers. Wired into the scheduler + handler registry. Closes #160.

## #504 — ternary `needs_reclassification` (write-side contract)
`Optional[bool]`: `True` = needs reclassifying (first-pass default); `False` = nowhere better right now (written only by #504); `None` = cycle/problem flagged for resolution. Replaces the inert blanket `confidence<0.5 -> True`.

Tests: rollup handler (7) + classifier ternary (6). ruff/black/mypy clean.