### PR TITLE
feat(#504): structural type-correction + naming-time outlier omission

### DIFF
--- a/src/sophia/api/app.py
+++ b/src/sophia/api/app.py
@@ -589,9 +589,23 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
                     token=get_env_value("SOPHIA_API_TOKEN") or "",
                 )
 
+                from sophia.maintenance.type_correction_handler import (
+                    build_type_correction_handler,
+                )
+
+                # Deterministic structural correction (#504): evict a member that
+                # is a PART/PRODUCT of a same-type peer. Embedding-free, so it
+                # needs no Milvus/Hermes. Runs before type_rollup each cycle.
+                _correction_run = build_type_correction_handler(
+                    config=_maintenance_config,
+                    hcg=_hcg_client,
+                    event_bus=_event_bus,
+                )
+
                 _handlers = {
                     "type_emergence": _handle_type_emergence,
                     "relationship_discovery": _handle_relationship_discovery,
+                    "type_correction": _correction_run,
                     "type_rollup": _rollup_run,
                 }
 

--- a/src/sophia/maintenance/emergence_handler.py
+++ b/src/sophia/maintenance/emergence_handler.py
@@ -242,6 +242,30 @@ class EmergenceHandler:
                 logger.info("emergence: skip cluster (no/low-confidence name)")
                 return
 
+            # Hermes flags members that don't fit the named category (#504):
+            # outliers -- a part of another member, or a different kind -- that
+            # would force a looser name. Leave them in the base type rather than
+            # mint them in. Naming-time judgment handles self-similar part-types
+            # (a component within a component) that the structural PART_OF evictor
+            # cannot distinguish.
+            members = node.members
+            if name.removed:
+                removed_set = set(name.removed)
+                members = [m for m in node.members if m.uuid not in removed_set]
+                if not members:
+                    logger.info(
+                        "emergence: all %d members flagged as outliers; skipping",
+                        len(node.members),
+                    )
+                    return
+                if len(members) < len(node.members):
+                    logger.info(
+                        "emergence: omitting %d Hermes-flagged outlier(s) from %r",
+                        len(node.members) - len(members),
+                        name.label,
+                    )
+                    cluster = EmergentCluster(members=members)
+
             is_leaf = not node.children
             existing = self._match_existing_type(node.centroid, parent_type_uuid)
             if existing is not None:
@@ -256,10 +280,10 @@ class EmergenceHandler:
                 )
                 minted_name = existing_node.get("name") or _type_name(type_uuid)
                 if is_leaf:
-                    self._attach_members(node.members, type_uuid, existing_node)
+                    self._attach_members(members, type_uuid, existing_node)
                 logger.info(
                     "emergence: reconciled %d members into existing type %s",
-                    len(node.members),
+                    len(members),
                     type_uuid,
                 )
             else:

--- a/src/sophia/maintenance/emergence_types.py
+++ b/src/sophia/maintenance/emergence_types.py
@@ -38,8 +38,10 @@ class EmergentCluster:
 
 @dataclass
 class NameResult:
-    """Hermes' answer to 'what binds these together?' -- just a label."""
+    """Hermes' answer to 'what binds these together?' -- a label plus the
+    member uuids that don't fit it (outliers to leave in the base type, #504)."""
 
     label: str
     description: str
     confidence: float
+    removed: list[str] = field(default_factory=list)

