### PR TITLE
refactor: detect the type layer structurally, not by flag (#171)

### DIFF
--- a/src/sophia/maintenance/type_minting.py
+++ b/src/sophia/maintenance/type_minting.py
@@ -104,7 +104,8 @@ def mint_type(
         node_type="type_definition",
         uuid=type_uuid,
         properties={
-            "is_type_definition": True,
+            # No `is_type_definition` flag (#171): the type layer is detected
+            # structurally via node_type="type_definition" + the type_ uuid.
             "ancestors": _anc + [_pname],
             "name_history": name_history,
         },

--- a/src/sophia/maintenance/type_rollup_handler.py
+++ b/src/sophia/maintenance/type_rollup_handler.py
@@ -86,11 +86,11 @@ def _is_rollup_candidate(td: dict) -> bool:
     # Structural type-layer detection (#171). The foundry is structure-not-
     # flags: add_node/the seeder never write an `is_type_definition` flag, so
     # filtering on it dropped every seeded root. The node `type` is set to
-    # "type_definition" by BOTH the seeder and type_minting; the real client
-    # nests the full node map under `properties`, but tolerate a flattened
-    # record with a top-level `type` as well.
-    node_type = td.get("type") or props.get("type")
-    return node_type == "type_definition"
+    # "type_definition" by BOTH the seeder and type_minting, and every record
+    # reaching this predicate comes through get_all_type_definitions(), which
+    # returns the full node map nested under `properties` -- that is the ONE
+    # canonical shape, so no flattened-record tolerance (PR #173 review).
+    return props.get("type") == "type_definition"
 
 
 class TypeRollupHandler:

--- a/src/sophia/maintenance/type_rollup_handler.py
+++ b/src/sophia/maintenance/type_rollup_handler.py
@@ -69,7 +69,7 @@ _BIG = 100_000
 
 
 def _is_rollup_candidate(td: dict) -> bool:
-    """A minted, non-reserved entity-side type-def eligible for rollup."""
+    """A non-reserved entity-side type-def (seeded or minted) eligible for rollup."""
     name = (td.get("name") or "").strip()
     uuid = td.get("uuid") or ""
     if not name or not uuid.startswith("type_"):
@@ -78,11 +78,19 @@ def _is_rollup_candidate(td: dict) -> bool:
         return False
     props = td.get("properties") or {}
     anc = props.get("ancestors")
-    if (
-        isinstance(anc, list) and "edge_type" in anc
-    ):  # edge-type-defs are not entity types
+    # Edge-type-defs are not entity types: minted ones carry `edge_type` in
+    # their ancestors; the seeded edge-type ROOT (`type_edge_type`) carries no
+    # ancestors at all, so it is excluded by name.
+    if name == "edge_type" or (isinstance(anc, list) and "edge_type" in anc):
         return False
-    return bool(props.get("is_type_definition"))
+    # Structural type-layer detection (#171). The foundry is structure-not-
+    # flags: add_node/the seeder never write an `is_type_definition` flag, so
+    # filtering on it dropped every seeded root. The node `type` is set to
+    # "type_definition" by BOTH the seeder and type_minting; the real client
+    # nests the full node map under `properties`, but tolerate a flattened
+    # record with a top-level `type` as well.
+    node_type = td.get("type") or props.get("type")
+    return node_type == "type_definition"
 
 
 class TypeRollupHandler:

--- a/tests/maintenance/test_type_minting.py
+++ b/tests/maintenance/test_type_minting.py
@@ -96,7 +96,9 @@ def test_mint_creates_type_node_centroid_and_retypes():
     tdef = [n for n in hcg.added_nodes if n["node_type"] == "type_definition"]
     assert len(tdef) == 1
     props = tdef[0]["properties"]
-    assert props["is_type_definition"] is True
+    # Structural typing (#171): node_type="type_definition" + the type_ uuid
+    # prefix carry the type-layer signal; the legacy flag is never written.
+    assert "is_type_definition" not in props
     assert props["ancestors"] == ["root", "node", "entity"]
     assert props["name_history"][0]["name"] == "concept"
     assert props["name_history"][0]["hermes_confidence"] == 0.8

--- a/tests/maintenance/test_type_rollup.py
+++ b/tests/maintenance/test_type_rollup.py
@@ -7,14 +7,17 @@ from collections import Counter
 from sophia.maintenance.config import MaintenanceConfig
 from sophia.maintenance.emergence_clustering import HierarchyNode
 from sophia.maintenance.emergence_types import Member, NameResult
-from sophia.maintenance.type_rollup_handler import TypeRollupHandler
+from sophia.maintenance.type_rollup_handler import (
+    TypeRollupHandler,
+    _is_rollup_candidate,
+)
 
 
 class FakeHCG:
     """In-memory type-def graph: nodes + reified IS_A edges, recording writes."""
 
     def __init__(self, type_defs, members=None, is_a=None, other_edges=None):
-        # type_defs: list of {uuid,name,properties{ancestors,is_type_definition}}
+        # type_defs: list of {uuid,name,properties{type,ancestors}}
         self.nodes = {td["uuid"]: td for td in type_defs}
         for m in members or []:  # entity members carry a type_uuid
             self.nodes[m["uuid"]] = m
@@ -24,10 +27,12 @@ class FakeHCG:
         self.writes = []  # (op, *args)
 
     def get_all_type_definitions(self):
+        # Mirrors the real client: structural match on the node type
+        # (MATCH (t:Node {type: "type_definition"})), never a flag (#171).
         return [
             n
             for n in self.nodes.values()
-            if (n.get("properties") or {}).get("is_type_definition")
+            if (n.get("properties") or {}).get("type") == "type_definition"
         ]
 
     def get_node(self, uuid):
@@ -105,7 +110,7 @@ def _td(uuid, name, ancestors):
     return {
         "uuid": uuid,
         "name": name,
-        "properties": {"is_type_definition": True, "ancestors": ancestors},
+        "properties": {"type": "type_definition", "ancestors": ancestors},
     }
 
 
@@ -134,7 +139,7 @@ def _handler(hcg, milvus, mint_calls=None, name_label="mathematics"):
             "uuid": uuid,
             "name": name.label,
             "properties": {
-                "is_type_definition": True,
+                "type": "type_definition",
                 "ancestors": list(parent_ancestors) + [parent_name],
             },
         }
@@ -154,6 +159,131 @@ def _handler(hcg, milvus, mint_calls=None, name_label="mathematics"):
         name_fn=name_fn,
         mint_fn=mint_fn,
     )
