### PR TITLE
fix: durably park evicted members at eviction time (#175)

### DIFF
--- a/src/sophia/maintenance/emergence_handler.py
+++ b/src/sophia/maintenance/emergence_handler.py
@@ -33,6 +33,15 @@ _BASE_TYPE = "entity"
 # two prefixes and its own full ancestors append "entity" (#505).
 _ENTITY_ANCESTORS = ["root", "node"]
 
+# Durable neutral home for evicted/residual members (SPEC 5.13 / R8, #175).
+# A dedicated sentinel rather than `type_entity`: emergence clusters the
+# `entity` junk drawer itself (the `_BASE_TYPE` branches in `run` and
+# `_member_rows`), so parking evictees at `type_entity` would re-include them
+# whenever the junk drawer is the seed. The sentinel has no type-definition
+# node and `run` skips it, so it is never a candidate source.
+_UNSORTED_TYPE = "unsorted"
+_UNSORTED_TYPE_UUID = "type_unsorted"
+
 
 def _cosine(a: list[float], b: list[float]) -> float:
     """Cosine similarity of two equal-length vectors (0.0 if either is zero)."""
@@ -176,6 +185,12 @@ class EmergenceHandler:
         self._candidates_fn = candidates_fn
 
     def run(self, type_uuid: str) -> None:
+        # Parked residuals are not a clustering source (SPEC 5.13): the
+        # sentinel exists precisely so evicted members stop re-entering
+        # candidate pulls.
+        if type_uuid == _UNSORTED_TYPE_UUID:
+            logger.info("emergence: skipping unsorted sentinel (parked residuals)")
+            return
         members = self._load_members(type_uuid)
         # Roll the fine clusters up into a multi-level hierarchy: leaves are the
         # fine clusters, internal nodes are super-types grouping related leaves
@@ -265,6 +280,13 @@ class EmergenceHandler:
                         name.label,
                     )
                     cluster = EmergentCluster(members=members)
+                    # Durably park the evictees off the candidate source
+                    # (SPEC 5.13 / R8, #175): without the retype they keep
+                    # the seed type_uuid and the next pull re-includes them.
+                    self._park_residuals(
+                        [m for m in node.members if m.uuid in removed_set],
+                        name.label,
+                    )
 
             is_leaf = not node.children
             existing = self._match_existing_type(node.centroid, parent_type_uuid)
@@ -324,6 +346,27 @@ class EmergenceHandler:
                 )
         except Exception:
             logger.exception("emergence: node failed, skipping")
