### PR TITLE
feat(typing): root top-level emergent super-types under their realm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/c-daly/logos-foundry:0.7.2
+FROM ghcr.io/c-daly/logos-foundry:0.7.3
 
 # Set working directory
 WORKDIR /app/sophia

--- a/poetry.lock
+++ b/poetry.lock
@@ -863,7 +863,7 @@ i18n = ["Babel (>=2.7)"]
 
 [[package]]
 name = "logos-foundry"
-version = "0.7.2"
+version = "0.7.3"
 description = "LOGOS Foundry - Canonical source of truth for Project LOGOS specifications, ontology, and infrastructure"
 optional = false
 python-versions = "^3.12"
@@ -886,8 +886,8 @@ uvicorn = {version = "^0.32.0", extras = ["standard"]}
 [package.source]
 type = "git"
 url = "https://github.com/c-daly/logos.git"
-reference = "v0.7.2"
-resolved_reference = "7c50b3415eaf885637f2675081e417d745c35b3d"
+reference = "v0.7.3"
+resolved_reference = "df52348fc1c393c3401ecbdd98198aaaff560147"
 
 [[package]]
 name = "markupsafe"
@@ -3516,4 +3516,4 @@ otel = ["opentelemetry-api", "opentelemetry-exporter-otlp", "opentelemetry-instr
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "6336ff5914b4a4f89a0b64878ef1f028319ca32990bb14c4da4e55e3da7649ed"
+content-hash = "a1f30de884e433d242ebf124fbd8764dffa4a73c1b1a09cdaf1934f4190a2651"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ urllib3 = "^2.5.0"
 redis = ">=5.0.0"
 pydantic-settings = ">=2.0.0"
 # Also provides: logos_config, logos_test_utils, logos_tools, logos_hcg
-logos-foundry = { git = "https://github.com/c-daly/logos.git", tag = "v0.7.2" }
+logos-foundry = { git = "https://github.com/c-daly/logos.git", tag = "v0.7.3" }
 # OpenTelemetry (optional, see [tool.poetry.extras])
 opentelemetry-api = {version = "^1.20.0", optional = true}
 opentelemetry-sdk = {version = "^1.20.0", optional = true}

--- a/src/sophia/maintenance/emergence_types.py
+++ b/src/sophia/maintenance/emergence_types.py
@@ -38,10 +38,14 @@ class EmergentCluster:
 
 @dataclass
 class NameResult:
-    """Hermes' answer to 'what binds these together?' -- a label plus the
-    member uuids that don't fit it (outliers to leave in the base type, #504)."""
+    """Hermes' answer to 'what binds these together?' -- a label, the member
+    uuids that don't fit it (outliers to leave in the base type, #504), and an
+    optional graft ``parent``: when the label is newly coined, the existing type
+    to attach it under so a concept-cluster lands under ``concept`` etc.; None on
+    reuse or when no listed category is a sensible parent."""
 
     label: str
     description: str
     confidence: float
     removed: list[str] = field(default_factory=list)
+    parent: str | None = None

--- a/src/sophia/maintenance/hermes_naming.py
+++ b/src/sophia/maintenance/hermes_naming.py
@@ -68,11 +68,17 @@ def name_cluster(
         resp.raise_for_status()
         data = resp.json()
         removed = data.get("removed") or []
+        parent = data.get("parent")
         return NameResult(
             label=data["label"],
             description=data.get("description", ""),
             confidence=float(data.get("confidence", 0.0)),
             removed=[str(r) for r in removed if r],
+            parent=(
+                str(parent).strip()
+                if isinstance(parent, str) and parent.strip()
+                else None
+            ),
         )
     except (httpx.HTTPError, KeyError, ValueError) as exc:
         logger.warning("name_cluster failed: %s", exc)

--- a/src/sophia/maintenance/type_rollup_handler.py
+++ b/src/sophia/maintenance/type_rollup_handler.py
@@ -366,31 +366,26 @@ class TypeRollupHandler:
             # domain type -- instead of flat under `entity`. "Create the group as
             # close as you can to the cluster name": realm roots are the fallback,
             # not the only option. Top level only; deeper super-types keep nesting
-            # under their tree parent. Guard the rebind (mint_fn has no cycle
-            # guard): never graft under one of the cluster's own members, the
-            # coined label itself, or a type that IS_A-descends from a member (its
-            # ancestor chain contains a member name). Degrades to the default
-            # `entity` parent when nothing valid resolves.
+            # under their tree parent. Guard the rebind: never graft under one of
+            # the cluster's own members or the coined label itself. Degrades to
+            # the default `entity` parent when nothing valid resolves.
             if (
                 parent_type_uuid == f"type_{_BASE_TYPE}"
                 and name.parent
                 and name.parent.strip().lower() != name.label.strip().lower()
             ):
                 rooted = self._resolve_parent(name.parent)
-                if rooted is not None:
-                    member_names = {m.name.strip().lower() for m in node.members}
-                    parent_ancestry = {a.strip().lower() for a in rooted[1]}
-                    if (
-                        rooted[0] not in member_uuids
-                        and rooted[0] != self._uuid_by_name.get(clean_label)
-                        and not (member_names & parent_ancestry)
-                    ):
-                        parent_type_uuid, parent_ancestors, parent_name = rooted
-                        logger.info(
-                            "type_rollup: rooting super-type %r under %r",
-                            name.label,
-                            parent_name,
-                        )
+                if (
+                    rooted is not None
+                    and rooted[0] not in member_uuids
+                    and rooted[0] != self._uuid_by_name.get(clean_label)
+                ):
+                    parent_type_uuid, parent_ancestors, parent_name = rooted
+                    logger.info(
+                        "type_rollup: rooting super-type %r under %r",
+                        name.label,
+                        parent_name,
+                    )
             super_uuid = self._match_existing_type(
                 node.centroid, parent_type_uuid, exclude=member_uuids
             )
@@ -668,9 +663,9 @@ class TypeRollupHandler:
             uuid = f"type_{target}"
         else:
             # A deeper domain type Hermes named as the closest cover. Resolve it
-            # via the run's name->uuid map, which holds only entity-side rollup
-            # candidates (reserved/edge/protected types are excluded), so a hit
-            # is by construction a valid domain graft target.
+            # via the run's name->uuid map (reserved/edge/protected types are
+            # already excluded from it). Its domain-rootedness is verified below --
+            # the map alone does not guarantee a domain ancestry.
             resolved = self._uuid_by_name.get(target)
             if not resolved:
                 return None
@@ -691,6 +686,17 @@ class TypeRollupHandler:
                 ancestors = list(_ENTITY_ANCESTORS)
             else:
                 return None
+        # Invariant: the parent must live within a DOMAIN realm -- a graftable
+        # realm root itself (entity / concept / process) or a descendant of one.
+        # `_is_rollup_candidate` (the source of `_uuid_by_name`) does NOT require a
+        # domain ancestry, so a non-reserved type-def under `cognition` could
+        # otherwise resolve here. Reject anything not rooted in a domain so a
+        # domain super never grafts into the metacognitive (`cognition`) subtree
+        # or onto bare structure.
+        if target not in _GRAFTABLE_REALMS and not (
+            _GRAFTABLE_REALMS & {a.strip().lower() for a in ancestors}
+        ):
+            return None
         return uuid, ancestors, node.get("name") or target
 
     def _match_existing_type(

--- a/src/sophia/maintenance/type_rollup_handler.py
+++ b/src/sophia/maintenance/type_rollup_handler.py
@@ -45,6 +45,13 @@ _DEFAULT_MODEL = "all-MiniLM-L6-v2"
 # roots. `cognition` is intentionally excluded: it is populated by metacognitive
 # schema induction, not by domain type rollup.
 _REALM_ROOTS = ("concept", "process")
+# Seeded roots a super-type MAY be grafted under as the *fallback* when no closer
+# domain type covers the cluster (siblings of `entity` under `node`). `cognition`
+# is excluded -- it is populated by metacognitive schema induction, not domain
+# rollup -- and the pure structural roots `root`/`node` are never domain parents.
+# A super normally roots under the closest covering domain type Hermes names; a
+# realm root is only the top-of-chain fallback.
+_GRAFTABLE_REALMS = frozenset({"entity", "concept", "process"})
 # Seeded structural roots that must NEVER be minted as a super, matched/reused as
 # a super, or reparented -- they are the fixed top of the ontology. Guards the
 # rollup against corrupting them (review blocker + duplicate-root path).
@@ -354,30 +361,36 @@ class TypeRollupHandler:
                         candidates,
                     )
                 return
-            # Root a TOP-LEVEL super-type under the realm Hermes named (concept /
-            # process) instead of flat under `entity` -- this is how the entity
-            # shelf reaches the other roots. Top level only; deeper super-types
-            # keep nesting under their tree parent. Guard the rebind: never graft
-            # under one of the cluster's own members or under the coined label
-            # itself (mint_fn has no cycle guard). Degrades to the default parent
-            # when the suggestion does not resolve.
+            # Root a TOP-LEVEL super-type under the CLOSEST covering type Hermes
+            # named -- a realm root (concept / process) OR a deeper existing
+            # domain type -- instead of flat under `entity`. "Create the group as
+            # close as you can to the cluster name": realm roots are the fallback,
+            # not the only option. Top level only; deeper super-types keep nesting
+            # under their tree parent. Guard the rebind (mint_fn has no cycle
+            # guard): never graft under one of the cluster's own members, the
+            # coined label itself, or a type that IS_A-descends from a member (its
+            # ancestor chain contains a member name). Degrades to the default
+            # `entity` parent when nothing valid resolves.
             if (
                 parent_type_uuid == f"type_{_BASE_TYPE}"
                 and name.parent
                 and name.parent.strip().lower() != name.label.strip().lower()
             ):
                 rooted = self._resolve_parent(name.parent)
-                if (
-                    rooted is not None
-                    and rooted[0] not in member_uuids
-                    and rooted[0] != self._uuid_by_name.get(clean_label)
-                ):
-                    parent_type_uuid, parent_ancestors, parent_name = rooted
-                    logger.info(
-                        "type_rollup: rooting super-type %r under realm %r",
-                        name.label,
-                        parent_name,
-                    )
+                if rooted is not None:
+                    member_names = {m.name.strip().lower() for m in node.members}
+                    parent_ancestry = {a.strip().lower() for a in rooted[1]}
+                    if (
+                        rooted[0] not in member_uuids
+                        and rooted[0] != self._uuid_by_name.get(clean_label)
+                        and not (member_names & parent_ancestry)
+                    ):
+                        parent_type_uuid, parent_ancestors, parent_name = rooted
+                        logger.info(
+                            "type_rollup: rooting super-type %r under %r",
+                            name.label,
+                            parent_name,
+                        )
             super_uuid = self._match_existing_type(
                 node.centroid, parent_type_uuid, exclude=member_uuids
             )
@@ -630,28 +643,38 @@ class TypeRollupHandler:
         return None, None
 
     def _resolve_parent(self, parent_name: str) -> tuple[str, list[str], str] | None:
-        """Resolve a Hermes-suggested realm parent *name* (concept / process) to
-        ``(type_uuid, ancestors, clean_name)`` for rooting a top-level
-        super-type. Resolves to the realm root's canonical ``type_<name>`` uuid.
-        Returns None when nothing resolves, so an invalid suggestion degrades to
-        the default `entity` parent rather than a dangling root."""
+        """Resolve a Hermes-named graft parent to ``(type_uuid, ancestors, name)``.
+        The parent is the CLOSEST covering type Hermes named -- a realm root OR a
+        deeper existing domain type-def -- so a super-type roots as near the
+        cluster as possible ("create the group as close as you can to the cluster
+        name") instead of flat under `entity`. Realm roots are the top-of-chain
+        fallback, not the only allowed parents.
+
+        Returns None for an unresolvable name or a forbidden target, so the caller
+        degrades to the default `entity` parent. Forbidden: `cognition` (reserved
+        for metacognitive schema induction) and the pure structural roots
+        `root`/`node`. The caller adds the cycle guards (member / self / IS_A
+        descendant)."""
         target = (parent_name or "").strip().lower()
         if not target:
             return None
-        # Closed-world: only the realm roots (concept / process) are valid graft
-        # parents for a top-level super. Reject anything else -- `cognition` is
-        # reserved for metacognitive schema induction, and an arbitrary domain
-        # type must never become a graft target (review: wrong-realm / cycle).
-        if target not in _REALM_ROOTS:
-            return None
-        # Resolve to the realm root's CANONICAL uuid directly, never via
-        # _uuid_by_name. That map is keyed by lowercased name, so a case-variant
-        # domain type-def (display name "Concept") could own the "concept" key
-        # and be returned here as a foreign graft parent. The seeded root is
-        # always `type_<name>` and is filtered out of the rollup candidates, so
-        # consulting the map could only ever mis-resolve to a shadow (adversarial
-        # review of gemini@648: validate the resolved uuid, not just the name).
-        uuid = f"type_{target}"
+        if target in _PROTECTED_ROOT_NAMES:
+            # A seeded root: only the graftable realms (entity / concept /
+            # process) are valid; `cognition` and the structural roots are not.
+            # Resolve to the CANONICAL `type_<name>` uuid so a case-variant domain
+            # type-def cannot shadow the realm key (the run map is lowercased).
+            if target not in _GRAFTABLE_REALMS:
+                return None
+            uuid = f"type_{target}"
+        else:
+            # A deeper domain type Hermes named as the closest cover. Resolve it
+            # via the run's name->uuid map, which holds only entity-side rollup
+            # candidates (reserved/edge/protected types are excluded), so a hit
+            # is by construction a valid domain graft target.
+            resolved = self._uuid_by_name.get(target)
+            if not resolved:
+                return None
+            uuid = resolved
         try:
             node = self._hcg.get_node(uuid)
         except Exception:

--- a/src/sophia/maintenance/type_rollup_handler.py
+++ b/src/sophia/maintenance/type_rollup_handler.py
@@ -632,8 +632,7 @@ class TypeRollupHandler:
     def _resolve_parent(self, parent_name: str) -> tuple[str, list[str], str] | None:
         """Resolve a Hermes-suggested realm parent *name* (concept / process) to
         ``(type_uuid, ancestors, clean_name)`` for rooting a top-level
-        super-type. Minted types live in the per-run name->uuid map; the seeded
-        realm roots do not, so fall back to their canonical ``type_<name>`` uuid.
+        super-type. Resolves to the realm root's canonical ``type_<name>`` uuid.
         Returns None when nothing resolves, so an invalid suggestion degrades to
         the default `entity` parent rather than a dangling root."""
         target = (parent_name or "").strip().lower()
@@ -645,7 +644,14 @@ class TypeRollupHandler:
         # type must never become a graft target (review: wrong-realm / cycle).
         if target not in _REALM_ROOTS:
             return None
-        uuid = self._uuid_by_name.get(target) or f"type_{target}"
+        # Resolve to the realm root's CANONICAL uuid directly, never via
+        # _uuid_by_name. That map is keyed by lowercased name, so a case-variant
+        # domain type-def (display name "Concept") could own the "concept" key
+        # and be returned here as a foreign graft parent. The seeded root is
+        # always `type_<name>` and is filtered out of the rollup candidates, so
+        # consulting the map could only ever mis-resolve to a shadow (adversarial
+        # review of gemini@648: validate the resolved uuid, not just the name).
+        uuid = f"type_{target}"
         try:
             node = self._hcg.get_node(uuid)
         except Exception:

--- a/src/sophia/maintenance/type_rollup_handler.py
+++ b/src/sophia/maintenance/type_rollup_handler.py
@@ -328,11 +328,15 @@ class TypeRollupHandler:
             # and cascaded ancestor chains. Exclude the members from BOTH the
             # centroid match and the name reconcile below.
             member_uuids = {m.uuid for m in node.members}
+            # Hermes labels come from an LLM; normalize before any name/uuid
+            # comparison so a capitalized label (e.g. "Concept") cannot bypass the
+            # protected-root / self-graft guards below (review).
+            clean_label = name.label.strip().lower()
             # Never use a seeded structural root as a super-type *name*: minting
             # would duplicate the root, and reusing it would reparent it. If
             # Hermes labelled the cluster after a root, skip this super level and
             # attach the children directly under the current parent.
-            if f"type_{name.label}" in _PROTECTED_ROOT_UUIDS:
+            if f"type_{clean_label}" in _PROTECTED_ROOT_UUIDS:
                 logger.info(
                     "type_rollup: cluster named after root %r -- skipping super level",
                     name.label,
@@ -362,7 +366,7 @@ class TypeRollupHandler:
                 if (
                     rooted is not None
                     and rooted[0] not in member_uuids
-                    and rooted[0] != self._uuid_by_name.get(name.label)
+                    and rooted[0] != self._uuid_by_name.get(clean_label)
                 ):
                     parent_type_uuid, parent_ancestors, parent_name = rooted
                     logger.info(
@@ -629,6 +633,12 @@ class TypeRollupHandler:
         the default `entity` parent rather than a dangling root."""
         target = (parent_name or "").strip().lower()
         if not target:
+            return None
+        # Closed-world: only the realm roots (concept / process) are valid graft
+        # parents for a top-level super. Reject anything else -- `cognition` is
+        # reserved for metacognitive schema induction, and an arbitrary domain
+        # type must never become a graft target (review: wrong-realm / cycle).
+        if target not in _REALM_ROOTS:
             return None
         uuid = self._uuid_by_name.get(target) or f"type_{target}"
         try:

--- a/src/sophia/maintenance/type_rollup_handler.py
+++ b/src/sophia/maintenance/type_rollup_handler.py
@@ -117,7 +117,11 @@ class TypeRollupHandler:
         self._build_is_a_adjacency()
         self._name_of = {r["uuid"]: r["name"] for r in rows}
         # name -> uuid, for name-based reconcile (no duplicate-named type-defs).
-        self._uuid_by_name = {r["name"]: r["uuid"] for r in rows}
+        # Keyed case-insensitively (lowercased): Hermes labels are normalized to
+        # lower case, so a stored type-def with legacy/mixed casing must still
+        # match a coined label and never bypass the reuse / protected-root guards
+        # (review #165: case-insensitive lookup on the name->uuid map).
+        self._uuid_by_name = {r["name"].strip().lower(): r["uuid"] for r in rows}
 
         # Include the realm roots so Hermes can name one as a super-type's
         # parent: the rollup is the single authority that roots types under
@@ -391,7 +395,7 @@ class TypeRollupHandler:
                 # Hermes named identically; an exact name is a strong reconcile
                 # signal. Skip if it is the parent or a member of this very
                 # cluster (reusing those would just re-introduce a cycle).
-                by_name = self._uuid_by_name.get(name.label)
+                by_name = self._uuid_by_name.get(clean_label)
                 if (
                     by_name
                     and by_name != parent_type_uuid
@@ -421,7 +425,8 @@ class TypeRollupHandler:
                     candidates.append(name.label)
                 super_name = name.label
                 self._name_of[super_uuid] = super_name
-                self._uuid_by_name[super_name] = super_uuid
+                # Preserve the case-insensitive invariant of the name->uuid map.
+                self._uuid_by_name[super_name.strip().lower()] = super_uuid
                 if self._event_bus is not None:
                     try:
                         self._event_bus.publish(

--- a/src/sophia/maintenance/type_rollup_handler.py
+++ b/src/sophia/maintenance/type_rollup_handler.py
@@ -39,6 +39,19 @@ logger = logging.getLogger(__name__)
 _BASE_TYPE = "entity"
 _ENTITY_ANCESTORS = ["root", "node"]
 _DEFAULT_MODEL = "all-MiniLM-L6-v2"
+# Domain realm roots a TOP-LEVEL super-type may be grafted under (besides the
+# `entity` junk-drawer). Sent as naming candidates so Hermes can name one as a
+# super-type's parent -- this is how the flat `entity` shelf reaches the other
+# roots. `cognition` is intentionally excluded: it is populated by metacognitive
+# schema induction, not by domain type rollup.
+_REALM_ROOTS = ("concept", "process")
+# Seeded structural roots that must NEVER be minted as a super, matched/reused as
+# a super, or reparented -- they are the fixed top of the ontology. Guards the
+# rollup against corrupting them (review blocker + duplicate-root path).
+_PROTECTED_ROOT_NAMES = frozenset(
+    {"root", "node", "entity", "concept", "cognition", "process"}
+)
+_PROTECTED_ROOT_UUIDS = frozenset(f"type_{n}" for n in _PROTECTED_ROOT_NAMES)
 
 # Member-relation labels that imply a type-level relationship.
 _PARENT_REL = {"HAS_PART", "INCLUDES", "COMPOSED_OF"}  # source-type is the PARENT
@@ -54,9 +67,7 @@ def _is_rollup_candidate(td: dict) -> bool:
     uuid = td.get("uuid") or ""
     if not name or not uuid.startswith("type_"):
         return False
-    if name in (_BASE_TYPE, "node", "concept", "cognition") or name.startswith(
-        "reserved_"
-    ):
+    if name in _PROTECTED_ROOT_NAMES or name.startswith("reserved_"):
         return False
     props = td.get("properties") or {}
     anc = props.get("ancestors")
@@ -108,7 +119,10 @@ class TypeRollupHandler:
         # name -> uuid, for name-based reconcile (no duplicate-named type-defs).
         self._uuid_by_name = {r["name"]: r["uuid"] for r in rows}
 
-        candidates = list({r["name"] for r in rows})
+        # Include the realm roots so Hermes can name one as a super-type's
+        # parent: the rollup is the single authority that roots types under
+        # concept/process (emergence stays flat-under-entity).
+        candidates = list({r["name"] for r in rows} | set(_REALM_ROOTS))
         # Tier 1: explicit subsumption + synonyms.
         explicit_children = self._tier1_explicit(rows)
         # Tier 2: cluster only the *flat leaves* -- types still directly under
@@ -314,9 +328,58 @@ class TypeRollupHandler:
             # and cascaded ancestor chains. Exclude the members from BOTH the
             # centroid match and the name reconcile below.
             member_uuids = {m.uuid for m in node.members}
+            # Never use a seeded structural root as a super-type *name*: minting
+            # would duplicate the root, and reusing it would reparent it. If
+            # Hermes labelled the cluster after a root, skip this super level and
+            # attach the children directly under the current parent.
+            if f"type_{name.label}" in _PROTECTED_ROOT_UUIDS:
+                logger.info(
+                    "type_rollup: cluster named after root %r -- skipping super level",
+                    name.label,
+                )
+                for child in node.children:
+                    self._reparent_subtree(
+                        child,
+                        parent_type_uuid,
+                        parent_ancestors,
+                        parent_name,
+                        candidates,
+                    )
+                return
+            # Root a TOP-LEVEL super-type under the realm Hermes named (concept /
+            # process) instead of flat under `entity` -- this is how the entity
+            # shelf reaches the other roots. Top level only; deeper super-types
+            # keep nesting under their tree parent. Guard the rebind: never graft
+            # under one of the cluster's own members or under the coined label
+            # itself (mint_fn has no cycle guard). Degrades to the default parent
+            # when the suggestion does not resolve.
+            if (
+                parent_type_uuid == f"type_{_BASE_TYPE}"
+                and name.parent
+                and name.parent.strip().lower() != name.label.strip().lower()
+            ):
+                rooted = self._resolve_parent(name.parent)
+                if (
+                    rooted is not None
+                    and rooted[0] not in member_uuids
+                    and rooted[0] != self._uuid_by_name.get(name.label)
+                ):
+                    parent_type_uuid, parent_ancestors, parent_name = rooted
+                    logger.info(
+                        "type_rollup: rooting super-type %r under realm %r",
+                        name.label,
+                        parent_name,
+                    )
             super_uuid = self._match_existing_type(
                 node.centroid, parent_type_uuid, exclude=member_uuids
             )
+            # Never reuse a seeded structural root as a domain super-type: a root
+            # is not a cluster member, so exclude=members does not catch it, and
+            # the reuse branch's _reparent_one would then move the root into the
+            # domain tree (no cycle, so the cycle guard cannot stop it). Treat a
+            # realm-root hit as no-match -> mint a fresh super instead (blocker).
+            if super_uuid in _PROTECTED_ROOT_UUIDS:
+                super_uuid = None
             if super_uuid is None:
                 # Name-based reconcile before minting: never create a second
                 # type-def with a name that already exists (the duplicate
@@ -556,6 +619,35 @@ class TypeRollupHandler:
         except Exception:
             logger.exception("type_rollup: query_edges_from failed for %s", child_uuid)
         return None, None
+
+    def _resolve_parent(self, parent_name: str) -> tuple[str, list[str], str] | None:
+        """Resolve a Hermes-suggested realm parent *name* (concept / process) to
+        ``(type_uuid, ancestors, clean_name)`` for rooting a top-level
+        super-type. Minted types live in the per-run name->uuid map; the seeded
+        realm roots do not, so fall back to their canonical ``type_<name>`` uuid.
+        Returns None when nothing resolves, so an invalid suggestion degrades to
+        the default `entity` parent rather than a dangling root."""
+        target = (parent_name or "").strip().lower()
+        if not target:
+            return None
+        uuid = self._uuid_by_name.get(target) or f"type_{target}"
+        try:
+            node = self._hcg.get_node(uuid)
+        except Exception:
+            logger.exception("type_rollup: _resolve_parent(%s) failed", parent_name)
+            return None
+        if not node:
+            return None
+        ancestors = list((node.get("properties") or {}).get("ancestors") or [])
+        if not ancestors:
+            # A seeded realm root's canonical ancestors are [root, node]; for
+            # anything else with no chain, fail closed (degrade to the default
+            # parent) rather than fabricate a truncated chain (review).
+            if uuid in _PROTECTED_ROOT_UUIDS:
+                ancestors = list(_ENTITY_ANCESTORS)
+            else:
+                return None
+        return uuid, ancestors, node.get("name") or target
 
     def _match_existing_type(
         self,

--- a/tests/maintenance/test_type_rollup.py
+++ b/tests/maintenance/test_type_rollup.py
@@ -971,3 +971,58 @@ def test_resolve_parent_only_accepts_realm_roots():
     # Empty / missing suggestions degrade to the default parent.
     assert handler._resolve_parent("") is None
     assert handler._resolve_parent(None) is None
+
+
+def test_name_reconcile_is_case_insensitive(monkeypatch):
+    """`_uuid_by_name` is keyed case-insensitively: a stored type-def named with
+    different casing ("Mathematics") must still be reused when Hermes coins the
+    lowercase label ("mathematics"), instead of minting a case-variant duplicate
+    (review #165 gemini@365: case-insensitive lookup on the name->uuid map)."""
+    import sophia.maintenance.type_rollup_handler as tr
+
+    tds = [
+        _td("type_mathematics_existing", "Mathematics", ["root", "node", "entity"]),
+        _td("type_calculus_aa", "calculus", ["root", "node", "entity"]),
+        _td("type_algebra_bb", "algebra", ["root", "node", "entity"]),
+    ]
+    hcg = FakeHCG(tds)
+    milvus = FakeMilvus(
+        {
+            "type_mathematics_existing": [0.5, 0.5],
+            "type_calculus_aa": [1.0, 0.0],
+            "type_algebra_bb": [0.9, 0.1],
+        }
+    )
+
+    def _m(uuid, name, vec):
+        return Member(uuid, name, vec, Counter(), "type_definition", None, [], "m")
+
+    leaf = HierarchyNode(
+        members=[
+            _m("type_calculus_aa", "calculus", [1.0, 0.0]),
+            _m("type_algebra_bb", "algebra", [0.9, 0.1]),
+        ],
+        centroid=[0.95, 0.05],
+        children=[
+            HierarchyNode(
+                members=[_m("type_calculus_aa", "calculus", [1.0, 0.0])],
+                centroid=[1.0, 0.0],
+            ),
+            HierarchyNode(
+                members=[_m("type_algebra_bb", "algebra", [0.9, 0.1])],
+                centroid=[0.9, 0.1],
+            ),
+        ],
+    )
+    monkeypatch.setattr(tr, "find_emergent_hierarchy", lambda *a, **k: [leaf])
+    mint_calls: list = []
+    # Hermes coins lowercase 'mathematics'; the stored 'Mathematics' is reused.
+    _handler(hcg, milvus, mint_calls=mint_calls, name_label="mathematics").run()
+    assert mint_calls == []  # no case-variant duplicate minted
+    for leaf_uuid in ("type_calculus_aa", "type_algebra_bb"):
+        assert any(
+            e["source"] == leaf_uuid
+            and e["target"] == "type_mathematics_existing"
+            and e["relation"] == "IS_A"
+            for e in hcg.edges
+        )

--- a/tests/maintenance/test_type_rollup.py
+++ b/tests/maintenance/test_type_rollup.py
@@ -760,3 +760,171 @@ def test_reparent_drops_stale_is_a_even_without_edge_id():
     assert ("delete_edges_between", "type_child_aa", "type_oldparent_xx", "IS_A") in (
         hcg.writes
     )
+
+
+def test_top_level_super_grafts_under_realm_root(monkeypatch):
+    """B (concept/process population): when Hermes names a ``parent`` for a
+    TOP-LEVEL super-type, the rollup roots it under that realm root (here
+    ``concept``) instead of flat under ``entity``, and the realm chain flows
+    down to the leaves. The rollup is the single hierarchy authority (#160)."""
+    import sophia.maintenance.type_rollup_handler as tr
+
+    tds = [
+        _td("type_concept", "concept", ["root", "node"]),  # seeded realm root
+        _td("type_calculus_aa", "calculus", ["root", "node", "entity"]),
+        _td("type_algebra_bb", "algebra", ["root", "node", "entity"]),
+    ]
+    hcg = FakeHCG(tds)
+    milvus = FakeMilvus({"type_calculus_aa": [1.0, 0.0], "type_algebra_bb": [0.9, 0.1]})
+
+    def _m(uuid, name, vec):
+        return Member(uuid, name, vec, Counter(), "type_definition", None, [], "m")
+
+    leaf = HierarchyNode(
+        members=[
+            _m("type_calculus_aa", "calculus", [1.0, 0.0]),
+            _m("type_algebra_bb", "algebra", [0.9, 0.1]),
+        ],
+        centroid=[0.95, 0.05],
+        children=[
+            HierarchyNode(
+                members=[_m("type_calculus_aa", "calculus", [1.0, 0.0])],
+                centroid=[1.0, 0.0],
+            ),
+            HierarchyNode(
+                members=[_m("type_algebra_bb", "algebra", [0.9, 0.1])],
+                centroid=[0.9, 0.1],
+            ),
+        ],
+    )
+    monkeypatch.setattr(tr, "find_emergent_hierarchy", lambda *a, **k: [leaf])
+
+    mint_calls: list = []
+
+    def name_fn(cluster, candidates, url, tok):
+        # `concept` must be offered as a candidate so Hermes can graft under it.
+        assert "concept" in candidates
+        return NameResult(
+            label="mathematics", description="", confidence=0.9, parent="concept"
+        )
+
+    def mint_fn(
+        cluster,
+        name,
+        *,
+        hcg,
+        milvus,
+        source_cluster_id,
+        parent_type_uuid,
+        parent_ancestors,
+        parent_name,
+        retype_members,
+    ):
+        uuid = f"type_{name.label}_super01"
+        hcg.nodes[uuid] = {
+            "uuid": uuid,
+            "name": name.label,
+            "properties": {
+                "is_type_definition": True,
+                "ancestors": list(parent_ancestors) + [parent_name],
+            },
+        }
+        hcg.add_edge(uuid, parent_type_uuid, "IS_A")
+        milvus.update_centroid(uuid, cluster.embeddings[0], "m")
+        mint_calls.append((name.label, parent_type_uuid, retype_members))
+        return uuid
+
+    TypeRollupHandler(
+        config=_cfg(),
+        hcg=hcg,
+        milvus=milvus,
+        event_bus=None,
+        hermes_url="http://h",
+        token="t",
+        name_fn=name_fn,
+        mint_fn=mint_fn,
+    ).run()
+
+    # The super-type was rooted under `concept`, not `entity`.
+    assert mint_calls == [("mathematics", "type_concept", False)]
+    super_uuid = "type_mathematics_super01"
+    assert any(
+        e["source"] == super_uuid
+        and e["target"] == "type_concept"
+        and e["relation"] == "IS_A"
+        for e in hcg.edges
+    )
+    assert hcg.nodes[super_uuid]["properties"]["ancestors"] == [
+        "root",
+        "node",
+        "concept",
+    ]
+    # The realm chain flows down to the leaves.
+    for leaf_uuid in ("type_calculus_aa", "type_algebra_bb"):
+        assert hcg.nodes[leaf_uuid]["properties"]["ancestors"] == [
+            "root",
+            "node",
+            "concept",
+            "mathematics",
+        ]
+
+
+def test_centroid_match_never_reparents_a_seeded_realm_root(monkeypatch):
+    """Blocker (review): the reuse path must never move a seeded structural root.
+    A domain super-cluster whose centroid is nearest the seeded `concept`
+    centroid must MINT a fresh super, not reuse type_concept (which _reparent_one
+    would then move under the domain tree -- no cycle, so the cycle guard cannot
+    stop it). Realm roots are not cluster members, so exclude=members can't catch
+    this; the _PROTECTED_ROOT_UUIDS guard must."""
+    import sophia.maintenance.type_rollup_handler as tr
+
+    tds = [
+        _td("type_concept", "concept", ["root", "node"]),  # seeded root w/ centroid
+        _td("type_calculus_aa", "calculus", ["root", "node", "entity"]),
+        _td("type_algebra_bb", "algebra", ["root", "node", "entity"]),
+    ]
+    hcg = FakeHCG(tds)
+    milvus = FakeMilvus(
+        {
+            "type_concept": [0.95, 0.05],
+            "type_calculus_aa": [1.0, 0.0],
+            "type_algebra_bb": [0.9, 0.1],
+        }
+    )
+    # The cluster centroid is nearest the seeded concept centroid.
+    milvus.find_nearest_types = lambda q, top_k=1: [
+        {"uuid": "type_concept", "score": 0.0}
+    ]
+
+    def _m(uuid, name, vec):
+        return Member(uuid, name, vec, Counter(), "type_definition", None, [], "m")
+
+    leaf = HierarchyNode(
+        members=[
+            _m("type_calculus_aa", "calculus", [1.0, 0.0]),
+            _m("type_algebra_bb", "algebra", [0.9, 0.1]),
+        ],
+        centroid=[0.95, 0.05],
+        children=[
+            HierarchyNode(
+                members=[_m("type_calculus_aa", "calculus", [1.0, 0.0])],
+                centroid=[1.0, 0.0],
+            ),
+            HierarchyNode(
+                members=[_m("type_algebra_bb", "algebra", [0.9, 0.1])],
+                centroid=[0.9, 0.1],
+            ),
+        ],
+    )
+    monkeypatch.setattr(tr, "find_emergent_hierarchy", lambda *a, **k: [leaf])
+    mint_calls: list = []
+    # name_fn returns a normal label with no parent (no graft rebind interferes).
+    _handler(hcg, milvus, mint_calls=mint_calls, name_label="mathematics").run()
+
+    # The seeded concept root was NOT reused/reparented.
+    assert not any(
+        e["source"] == "type_concept" and e["relation"] == "IS_A" for e in hcg.edges
+    )
+    assert hcg.nodes["type_concept"]["properties"]["ancestors"] == ["root", "node"]
+    # A fresh super was minted under entity instead.
+    assert mint_calls == [("mathematics", "type_entity", False)]

--- a/tests/maintenance/test_type_rollup.py
+++ b/tests/maintenance/test_type_rollup.py
@@ -1026,3 +1026,27 @@ def test_name_reconcile_is_case_insensitive(monkeypatch):
             and e["relation"] == "IS_A"
             for e in hcg.edges
         )
+
+
+def test_resolve_parent_ignores_shadowing_domain_type():
+    """A realm root must resolve to its canonical seeded uuid even when a
+    case-variant domain type-def ("Concept") shadows the lowercased realm key in
+    the name->uuid map. `_resolve_parent` must return the seeded `type_concept`
+    root, never the foreign domain uuid -- otherwise a top-level super-type would
+    be grafted under an arbitrary domain type (adversarial review of #165
+    gemini@648: validate the resolved uuid, not just the suggested name)."""
+    tds = [
+        _td("type_concept", "concept", ["root", "node"]),  # canonical seeded root
+        _td("type_process", "process", ["root", "node"]),  # canonical seeded root
+        # A capitalized domain type-def that the case-sensitive candidate filter
+        # admits; run() then keys it under the lowercased "concept" slot.
+        _td("type_concept_shadow01", "Concept", ["root", "node", "entity"]),
+    ]
+    hcg = FakeHCG(tds)
+    handler = _handler(hcg, FakeMilvus({}))
+    handler._uuid_by_name = {
+        "concept": "type_concept_shadow01",  # shadow owns the realm key
+        "process": "type_process",
+    }
+    assert handler._resolve_parent("concept")[0] == "type_concept"
+    assert handler._resolve_parent("process")[0] == "type_process"

--- a/tests/maintenance/test_type_rollup.py
+++ b/tests/maintenance/test_type_rollup.py
@@ -944,6 +944,9 @@ def test_resolve_parent_accepts_covering_types_and_rejects_forbidden():
         _td(
             "type_mathematics", "mathematics", ["root", "node", "concept"]
         ),  # domain type
+        _td(
+            "type_metaschema", "metaschema", ["root", "node", "cognition"]
+        ),  # under cognition -- NOT domain-rooted
     ]
     hcg = FakeHCG(tds)
     handler = _handler(hcg, FakeMilvus({}))
@@ -952,6 +955,7 @@ def test_resolve_parent_accepts_covering_types_and_rejects_forbidden():
         "process": "type_process",
         "cognition": "type_cognition",
         "mathematics": "type_mathematics",
+        "metaschema": "type_metaschema",
     }
 
     # Realm roots resolve to their canonical seeded uuid + ancestors.
@@ -979,6 +983,9 @@ def test_resolve_parent_accepts_covering_types_and_rejects_forbidden():
     # Forbidden: `cognition` is reserved for metacognition, not domain rollup --
     # rejected even though the node exists.
     assert handler._resolve_parent("cognition") is None
+    # Forbidden: a type under the `cognition` subtree is NOT domain-rooted, so a
+    # domain super must never graft into the metacognitive realm.
+    assert handler._resolve_parent("metaschema") is None
     # Forbidden: pure structural roots are never domain parents.
     assert handler._resolve_parent("root") is None
     assert handler._resolve_parent("node") is None
@@ -1168,94 +1175,3 @@ def test_top_level_super_grafts_under_deeper_domain_type(monkeypatch):
         "concept",
         "science",
     ]
-
-
-def test_super_not_grafted_under_a_descendant_of_a_member(monkeypatch):
-    """Cycle guard: if Hermes names a parent that IS_A-descends from a cluster
-    member, grafting the super above the members AND under that parent would
-    cycle. The graft is rejected and the super degrades to `entity` (#165)."""
-    import sophia.maintenance.type_rollup_handler as tr
-
-    tds = [
-        _td("type_concept", "concept", ["root", "node"]),
-        _td("type_calculus_aa", "calculus", ["root", "node", "entity"]),
-        _td("type_algebra_bb", "algebra", ["root", "node", "entity"]),
-        # `advanced_calculus` IS_A-descends from `calculus`, a cluster member --
-        # naming it as the super's parent would create a cycle.
-        _td("type_adv_cc", "advanced_calculus", ["root", "node", "entity", "calculus"]),
-    ]
-    hcg = FakeHCG(tds)
-    milvus = FakeMilvus({"type_calculus_aa": [1.0, 0.0], "type_algebra_bb": [0.9, 0.1]})
-
-    def _m(uuid, name, vec):
-        return Member(uuid, name, vec, Counter(), "type_definition", None, [], "m")
-
-    leaf = HierarchyNode(
-        members=[
-            _m("type_calculus_aa", "calculus", [1.0, 0.0]),
-            _m("type_algebra_bb", "algebra", [0.9, 0.1]),
-        ],
-        centroid=[0.95, 0.05],
-        children=[
-            HierarchyNode(
-                members=[_m("type_calculus_aa", "calculus", [1.0, 0.0])],
-                centroid=[1.0, 0.0],
-            ),
-            HierarchyNode(
-                members=[_m("type_algebra_bb", "algebra", [0.9, 0.1])],
-                centroid=[0.9, 0.1],
-            ),
-        ],
-    )
-    monkeypatch.setattr(tr, "find_emergent_hierarchy", lambda *a, **k: [leaf])
-
-    mint_calls: list = []
-
-    def name_fn(cluster, candidates, url, tok):
-        return NameResult(
-            label="mathematics",
-            description="",
-            confidence=0.9,
-            parent="advanced_calculus",
-        )
-
-    def mint_fn(
-        cluster,
-        name,
-        *,
-        hcg,
-        milvus,
-        source_cluster_id,
-        parent_type_uuid,
-        parent_ancestors,
-        parent_name,
-        retype_members,
-    ):
-        uuid = f"type_{name.label}_super01"
-        hcg.nodes[uuid] = {
-            "uuid": uuid,
-            "name": name.label,
-            "properties": {
-                "is_type_definition": True,
-                "ancestors": list(parent_ancestors) + [parent_name],
-            },
-        }
-        hcg.add_edge(uuid, parent_type_uuid, "IS_A")
-        milvus.update_centroid(uuid, cluster.embeddings[0], "m")
-        mint_calls.append((name.label, parent_type_uuid, retype_members))
-        return uuid
-
-    TypeRollupHandler(
-        config=_cfg(),
-        hcg=hcg,
-        milvus=milvus,
-        event_bus=None,
-        hermes_url="http://h",
-        token="t",
-        name_fn=name_fn,
-        mint_fn=mint_fn,
-    ).run()
-
-    # The cycle was caught: the super stayed under `entity`, NOT under the
-    # descendant `advanced_calculus`.
-    assert mint_calls == [("mathematics", "type_entity", False)]

--- a/tests/maintenance/test_type_rollup.py
+++ b/tests/maintenance/test_type_rollup.py
@@ -928,3 +928,46 @@ def test_centroid_match_never_reparents_a_seeded_realm_root(monkeypatch):
     assert hcg.nodes["type_concept"]["properties"]["ancestors"] == ["root", "node"]
     # A fresh super was minted under entity instead.
     assert mint_calls == [("mathematics", "type_entity", False)]
+
+
+def test_resolve_parent_only_accepts_realm_roots():
+    """Closed-world graft target: `_resolve_parent` resolves the two realm roots
+    (concept / process) and rejects everything else -- a reserved root like
+    `cognition` and any arbitrary domain type both degrade to None so the caller
+    falls back to the default `entity` parent instead of grafting into the wrong
+    realm or minting a cycle (review #165: gemini@633 / greptile P1@650)."""
+    tds = [
+        _td("type_concept", "concept", ["root", "node"]),  # seeded realm root
+        _td("type_process", "process", ["root", "node"]),  # seeded realm root
+        _td("type_cognition", "cognition", ["root", "node"]),  # reserved, NOT a root
+        _td("type_mathematics", "mathematics", ["root", "node", "entity", "concept"]),
+    ]
+    hcg = FakeHCG(tds)
+    handler = _handler(hcg, FakeMilvus({}))
+
+    # The two realm roots resolve to (uuid, ancestors, clean_name).
+    assert handler._resolve_parent("concept") == (
+        "type_concept",
+        ["root", "node"],
+        "concept",
+    )
+    assert handler._resolve_parent("process") == (
+        "type_process",
+        ["root", "node"],
+        "process",
+    )
+    # Case / whitespace from an LLM label must not bypass the closed-world check.
+    assert handler._resolve_parent("  Concept ") == (
+        "type_concept",
+        ["root", "node"],
+        "concept",
+    )
+
+    # `cognition` exists as a seeded node but is reserved for metacognition -- it
+    # is NOT a valid graft target, so it must be rejected closed.
+    assert handler._resolve_parent("cognition") is None
+    # An arbitrary domain type must never become a graft parent.
+    assert handler._resolve_parent("mathematics") is None
+    # Empty / missing suggestions degrade to the default parent.
+    assert handler._resolve_parent("") is None
+    assert handler._resolve_parent(None) is None

--- a/tests/maintenance/test_type_rollup.py
+++ b/tests/maintenance/test_type_rollup.py
@@ -930,22 +930,31 @@ def test_centroid_match_never_reparents_a_seeded_realm_root(monkeypatch):
     assert mint_calls == [("mathematics", "type_entity", False)]
 
 
-def test_resolve_parent_only_accepts_realm_roots():
-    """Closed-world graft target: `_resolve_parent` resolves the two realm roots
-    (concept / process) and rejects everything else -- a reserved root like
-    `cognition` and any arbitrary domain type both degrade to None so the caller
-    falls back to the default `entity` parent instead of grafting into the wrong
-    realm or minting a cycle (review #165: gemini@633 / greptile P1@650)."""
+def test_resolve_parent_accepts_covering_types_and_rejects_forbidden():
+    """`_resolve_parent` grafts under the CLOSEST covering type Hermes names -- a
+    realm root OR a deeper domain type-def -- so a super roots as near the cluster
+    as possible ("create the group as close as you can to the cluster name"), NOT
+    flat under a realm. It rejects only forbidden targets: `cognition` (reserved
+    for metacognition), the pure structural roots, and names that do not resolve
+    (#165 review: the earlier realm-root-only restriction was wrong)."""
     tds = [
         _td("type_concept", "concept", ["root", "node"]),  # seeded realm root
         _td("type_process", "process", ["root", "node"]),  # seeded realm root
-        _td("type_cognition", "cognition", ["root", "node"]),  # reserved, NOT a root
-        _td("type_mathematics", "mathematics", ["root", "node", "entity", "concept"]),
+        _td("type_cognition", "cognition", ["root", "node"]),  # reserved, NOT graftable
+        _td(
+            "type_mathematics", "mathematics", ["root", "node", "concept"]
+        ),  # domain type
     ]
     hcg = FakeHCG(tds)
     handler = _handler(hcg, FakeMilvus({}))
+    handler._uuid_by_name = {
+        "concept": "type_concept",
+        "process": "type_process",
+        "cognition": "type_cognition",
+        "mathematics": "type_mathematics",
+    }
 
-    # The two realm roots resolve to (uuid, ancestors, clean_name).
+    # Realm roots resolve to their canonical seeded uuid + ancestors.
     assert handler._resolve_parent("concept") == (
         "type_concept",
         ["root", "node"],
@@ -956,19 +965,25 @@ def test_resolve_parent_only_accepts_realm_roots():
         ["root", "node"],
         "process",
     )
-    # Case / whitespace from an LLM label must not bypass the closed-world check.
-    assert handler._resolve_parent("  Concept ") == (
-        "type_concept",
-        ["root", "node"],
-        "concept",
+    # A DEEPER domain type Hermes names as the closest cover resolves to that
+    # type-def -- the whole point: graft close, not flat under a realm.
+    assert handler._resolve_parent("mathematics") == (
+        "type_mathematics",
+        ["root", "node", "concept"],
+        "mathematics",
     )
+    # Casing / whitespace from the LLM does not bypass resolution.
+    assert handler._resolve_parent("  Mathematics ")[0] == "type_mathematics"
+    assert handler._resolve_parent("Concept")[0] == "type_concept"
 
-    # `cognition` exists as a seeded node but is reserved for metacognition -- it
-    # is NOT a valid graft target, so it must be rejected closed.
+    # Forbidden: `cognition` is reserved for metacognition, not domain rollup --
+    # rejected even though the node exists.
     assert handler._resolve_parent("cognition") is None
-    # An arbitrary domain type must never become a graft parent.
-    assert handler._resolve_parent("mathematics") is None
-    # Empty / missing suggestions degrade to the default parent.
+    # Forbidden: pure structural roots are never domain parents.
+    assert handler._resolve_parent("root") is None
+    assert handler._resolve_parent("node") is None
+    # Unresolvable domain name / empty -> None (degrade to the entity default).
+    assert handler._resolve_parent("nonexistent_type") is None
     assert handler._resolve_parent("") is None
     assert handler._resolve_parent(None) is None
 
@@ -1050,3 +1065,197 @@ def test_resolve_parent_ignores_shadowing_domain_type():
     }
     assert handler._resolve_parent("concept")[0] == "type_concept"
     assert handler._resolve_parent("process")[0] == "type_process"
+
+
+def test_top_level_super_grafts_under_deeper_domain_type(monkeypatch):
+    """The design: a TOP-LEVEL super roots under the CLOSEST covering type Hermes
+    names, NOT just a realm root. Here Hermes names an existing deeper domain type
+    (`science`) as the parent, so `mathematics` roots under `science` (itself
+    under `concept`) -- not flat under `entity`, and not forced up to the realm
+    root. "Create the group as close as you can to the cluster name" (#165)."""
+    import sophia.maintenance.type_rollup_handler as tr
+
+    tds = [
+        _td("type_concept", "concept", ["root", "node"]),  # realm root
+        _td("type_science_xx", "science", ["root", "node", "concept"]),  # deeper cover
+        _td("type_calculus_aa", "calculus", ["root", "node", "entity"]),
+        _td("type_algebra_bb", "algebra", ["root", "node", "entity"]),
+    ]
+    hcg = FakeHCG(tds)
+    milvus = FakeMilvus({"type_calculus_aa": [1.0, 0.0], "type_algebra_bb": [0.9, 0.1]})
+
+    def _m(uuid, name, vec):
+        return Member(uuid, name, vec, Counter(), "type_definition", None, [], "m")
+
+    leaf = HierarchyNode(
+        members=[
+            _m("type_calculus_aa", "calculus", [1.0, 0.0]),
+            _m("type_algebra_bb", "algebra", [0.9, 0.1]),
+        ],
+        centroid=[0.95, 0.05],
+        children=[
+            HierarchyNode(
+                members=[_m("type_calculus_aa", "calculus", [1.0, 0.0])],
+                centroid=[1.0, 0.0],
+            ),
+            HierarchyNode(
+                members=[_m("type_algebra_bb", "algebra", [0.9, 0.1])],
+                centroid=[0.9, 0.1],
+            ),
+        ],
+    )
+    monkeypatch.setattr(tr, "find_emergent_hierarchy", lambda *a, **k: [leaf])
+
+    mint_calls: list = []
+
+    def name_fn(cluster, candidates, url, tok):
+        # `science` (a deeper domain type) is offered so Hermes can graft under it.
+        assert "science" in candidates
+        return NameResult(
+            label="mathematics", description="", confidence=0.9, parent="science"
+        )
+
+    def mint_fn(
+        cluster,
+        name,
+        *,
+        hcg,
+        milvus,
+        source_cluster_id,
+        parent_type_uuid,
+        parent_ancestors,
+        parent_name,
+        retype_members,
+    ):
+        uuid = f"type_{name.label}_super01"
+        hcg.nodes[uuid] = {
+            "uuid": uuid,
+            "name": name.label,
+            "properties": {
+                "is_type_definition": True,
+                "ancestors": list(parent_ancestors) + [parent_name],
+            },
+        }
+        hcg.add_edge(uuid, parent_type_uuid, "IS_A")
+        milvus.update_centroid(uuid, cluster.embeddings[0], "m")
+        mint_calls.append((name.label, parent_type_uuid, retype_members))
+        return uuid
+
+    TypeRollupHandler(
+        config=_cfg(),
+        hcg=hcg,
+        milvus=milvus,
+        event_bus=None,
+        hermes_url="http://h",
+        token="t",
+        name_fn=name_fn,
+        mint_fn=mint_fn,
+    ).run()
+
+    # The super rooted under the DEEPER domain type `science`, not `entity`,
+    # and not lifted only as far as the `concept` realm root.
+    assert mint_calls == [("mathematics", "type_science_xx", False)]
+    super_uuid = "type_mathematics_super01"
+    assert any(
+        e["source"] == super_uuid
+        and e["target"] == "type_science_xx"
+        and e["relation"] == "IS_A"
+        for e in hcg.edges
+    )
+    assert hcg.nodes[super_uuid]["properties"]["ancestors"] == [
+        "root",
+        "node",
+        "concept",
+        "science",
+    ]
+
+
+def test_super_not_grafted_under_a_descendant_of_a_member(monkeypatch):
+    """Cycle guard: if Hermes names a parent that IS_A-descends from a cluster
+    member, grafting the super above the members AND under that parent would
+    cycle. The graft is rejected and the super degrades to `entity` (#165)."""
+    import sophia.maintenance.type_rollup_handler as tr
+
+    tds = [
+        _td("type_concept", "concept", ["root", "node"]),
+        _td("type_calculus_aa", "calculus", ["root", "node", "entity"]),
+        _td("type_algebra_bb", "algebra", ["root", "node", "entity"]),
+        # `advanced_calculus` IS_A-descends from `calculus`, a cluster member --
+        # naming it as the super's parent would create a cycle.
+        _td("type_adv_cc", "advanced_calculus", ["root", "node", "entity", "calculus"]),
+    ]
+    hcg = FakeHCG(tds)
+    milvus = FakeMilvus({"type_calculus_aa": [1.0, 0.0], "type_algebra_bb": [0.9, 0.1]})
+
+    def _m(uuid, name, vec):
+        return Member(uuid, name, vec, Counter(), "type_definition", None, [], "m")
+
+    leaf = HierarchyNode(
+        members=[
+            _m("type_calculus_aa", "calculus", [1.0, 0.0]),
+            _m("type_algebra_bb", "algebra", [0.9, 0.1]),
+        ],
+        centroid=[0.95, 0.05],
+        children=[
+            HierarchyNode(
+                members=[_m("type_calculus_aa", "calculus", [1.0, 0.0])],
+                centroid=[1.0, 0.0],
+            ),
+            HierarchyNode(
+                members=[_m("type_algebra_bb", "algebra", [0.9, 0.1])],
+                centroid=[0.9, 0.1],
+            ),
+        ],
+    )
+    monkeypatch.setattr(tr, "find_emergent_hierarchy", lambda *a, **k: [leaf])
+
+    mint_calls: list = []
+
+    def name_fn(cluster, candidates, url, tok):
+        return NameResult(
+            label="mathematics",
+            description="",
+            confidence=0.9,
+            parent="advanced_calculus",
+        )
+
+    def mint_fn(
+        cluster,
+        name,
+        *,
+        hcg,
+        milvus,
+        source_cluster_id,
+        parent_type_uuid,
+        parent_ancestors,
+        parent_name,
+        retype_members,
+    ):
+        uuid = f"type_{name.label}_super01"
+        hcg.nodes[uuid] = {
+            "uuid": uuid,
+            "name": name.label,
+            "properties": {
+                "is_type_definition": True,
+                "ancestors": list(parent_ancestors) + [parent_name],
+            },
+        }
+        hcg.add_edge(uuid, parent_type_uuid, "IS_A")
+        milvus.update_centroid(uuid, cluster.embeddings[0], "m")
+        mint_calls.append((name.label, parent_type_uuid, retype_members))
+        return uuid
+
+    TypeRollupHandler(
+        config=_cfg(),
+        hcg=hcg,
+        milvus=milvus,
+        event_bus=None,
+        hermes_url="http://h",
+        token="t",
+        name_fn=name_fn,
+        mint_fn=mint_fn,
+    ).run()
+
+    # The cycle was caught: the super stayed under `entity`, NOT under the
+    # descendant `advanced_calculus`.
+    assert mint_calls == [("mathematics", "type_entity", False)]


### PR DESCRIPTION
The #160 type-rollup now roots a NEW top-level super-type under the realm Hermes names (concept/process) via an optional graft parent on NameResult, instead of flat under entity. Emergence stays discovery-only; the rollup is the sole placement authority. Seeded realm roots are guarded so centroid reuse never reparents them (regression test included).

Pins logos-foundry v0.7.3 (adds the process realm root). Depends on logos #550 (tag v0.7.3).

Part of #499.