### PR TITLE
fix: feedback hermes_url default port 18000 -> 17000

### DIFF
--- a/src/sophia/feedback/config.py
+++ b/src/sophia/feedback/config.py
@@ -18,8 +18,10 @@ class FeedbackConfig(BaseSettings):
         description="Redis configuration",
     )
     hermes_url: str = Field(
-        default="http://localhost:18000",
-        description="Hermes base URL",
+        default="http://localhost:17000",
+        description="Hermes base URL (Hermes listens on 17000; was 18000 — "
+        "wrong port silently broke maintenance naming via Connection refused). "
+        "Override with SOPHIA_FEEDBACK_HERMES_URL.",
     )
     worker_timeout: float = Field(
         default=10.0,


### PR DESCRIPTION
## What

`feedback/config.py` defaulted `hermes_url` to `http://localhost:18000`, but
Hermes listens on **17000** (per the ecosystem port map). The feedback loop's
calls to Hermes were hitting a dead port.

## Evidence

This was actively firing, not dormant: the running Sophia process had no
`hermes_url` override, and the log showed 1070+ `name_cluster failed: Connection
refused` entries (most recent within minutes of diagnosis). The `/name-cluster`
maintenance path shares this default, so emergence naming was failing silently
and falling back to no-mint.

## Change

- `hermes_url` default `18000` → `17000`, with an explanatory comment tying it to
  the shared port map.

A Sophia restart is required for the new default to take effect.