+
+
+# ------------------------------------------------- structural detection (#171)
+# The foundry is structure-not-flags: add_node/the seeder never write an
+# `is_type_definition` flag, so the predicate keys on the node `type` (set to
+# "type_definition" by BOTH the seeder and type_minting) + the `type_` uuid
+# prefix it already required.
+
+
+def test_candidate_seeded_root_shape_detected():
+    """A seeded domain root -- node type only, NO flag, NO ancestors -- is a
+    type-def structurally (the #171 bug: it vanished under the flag filter)."""
+    td = {
+        "uuid": "type_object",
+        "name": "object",
+        "properties": {"type": "type_definition"},
+    }
+    assert _is_rollup_candidate(td)
+
+
+def test_candidate_minted_type_shape_detected():
+    """A minted type-def (node type + ancestors + name_history, no flag)."""
+    td = {
+        "uuid": "type_dog_ab12cd34",
+        "name": "dog",
+        "properties": {
+            "type": "type_definition",
+            "ancestors": ["root", "node", "entity"],
+            "name_history": [{"name": "dog", "reason": "emergence"}],
+        },
+    }
+    assert _is_rollup_candidate(td)
+
+
+def test_candidate_tolerates_top_level_type_key():
+    """A flattened record carrying `type` at the top level (not nested under
+    properties, as the real client returns it) is also detected."""
+    td = {
+        "uuid": "type_location",
+        "name": "location",
+        "type": "type_definition",
+        "properties": {},
+    }
+    assert _is_rollup_candidate(td)
+
+
+def test_candidate_rejects_non_type_definition_nodes():
+    """Instance/entity nodes are not type-defs, whatever their uuid shape."""
+    # type_ uuid prefix but a non-type node type: structure says no.
+    odd = {"uuid": "type_oddball", "name": "oddball", "properties": {"type": "entity"}}
+    assert not _is_rollup_candidate(odd)
+    # plain instance: uuid4, domain type.
+    inst = {
+        "uuid": "9be07f63-2f6a-4f8e-9c1d-0a1b2c3d4e5f",
+        "name": "rex",
+        "properties": {"type": "dog"},
+    }
+    assert not _is_rollup_candidate(inst)
+
+
+def test_candidate_rejects_legacy_flag_without_structure():
+    """The legacy flag alone no longer qualifies a record (structure, not
+    flags; dev DBs are wiped/reseeded, so no migration path is needed)."""
+    td = {
+        "uuid": "type_legacy",
+        "name": "legacy",
+        "properties": {"is_type_definition": True},
+    }
+    assert not _is_rollup_candidate(td)
+
+
+def test_candidate_protected_and_reserved_exclusions_hold():
+    """Seeded structural roots and reserved_ types stay excluded."""
+    for name in ("root", "node", "entity", "concept", "cognition", "process"):
+        td = {
+            "uuid": f"type_{name}",
+            "name": name,
+            "properties": {"type": "type_definition"},
+        }
+        assert not _is_rollup_candidate(td), name
+    reserved = {
+        "uuid": "type_reserved_agent",
+        "name": "reserved_agent",
+        "properties": {"type": "type_definition"},
+    }
+    assert not _is_rollup_candidate(reserved)
+
+
+def test_candidate_edge_type_defs_stay_excluded():
+    """Edge-type defs (edge_type in ancestors) AND the seeded edge-type root
+    itself (name=edge_type, no ancestors) are not entity types."""
+    minted = {
+        "uuid": "type_edge_blocks",
+        "name": "BLOCKS",
+        "properties": {
+            "type": "type_definition",
+            "ancestors": ["root", "node", "edge_type"],
+        },
+    }
+    assert not _is_rollup_candidate(minted)
+    root = {
+        "uuid": "type_edge_type",
+        "name": "edge_type",
+        "properties": {"type": "type_definition"},
+    }
+    assert not _is_rollup_candidate(root)
+
+
+def test_seeded_root_flows_through_load_type_layer():
+    """End-to-end through the fake client: a seeded-shaped root (no flag, no
+    ancestors) is part of the loaded type layer alongside minted types."""
+    seeded = {
+        "uuid": "type_object",
+        "name": "object",
+        "properties": {"type": "type_definition"},
+    }
+    minted = _td("type_dog_aa", "dog", ["root", "node", "entity"])
+    hcg = FakeHCG([seeded, minted])
+    milvus = FakeMilvus({"type_object": [1.0, 0.0], "type_dog_aa": [0.0, 1.0]})
+    handler = _handler(hcg, milvus)
+    rows = handler._load_type_layer()
+    assert {r["uuid"] for r in rows} == {"type_object", "type_dog_aa"}
+    # the seeded root defaults to the canonical [root, node] chain
+    seeded_row = next(r for r in rows if r["uuid"] == "type_object")
+    assert seeded_row["ancestors"] == ["root", "node"]
 
 
 def test_tier1_lifts_explicit_subsumption(monkeypatch):