+
+    def _park_residuals(self, evicted: list[Member], label: str) -> None:
+        """Retype Hermes-flagged outliers onto the `unsorted` sentinel.
+
+        Mirrors the production retype write (type_minting): membership is the
+        authoritative `type_uuid` property, so stamping the sentinel removes
+        the member from the next candidate pull of its seed, while `run`
+        keeps the sentinel itself out of clustering. Per-member isolation:
+        one failed write must not abort the mint of the surviving cluster.
+        """
+        for m in evicted:
+            try:
+                self._hcg.update_node(
+                    m.uuid,
+                    {"type": _UNSORTED_TYPE, "type_uuid": _UNSORTED_TYPE_UUID},
+                )
+                logger.info(
+                    "emergence: parked residual %s (outlier of %r)", m.uuid, label
+                )
+            except Exception:
+                logger.exception("emergence: failed to park residual %s", m.uuid)
 
     def _match_existing_type(
         self, centroid: list[float], parent_type_uuid: str

--- a/src/sophia/maintenance/emergence_handler.py
+++ b/src/sophia/maintenance/emergence_handler.py
@@ -268,10 +268,19 @@ class EmergenceHandler:
                 removed_set = set(name.removed)
                 members = [m for m in node.members if m.uuid not in removed_set]
                 if not members:
+                    # Total rejection still parks (SPEC 5.13): at temperature
+                    # 0 the namer's verdict is deterministic, so leaving the
+                    # members on the seed re-clusters and re-rejects them on
+                    # EVERY pass -- an unbounded churn loop with repeated LLM
+                    # spend. The sentinel is a durable, recoverable home, not
+                    # destruction (PR #176 review).
                     logger.info(
-                        "emergence: all %d members flagged as outliers; skipping",
+                        "emergence: all %d members flagged as outliers; "
+                        "parking to %s",
                         len(node.members),
+                        _UNSORTED_TYPE_UUID,
                     )
+                    self._park_residuals(list(node.members), name.label)
                     return
                 if len(members) < len(node.members):
                     logger.info(

--- a/tests/integration/test_r1_graft_invariants.py
+++ b/tests/integration/test_r1_graft_invariants.py
@@ -617,20 +617,6 @@ def test_same_norm_dedup_single_mint(hcg, ns):
     )
 
 
-@pytest.mark.xfail(
-    reason=(
-        "SPEC section 5.13 (residual durability) is UNIMPLEMENTED in "
-        "production: the eviction path (emergence_handler.py, the "
-        "Hermes-flagged outlier filter around lines 252-254) drops removed "
-        "members from the cluster but never retypes them off the source "
-        "type, so the next type_uuid pull re-includes them. This xfail IS "
-        "the promotion gate: remove the marker once residuals are durably "
-        "parked (retype to type_entity or an excluded unsorted sentinel; "
-        "sophia#175). strict=True so an unexpected XPASS fails the suite "
-        "loudly, forcing the marker off the moment production catches up."
-    ),
-    strict=True,
-)
 def test_evicted_member_not_reclustered(hcg, ns):
     """SPEC 5.13: an evicted member must not re-enter the next cluster pull.
 

--- a/tests/maintenance/test_emergence_handler.py
+++ b/tests/maintenance/test_emergence_handler.py
@@ -529,8 +529,11 @@ def test_handler_omits_hermes_flagged_outliers(monkeypatch):
     assert set(minted_members["concept"]) == {"c0", "c1", "c2", "c3"}
 
 
-def test_handler_skips_when_all_members_flagged(monkeypatch):
-    """If Hermes flags every member as an outlier, the cluster mints nothing."""
+def test_handler_parks_all_members_when_all_flagged(monkeypatch):
+    """If Hermes flags every member as an outlier, the cluster mints nothing
+    AND every member is parked to the unsorted sentinel -- at temperature 0
+    the rejection is deterministic, so leaving them on the seed would
+    re-cluster and re-reject them on every pass (SPEC 5.13, PR #176)."""
     from sophia.maintenance import emergence_handler as eh
     from sophia.maintenance.emergence_clustering import HierarchyNode
 
@@ -541,6 +544,11 @@ def test_handler_skips_when_all_members_flagged(monkeypatch):
     monkeypatch.setattr(eh, "find_emergent_hierarchy", fake_hierarchy)
 
     minted = []
+    parked: dict[str, dict] = {}
+
+    class _ParkRecordingHCG:
+        def update_node(self, uuid, props):
+            parked[uuid] = props
 
     def fake_name(cluster, candidates, hermes_url, token):
         return NameResult(
@@ -552,7 +560,7 @@ def test_handler_skips_when_all_members_flagged(monkeypatch):
 
     handler = EmergenceHandler(
         config=MaintenanceConfig(),
-        hcg=object(),
+        hcg=_ParkRecordingHCG(),
         milvus=_NoMatchMilvus(),
         event_bus=None,
         hermes_url="http://h",
@@ -565,3 +573,6 @@ def test_handler_skips_when_all_members_flagged(monkeypatch):
     handler.run(type_uuid="type_entity")
 
     assert minted == []
+    flagged = {m.uuid for m in _members() if m.uuid.startswith("p")}
+    assert set(parked) == flagged
+    assert all(p.get("type_uuid") == eh._UNSORTED_TYPE_UUID for p in parked.values())

--- a/tests/maintenance/test_emergence_residuals.py
+++ b/tests/maintenance/test_emergence_residuals.py
@@ -1,0 +1,178 @@
+"""Residual durability at eviction time (SPEC 5.13 / R8, #175).
+
+The Hermes-flagged outlier filter in `_mint_subtree` must durably park the
+members it drops: retype them to the `unsorted` sentinel via the production
+update path so the next candidate pull (membership by the authoritative
+`type_uuid` property) excludes them. `type_entity` is not a usable home
+because emergence clusters the entity junk drawer itself.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+
+from sophia.maintenance.config import MaintenanceConfig
+from sophia.maintenance.emergence_handler import EmergenceHandler
+from sophia.maintenance.emergence_types import Member, NameResult
+
+
+class _NoMatchMilvus:
+    """Match-before-mint (#504) never finds an existing type."""
+
+    def find_nearest_types(self, centroid, top_k=1):
+        return []
+
+    def get_embedding(self, node_type, uuid):
+        return None
+
+
+def _member(uuid, x, current_type="widgetbase"):
+    return Member(
+        uuid=uuid,
+        name=uuid,
+        embedding=[x, 0.0],
+        signature=Counter({("MOVED_TO", "location"): 1}),
+        current_type=current_type,
+        hermes_type_hint="object",
+        neighbors=[],
+    )
+
+
+def test_evicted_outlier_parked_and_not_repulled():
+    """An evicted member is retyped onto the sentinel at eviction time, so
+    the very next candidate pull over the seed excludes it and no later
+    cluster re-includes it.
+    """
+    seed = "type_widgetbase"
+
+    members_by_uuid = {f"w{i}": _member(f"w{i}", 0.01 * i) for i in range(4)}
+    members_by_uuid.update(
+        {f"g{i}": _member(f"g{i}", 9.0 + 0.01 * i) for i in range(4)}
+    )
+
+    class FakeHCG:
+        """Stateful fake whose candidate selection mirrors production:
+        membership is the authoritative `type_uuid` property (#505)."""
+
+        def __init__(self):
+            self.nodes = {
+                seed: {
+                    "uuid": seed,
+                    "name": "widgetbase",
+                    "properties": {"ancestors": ["root", "node", "entity"]},
+                }
+            }
+            for u in members_by_uuid:
+                self.nodes[u] = {
+                    "uuid": u,
+                    "properties": {"type": "widgetbase", "type_uuid": seed},
+                }
+
+        def get_node(self, uuid):
+            return self.nodes.get(uuid)
+
+        def update_node(self, uuid, props):
+            self.nodes[uuid]["properties"].update(props)
+
+        def get_nodes_by_type_uuid(self, type_uuid):
+            return [
+                n
+                for n in self.nodes.values()
+                if (n.get("properties") or {}).get("type_uuid") == type_uuid
+            ]
+
+    hcg = FakeHCG()
+    pulls = []
+    named_clusters = []
+
+    def load_members(type_uuid):
+        rows = hcg.get_nodes_by_type_uuid(type_uuid)
+        ms = [
+            members_by_uuid[r["uuid"]]
+            for r in rows
+            if r["uuid"] in members_by_uuid
+        ]
+        pulls.append({m.uuid for m in ms})
+        return ms
+
+    def fake_name(cluster, candidates, hermes_url, token):
+        uuids = {m.uuid for m in cluster.members}
+        named_clusters.append(uuids)
+        if any(u.startswith("w") for u in uuids):
+            return NameResult(
+                label="widget", description="", confidence=0.9, removed=["w3"]
+            )
+        if any(u.startswith("g") for u in uuids):
+            return NameResult(label="gadget", description="", confidence=0.9)
+        return NameResult(label="fresh", description="", confidence=0.9)
+
+    def fake_mint(cluster, name, hcg, milvus, source_cluster_id, **kwargs):
+        # Mirror the production retype write (type_minting.mint_type).
+        type_uuid = f"type_{name.label}"
+        if kwargs.get("retype_members", True):
+            for m in cluster.members:
+                hcg.update_node(
+                    m.uuid, {"type": name.label, "type_uuid": type_uuid}
+                )
+        return type_uuid
+
+    handler = EmergenceHandler(
+        config=MaintenanceConfig(),
+        hcg=hcg,
+        milvus=_NoMatchMilvus(),
+        event_bus=None,
+        hermes_url="http://h",
+        token="t",
+        load_members=load_members,
+        name_fn=fake_name,
+        mint_fn=fake_mint,
+        candidates_fn=lambda: [],
+    )
+
+    handler.run(seed)
+
+    # Sanity: the cluster minted without the evictee; keepers were retyped.
+    for u in ("w0", "w1", "w2"):
+        assert hcg.nodes[u]["properties"]["type_uuid"] == "type_widget"
+    # THE FIX (SPEC 5.13): eviction durably parks the outlier under the
+    # sentinel via the production update path, off the seed it came from.
+    assert hcg.nodes["w3"]["properties"]["type_uuid"] == "type_unsorted"
+    assert hcg.nodes["w3"]["properties"]["type"] == "unsorted"
+
+    # New arrivals land on the seed between passes, right next to the
+    # evictee -- without durable parking it would cluster straight back in.
+    for i in range(3):
+        u = f"n{i}"
+        members_by_uuid[u] = _member(u, 0.01 * i)
+        hcg.nodes[u] = {
+            "uuid": u,
+            "properties": {"type": "widgetbase", "type_uuid": seed},
+        }
+
+    named_clusters.clear()
+    handler.run(seed)
+
+    # The next candidate pull excludes the parked member entirely...
+    assert "w3" not in pulls[-1]
+    # ...and no cluster handed to the namer re-includes it.
+    assert all("w3" not in c for c in named_clusters)
+
+
+def test_run_skips_unsorted_sentinel_source():
+    """The `unsorted` sentinel is never a clustering source, so parked
+    residuals stay parked (SPEC 5.13)."""
+    loaded = []
+    handler = EmergenceHandler(
+        config=MaintenanceConfig(),
+        hcg=object(),
+        milvus=_NoMatchMilvus(),
+        event_bus=None,
+        hermes_url="http://h",
+        token="t",
+        load_members=lambda u: loaded.append(u) or [],
+        name_fn=lambda *a: None,
+        mint_fn=lambda *a, **k: None,
+        candidates_fn=lambda: [],
+    )
+    handler.run("type_unsorted")
+    assert loaded == []

--- a/tests/maintenance/test_emergence_residuals.py
+++ b/tests/maintenance/test_emergence_residuals.py
@@ -87,11 +87,7 @@ def test_evicted_outlier_parked_and_not_repulled():
 
     def load_members(type_uuid):
         rows = hcg.get_nodes_by_type_uuid(type_uuid)
-        ms = [
-            members_by_uuid[r["uuid"]]
-            for r in rows
-            if r["uuid"] in members_by_uuid
-        ]
+        ms = [members_by_uuid[r["uuid"]] for r in rows if r["uuid"] in members_by_uuid]
         pulls.append({m.uuid for m in ms})
         return ms
 
@@ -111,9 +107,7 @@ def test_evicted_outlier_parked_and_not_repulled():
         type_uuid = f"type_{name.label}"
         if kwargs.get("retype_members", True):
             for m in cluster.members:
-                hcg.update_node(
-                    m.uuid, {"type": name.label, "type_uuid": type_uuid}
-                )
+                hcg.update_node(m.uuid, {"type": name.label, "type_uuid": type_uuid})
         return type_uuid
 
     handler = EmergenceHandler(


### PR DESCRIPTION
## Summary
Evicted/residual members previously kept their source `type_uuid`, so the next clustering pass re-included them — the inert backlog was fiction (SPEC §5.13 / R8). Eviction now retypes them to a dedicated `unsorted`/`type_unsorted` sentinel via the production `update_node` path, with per-member exception isolation, parking at eviction time (independent of mint success), and a defense-in-depth guard so the sentinel can never become a clustering source.

## Design decision: sentinel, NOT retype-to-type_entity
The SPEC offers both options; the first fails on code evidence: **emergence clusters `type_entity` itself** — the junk-drawer pull is `list_all_nodes(node_type="entity")` and `scheduler.py:252-267` enqueues every type-def including `type_entity`, while the production eviction precedent (`type_correction_handler`) stamps members back INTO that scan deliberately. Stamping evictees `type_entity` would re-include them on every junk-drawer pass. The sentinel is passively excluded under both pull shapes (wrong `type` for the node-type scan, wrong `type_uuid` for minted pulls) and has no type-definition node, so the periodic scan never enqueues it.

## Related Issue
Closes #175

## Changes
- `src/sophia/maintenance/emergence_handler.py` — sentinel constants, `_park_residuals` (production update path), eviction-site call, sentinel-source guard in `run()`
- `tests/maintenance/test_emergence_residuals.py` (new) — evict → sentinel retype asserted → second pass with fresh arrivals → evictee absent from the pull and every namer cluster; sentinel-source no-op. Red-first.

## R1 gate
`test_evicted_member_not_reclustered` (PR #174) is `strict=True` xfail naming exactly this fix — the marker comes off on this branch once #174 merges (this fix satisfies the gate's exact `load_type_members` pull).

## How to run / test locally
```bash
poetry env use python3.12 && poetry install
poetry run pytest tests/maintenance/ -q   # 96 passed
```

## Checklist (required)
- [x] TDD red-first; ruff/black/mypy clean
- [x] Production write path reused; no consumers outside tests affected
- [x] PR references its issue

Part of epic c-daly/logos#553 (phase 2 — the 4th R1 invariant).