--- a/src/sophia/maintenance/hermes_naming.py
+++ b/src/sophia/maintenance/hermes_naming.py
@@ -47,6 +47,7 @@ def name_cluster(
     payload = {
         "members": [
             {
+                "id": m.uuid,
                 "name": m.name,
                 "type": m.current_type,
                 "hermes_type_hint": m.hermes_type_hint,
@@ -66,10 +67,12 @@ def name_cluster(
         )
         resp.raise_for_status()
         data = resp.json()
+        removed = data.get("removed") or []
         return NameResult(
             label=data["label"],
             description=data.get("description", ""),
             confidence=float(data.get("confidence", 0.0)),
+            removed=[str(r) for r in removed if r],
         )
     except (httpx.HTTPError, KeyError, ValueError) as exc:
         logger.warning("name_cluster failed: %s", exc)

--- a/src/sophia/maintenance/scheduler.py
+++ b/src/sophia/maintenance/scheduler.py
@@ -286,6 +286,13 @@ class MaintenanceScheduler:
             if not self._running:
                 break
             try:
+                # Structural type correction runs first so it evicts mis-clustered
+                # part/product members before the rollup organises the type layer.
+                if "type_correction" in self._handlers:
+                    logger.info("Type-correction scan triggered")
+                    self._queue.enqueue(
+                        job_type="type_correction", priority="low", params={}
+                    )
                 if "type_rollup" in self._handlers:
                     logger.info("Type-rollup scan triggered")
                     self._queue.enqueue(

--- a/src/sophia/maintenance/type_correction_handler.py
+++ b/src/sophia/maintenance/type_correction_handler.py
@@ -1,0 +1,167 @@
+"""Structural type correction (#504): evict a member that is a PART/PRODUCT of a
+same-type peer.
+
+Deterministic and embedding-free. A cluster centroid groups a thing with its
+parts and products (embeddings encode *association*, not *taxonomy*), so a type
+can end up containing both a whole and its part -- e.g. ``tusk`` inside the
+marine-mammal type, ``acorn`` inside the oak's type. An intra-type meronymic /
+productive edge (``tusk PART_OF narwhal``, ``oak PRODUCES acorn``) is conclusive
+structural evidence that one member is a part/product of another, NOT a
+co-member. We evict the part/product back to the ``type_entity`` junk-drawer
+(its ``PART_OF``/``PRODUCES`` edge stays, so its role is still recorded) by
+writing the inverse of ``type_minting``'s retype.
+
+This redirects #504 off the falsified centroid-cohesion approach (embedding
+distance cannot separate "same kind" from "merely related") onto the proven
+structural signal. No Milvus / Hermes required.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_BIG = 100000
+
+# Node ``type`` values that are NOT emergent types (base ontology + plan
+# scaffold). Correction only fires when two members share a *non-base* type.
+_BASE_TYPES = frozenset(
+    {
+        "entity",
+        "edge",
+        "type_definition",
+        "object",
+        "action",
+        "location",
+        "state",
+        "goal",
+        "plan",
+        "reserved_state",
+        "",
+    }
+)
+
+# Relations meaning "different KIND of thing": a member linked to a same-type
+# peer by one of these is a part/product, not a co-member.
+_ANTILINK = frozenset(
+    {
+        "PART_OF",
+        "HAS_PART",
+        "ATTACHED_TO",
+        "CONTAINS",
+        "COVERS",
+        "PRODUCES",
+        "DROPS",
+        "FORMS",
+        "EMITTED_BY",
+        "DISPENSES",
+        "CARRIES",
+        "GATHERS",
+        "DELIVERED_TO",
+        "DISPENSED_INTO",
+        "HARVESTS",
+        "HAULS",
+        "DRAGS",
+        "ABSORBS",
+        "ACCUMULATES",
+        "USES",
+    }
+)
+
+# Which endpoint is the part/product to evict. For PART_OF / HAS_PART /
+# ATTACHED_TO the *source* is the part (depends on the target); for the rest
+# the *target* is the product/object.
+_EVICT_SOURCE = frozenset({"PART_OF", "ATTACHED_TO"})
+
+
+class TypeCorrectionHandler:
+    """Evict part/product members from emergent types via the existing retype."""
+
+    def __init__(self, *, config: Any, hcg: Any, event_bus: Any = None) -> None:
+        self._config = config
+        self._hcg = hcg
+        self._event_bus = event_bus
+
+    def run(self) -> None:
+        try:
+            edges = self._hcg.list_all_edges(limit=_BIG) or []
+        except Exception:
+            logger.exception("type_correction: list_all_edges failed")
+            return
+
+        anti = [
+            e
+            for e in edges
+            if e.get("relation") in _ANTILINK
+            and e.get("source")
+            and e.get("target")
+            and e.get("source") != e.get("target")
+        ]
+        if not anti:
+            return
+
+        uuids = {e["source"] for e in anti} | {e["target"] for e in anti}
+        try:
+            rows = self._hcg.get_nodes_batch(list(uuids)) or []
+        except Exception:
+            logger.exception("type_correction: get_nodes_batch failed")
+            return
+        # Membership is the node's emergent type. `type` (the slug) is set
+        # alongside `type_uuid` on every retype (type_minting), so two members
+        # of one emergent type share a non-base `type`.
+        type_of: dict[str, str] = {
+            r.get("uuid"): r.get("type") for r in rows if r.get("uuid")
+        }
+
+        evicted = 0
+        for e in anti:
+            s, t = e["source"], e["target"]
+            st = type_of.get(s)
+            # Same emergent type on both ends -> one is a part/product, not a peer.
+            if not st or st != type_of.get(t) or st in _BASE_TYPES:
+                continue
+            victim = s if e["relation"] in _EVICT_SOURCE else t
+            if self._evict(victim, st, e["relation"]):
+                evicted += 1
+                # A second anti-link edge to the same victim is now a no-op.
+                type_of[victim] = "entity"
+
+        if evicted:
+            logger.info("type_correction: evicted %d part/product member(s)", evicted)
+
+    def _evict(self, uuid: str, from_type: str, rel: str) -> bool:
+        """Retype the member back to the junk-drawer (inverse of mint_type)."""
+        try:
+            self._hcg.update_node(
+                uuid,
+                {
+                    "type": "entity",
+                    "type_uuid": "type_entity",
+                    "needs_reclassification": True,
+                },
+            )
+            logger.info(
+                "type_correction: evicted %s from %s (intra-type %s edge)",
+                uuid,
+                from_type,
+                rel,
+            )
+            return True
+        except Exception:
+            logger.exception("type_correction: evict failed for %s", uuid)
+            return False
+
+
+def build_type_correction_handler(
+    *, config: Any, hcg: Any, event_bus: Any = None
+) -> Any:
+    """Return the callable registered as ``handlers['type_correction']`` (#504).
+
+    Deterministic + embedding-free: scans for intra-type meronymic edges and
+    evicts the part/product member to ``type_entity`` via the existing
+    ``update_node`` retype. No Milvus / Hermes needed.
+    """
+    handler = TypeCorrectionHandler(config=config, hcg=hcg, event_bus=event_bus)
+    return lambda **_kw: handler.run()

--- a/tests/maintenance/test_emergence_handler.py
+++ b/tests/maintenance/test_emergence_handler.py
@@ -476,3 +476,92 @@ def test_handler_dim_mismatch_declines_match_and_mints_fresh(monkeypatch):
 
     # Dim mismatch -> match declined -> minted fresh (cluster NOT skipped).
     assert minted == ["object"]
+
+
+def test_handler_omits_hermes_flagged_outliers(monkeypatch):
+    """Members Hermes flags as outliers (#504) are left out of the minted type;
+    a cluster with no flags is minted whole."""
+    from sophia.maintenance import emergence_handler as eh
+    from sophia.maintenance.emergence_clustering import HierarchyNode
+
+    def fake_hierarchy(members, *, min_cluster_size, variance_threshold):
+        phys = [m for m in members if m.uuid.startswith("p")]
+        con = [m for m in members if m.uuid.startswith("c")]
+        return [
+            HierarchyNode(members=phys, centroid=[0.0, 0.0]),
+            HierarchyNode(members=con, centroid=[9.0, 9.0]),
+        ]
+
+    monkeypatch.setattr(eh, "find_emergent_hierarchy", fake_hierarchy)
+
+    def fake_name(cluster, candidates, hermes_url, token):
+        if cluster.members[0].uuid.startswith("p"):
+            # p0 is an outlier that doesn't fit the object category.
+            return NameResult(
+                label="object", description="", confidence=0.9, removed=["p0"]
+            )
+        return NameResult(label="concept", description="", confidence=0.9)
+
+    minted_members: dict[str, list[str]] = {}
+
+    def fake_mint(cluster, name, hcg, milvus, source_cluster_id, **kwargs):
+        minted_members[name.label] = [m.uuid for m in cluster.members]
+        return f"type_{name.label}"
+
+    handler = EmergenceHandler(
+        config=MaintenanceConfig(),
+        hcg=object(),
+        milvus=_NoMatchMilvus(),
+        event_bus=None,
+        hermes_url="http://h",
+        token="t",
+        load_members=lambda u: _members(),
+        name_fn=fake_name,
+        mint_fn=fake_mint,
+        candidates_fn=lambda: ["object", "location", "concept"],
+    )
+    handler.run(type_uuid="type_entity")
+
+    # The flagged outlier p0 is excluded; the coherent majority still mints.
+    assert "p0" not in minted_members["object"]
+    assert set(minted_members["object"]) == {"p1", "p2", "p3"}
+    # The unflagged concept cluster is minted whole.
+    assert set(minted_members["concept"]) == {"c0", "c1", "c2", "c3"}
+
+
+def test_handler_skips_when_all_members_flagged(monkeypatch):
+    """If Hermes flags every member as an outlier, the cluster mints nothing."""
+    from sophia.maintenance import emergence_handler as eh
+    from sophia.maintenance.emergence_clustering import HierarchyNode
+
+    def fake_hierarchy(members, *, min_cluster_size, variance_threshold):
+        phys = [m for m in members if m.uuid.startswith("p")]
+        return [HierarchyNode(members=phys, centroid=[0.0, 0.0])]
+
+    monkeypatch.setattr(eh, "find_emergent_hierarchy", fake_hierarchy)
+
+    minted = []
+
+    def fake_name(cluster, candidates, hermes_url, token):
+        return NameResult(
+            label="object",
+            description="",
+            confidence=0.9,
+            removed=[m.uuid for m in cluster.members],
+        )
+
+    handler = EmergenceHandler(
+        config=MaintenanceConfig(),
+        hcg=object(),
+        milvus=_NoMatchMilvus(),
+        event_bus=None,
+        hermes_url="http://h",
+        token="t",
+        load_members=lambda u: _members(),
+        name_fn=fake_name,
+        mint_fn=lambda *a, **k: minted.append(1),
+        candidates_fn=lambda: [],
+    )
+    handler.run(type_uuid="type_entity")
+
+    assert minted == []

--- a/tests/maintenance/test_hermes_naming.py
+++ b/tests/maintenance/test_hermes_naming.py
@@ -58,6 +58,25 @@ def test_name_cluster_posts_and_parses(monkeypatch):
     assert captured["headers"]["Authorization"] == "Bearer t"
     assert captured["json"]["candidates"] == ["object", "concept"]
     assert captured["json"]["members"][0]["hermes_type_hint"] == "concept"
+    # The member's uuid travels as `id` so Hermes can flag it back by id (#504).
+    assert captured["json"]["members"][0]["id"] == "u1"
+    # No outliers flagged -> empty removed list, not an error.
+    assert result.removed == []
+
+
+def test_name_cluster_parses_removed_outliers(monkeypatch):
+    """Member ids Hermes flags as outliers come back on NameResult.removed (#504)."""
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        return _FakeResp({"label": "tree", "confidence": 0.9, "removed": ["u7", "u9"]})
+
+    monkeypatch.setattr(hn.httpx, "post", fake_post)
+
+    result = hn.name_cluster(
+        _cluster(), candidates=[], hermes_url="http://h", token="t"
+    )
+    assert result is not None
+    assert result.removed == ["u7", "u9"]
 
 
 def test_name_cluster_returns_none_on_error(monkeypatch):

--- a/tests/maintenance/test_type_correction.py
+++ b/tests/maintenance/test_type_correction.py
@@ -1,0 +1,109 @@
+"""Tests for the deterministic structural type-correction handler (#504)."""
+
+from __future__ import annotations
+
+from sophia.maintenance.config import MaintenanceConfig
+from sophia.maintenance.type_correction_handler import (
+    build_type_correction_handler,
+)
+
+
+class FakeHCG:
+    """Minimal in-memory HCG: content nodes + reified edges, recording retypes."""
+
+    def __init__(self, nodes, edges):
+        # nodes: list of {uuid, type, ...}; edges: list of {id, source, target, relation}
+        self.nodes = {n["uuid"]: dict(n) for n in nodes}
+        self.edges = list(edges)
+        self.updates = []  # (uuid, props)
+
+    def list_all_edges(self, relation_type=None, limit=1000):
+        return [
+            e
+            for e in self.edges
+            if relation_type is None or e["relation"] == relation_type
+        ]
+
+    def get_nodes_batch(self, uuids):
+        return [self.nodes[u] for u in uuids if u in self.nodes]
+
+    def update_node(self, uuid, properties=None):
+        self.nodes.setdefault(uuid, {"uuid": uuid}).update(properties or {})
+        self.updates.append((uuid, dict(properties or {})))
+        return uuid
+
+
+def _run(hcg):
+    build_type_correction_handler(config=MaintenanceConfig(), hcg=hcg)()
+
+
+def test_evicts_part_from_its_same_type_whole():
+    """tusk PART_OF narwhal, both in `marine_mammal` -> tusk is evicted, narwhal stays."""
+    hcg = FakeHCG(
+        nodes=[
+            {"uuid": "narwhal", "type": "marine_mammal"},
+            {"uuid": "tusk", "type": "marine_mammal"},
+            {"uuid": "dolphin", "type": "marine_mammal"},  # peer, no anti-link edge
+        ],
+        edges=[
+            {"id": "r1", "source": "tusk", "target": "narwhal", "relation": "PART_OF"}
+        ],
+    )
+    _run(hcg)
+    # the part (source of PART_OF) returns to the junk-drawer
+    assert hcg.nodes["tusk"]["type"] == "entity"
+    assert hcg.nodes["tusk"]["type_uuid"] == "type_entity"
+    assert hcg.nodes["tusk"]["needs_reclassification"] is True
+    # the whole, and an unrelated peer, are untouched
+    assert hcg.nodes["narwhal"]["type"] == "marine_mammal"
+    assert hcg.nodes["dolphin"]["type"] == "marine_mammal"
+    assert "dolphin" not in {u for u, _ in hcg.updates}
+
+
+def test_evicts_product_target_for_production_relation():
+    """oak PRODUCES acorn, both `flora` -> the product (target) is evicted."""
+    hcg = FakeHCG(
+        nodes=[{"uuid": "oak", "type": "flora"}, {"uuid": "acorn", "type": "flora"}],
+        edges=[
+            {"id": "r1", "source": "oak", "target": "acorn", "relation": "PRODUCES"}
+        ],
+    )
+    _run(hcg)
+    assert hcg.nodes["acorn"]["type"] == "entity"  # the product leaves
+    assert hcg.nodes["oak"]["type"] == "flora"  # the producer stays
+
+
+def test_no_eviction_across_different_types():
+    """A PART_OF spanning two DIFFERENT types is not an intra-type error."""
+    hcg = FakeHCG(
+        nodes=[
+            {"uuid": "tusk", "type": "animal_part"},
+            {"uuid": "narwhal", "type": "marine_mammal"},
+        ],
+        edges=[
+            {"id": "r1", "source": "tusk", "target": "narwhal", "relation": "PART_OF"}
+        ],
+    )
+    _run(hcg)
+    assert hcg.updates == []
+    assert hcg.nodes["tusk"]["type"] == "animal_part"
+
+
+def test_no_eviction_for_base_types():
+    """Two junk-drawer entities linked by PART_OF are skipped (base type)."""
+    hcg = FakeHCG(
+        nodes=[{"uuid": "a", "type": "entity"}, {"uuid": "b", "type": "entity"}],
+        edges=[{"id": "r1", "source": "a", "target": "b", "relation": "PART_OF"}],
+    )
+    _run(hcg)
+    assert hcg.updates == []
+
+
+def test_taxonomic_isa_edge_is_not_a_correction():
+    """IS_A is taxonomy, not meronymy -> never triggers eviction."""
+    hcg = FakeHCG(
+        nodes=[{"uuid": "x", "type": "mammal"}, {"uuid": "y", "type": "mammal"}],
+        edges=[{"id": "r1", "source": "x", "target": "y", "relation": "IS_A"}],
+    )
+    _run(hcg)
+    assert hcg.updates == []


### PR DESCRIPTION
## What

Two complementary pieces of the membership-coherence work for
`c-daly/logos#504`, which targets the meronymic false-linkage failure mode:
emergent clusters bundle a whole together with its parts/products, dragging the
minted type's name to something too general.

### 1. Structural type-correction maintenance job (`41dd334`) — coarse interim

A `type_correction` handler that walks anti-link edges (PART_OF, PRODUCES,
ATTACHED_TO, …) and, when both endpoints share the same non-base type, evicts the
part/product back to `entity` with `needs_reclassification`. Wired into the
maintenance scheduler (`_rollup_loop` enqueues `type_correction` before
`type_rollup`) and registered in `app.py`. Pure structural signal — no
embeddings, no LLM.

**Known limitation (intentional, interim):** per-edge eviction can't distinguish
a self-similar part-type (a component *within* a component) from a true outlier,
so it would wrongly evict the former. That case is handled by piece 2.

### 2. Naming-time outlier omission (`389970b`) — the real fix

The consumer side of the paired Hermes change (`c-daly/hermes#117`). Sophia sends
each member's `uuid` as `id` in the `name_cluster` request and reads back
`removed` — the members Hermes judged don't fit the named category.
`EmergenceHandler` excludes those before minting/attaching, so they stay in the
`entity` junk drawer and get reconsidered next cycle. If every member is flagged,
the cluster mints nothing. Hermes's semantic judgment correctly treats same-kind
nesting as **not** a removal — the case structural eviction can't see.

## Tests

- structural: 5 tests (evict part, evict product, no cross-type, no base-type,
  IS_A-is-not-meronymy)
- naming: `id` sent, `removed` parsed, outlier excluded from mint, all-flagged
  skipped
- full `tests/maintenance/` suite: 88 pass

## Deploy note

The naming-time feature engages only once **both** this and `c-daly/hermes#117`
are deployed (live Hermes needs a restart to serve `removed[]`). The contract is
backward-compatible in both directions in the meantime.

Refs c-daly/logos#504