@@ -578,7 +708,7 @@ def test_reused_super_is_reparented_to_intended_parent(monkeypatch):
             "uuid": uuid,
             "name": name.label,
             "properties": {
-                "is_type_definition": True,
+                "type": "type_definition",
                 "ancestors": list(parent_ancestors) + [parent_name],
             },
         }
@@ -825,7 +955,7 @@ def test_top_level_super_grafts_under_realm_root(monkeypatch):
             "uuid": uuid,
             "name": name.label,
             "properties": {
-                "is_type_definition": True,
+                "type": "type_definition",
                 "ancestors": list(parent_ancestors) + [parent_name],
             },
         }
@@ -1139,7 +1269,7 @@ def test_top_level_super_grafts_under_deeper_domain_type(monkeypatch):
             "uuid": uuid,
             "name": name.label,
             "properties": {
-                "is_type_definition": True,
+                "type": "type_definition",
                 "ancestors": list(parent_ancestors) + [parent_name],
             },
         }

--- a/tests/maintenance/test_type_rollup.py
+++ b/tests/maintenance/test_type_rollup.py
@@ -193,16 +193,25 @@ def test_candidate_minted_type_shape_detected():
     assert _is_rollup_candidate(td)
 
 
-def test_candidate_tolerates_top_level_type_key():
-    """A flattened record carrying `type` at the top level (not nested under
-    properties, as the real client returns it) is also detected."""
-    td = {
+def test_candidate_requires_nested_properties_type():
+    """The ONE canonical record shape is the full node map nested under
+    `properties` (what get_all_type_definitions returns). A top-level `type`
+    is never consulted -- neither to admit a flattened record nor to shadow
+    the nested value (PR #173 review)."""
+    flattened = {
         "uuid": "type_location",
         "name": "location",
         "type": "type_definition",
         "properties": {},
     }
-    assert _is_rollup_candidate(td)
+    assert not _is_rollup_candidate(flattened)
+    shadowed = {
+        "uuid": "type_location",
+        "name": "location",
+        "type": "Node",
+        "properties": {"type": "type_definition"},
+    }
+    assert _is_rollup_candidate(shadowed)
 
 
 def test_candidate_rejects_non_type_definition_nodes():


### PR DESCRIPTION
## Summary
The foundry design is structure-not-flags (`add_node` refuses `is_type_definition`; the seeder never writes it — pinned by logos `test_edge_reification.py`), so seeded realm roots were invisible to the rollup without a runtime patch. The rollup's type-layer predicate now keys on the structural `node_type == "type_definition"` (present on seeded AND minted types, checked at both record shapes the live client returns) with the existing uuid-prefix, protected/reserved, and edge-type guards preserved — plus an explicit `edge_type` root exclusion the old flag check provided only incidentally. `type_minting` stops writing the redundant flag.

## Related Issue
Closes #171

## Changes
- Files / modules changed:
  - `src/sophia/maintenance/type_rollup_handler.py` — structural predicate (+ edge-type-root guard)
  - `src/sophia/maintenance/type_minting.py` — flag write removed
  - `tests/maintenance/test_type_rollup.py` — fake client mirrors the real structural Cypher; 8 new tests (seeded-root no-flag/no-ancestors detected; legacy-flag-only rejected; exclusions hold; `_load_type_layer` flow)
  - `tests/maintenance/test_type_minting.py` — asserts the flag is NOT written

## Repo-wide flag audit
src readers/writers: exactly one each, both converted. Remaining mentions are aligned pins (model/client tests asserting the flag is absent), an inert integration fixture, and static seed data — enumerated in the work log.

## How to run / test locally
```bash
poetry env use python3.12 && poetry install
poetry run pytest tests/maintenance/ -q   # 102 passed
poetry run pytest tests/unit -q           # 324 passed, 6 skipped
poetry run mypy src/                      # clean
```

## Checklist (required)
- [x] TDD (tests committed first); ruff/black/mypy clean
- [x] Reader/writer audit complete
- [x] PR references its issue

Unblocks the A0 measured-rollup-baseline arm (c-daly/logos-experiments#12) — the baseline is only honest once seeded roots are structurally visible. Part of epic c-daly/logos#553 (phase 2).