### PR TITLE
perf(emergence): vectorize clustering geometry (#177)

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,15 +1,31 @@
+
+
 # list of languages for which language servers are started; choose from:
-#   al               bash             clojure          cpp              csharp           csharp_omnisharp
-#   dart             elixir           elm              erlang           fortran          go
-#   haskell          java             julia            kotlin           lua              markdown
-#   nix              perl             php              python           python_jedi      r
-#   rego             ruby             ruby_solargraph  rust             scala            swift
-#   terraform        typescript       typescript_vts   yaml             zig
+#   al                  angular             ansible             bash                clojure
+#   cpp                 cpp_ccls            crystal             csharp              csharp_omnisharp
+#   dart                elixir              elm                 erlang              fortran
+#   fsharp              go                  groovy              haskell             haxe
+#   hlsl                html                java                json                julia
+#   kotlin              lean4               lua                 luau                markdown
+#   matlab              msl                 nix                 ocaml               pascal
+#   perl                php                 php_phpactor        powershell          python
+#   python_jedi         python_ty           r                   rego                ruby
+#   ruby_solargraph     rust                scala               scss                solidity
+#   svelte              swift               systemverilog       terraform           toml
+#   typescript          typescript_vts      vue                 yaml                zig
+#   (This list may be outdated. For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
+#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
 # Note:
 #   - For C, use cpp
 #   - For JavaScript, use typescript
+#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For Svelte projects, use svelte (subsumes typescript/javascript for .svelte projects; requires npm)
+#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
+#   - For Free Pascal/Lazarus, use pascal
 # Special requirements:
-#   - csharp: Requires the presence of a .sln file in the project folder.
+#   Some languages require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
 # When using multiple languages, the first language server that supports a given file will be used for that file.
 # The first language is the default language and the respective language server will be used as a fallback.
 # Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
@@ -20,14 +36,12 @@ languages:
 # For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
 encoding: "utf-8"
 
-# whether to use the project's gitignore file to ignore files
-# Added on 2025-04-07
+# whether to use project's .gitignore files to ignore files
 ignore_all_files_in_gitignore: true
 
-# list of additional paths to ignore
-# same syntax as gitignore, so you can use * and **
-# Was previously called `ignored_dirs`, please update your config if you are using that.
-# Added (renamed) on 2025-04-07
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Note: global ignored_paths from serena_config.yml are also applied additively.
 ignored_paths: []
 
 # whether the project is in read-only mode
@@ -35,45 +49,9 @@ ignored_paths: []
 # Added on 2025-04-18
 read_only: false
 
-# list of tool names to exclude. We recommend not excluding any tools, see the readme for more details.
-# Below is the complete list of tools for convenience.
-# To make sure you have the latest list of tools, and to view their descriptions, 
-# execute `uv run scripts/print_tool_overview.py`.
-#
-#  * `activate_project`: Activates a project by name.
-#  * `check_onboarding_performed`: Checks whether project onboarding was already performed.
-#  * `create_text_file`: Creates/overwrites a file in the project directory.
-#  * `delete_lines`: Deletes a range of lines within a file.
-#  * `delete_memory`: Deletes a memory from Serena's project-specific memory store.
-#  * `execute_shell_command`: Executes a shell command.
-#  * `find_referencing_code_snippets`: Finds code snippets in which the symbol at the given location is referenced.
-#  * `find_referencing_symbols`: Finds symbols that reference the symbol at the given location (optionally filtered by type).
-#  * `find_symbol`: Performs a global (or local) search for symbols with/containing a given name/substring (optionally filtered by type).
-#  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
-#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
-#  * `initial_instructions`: Gets the initial instructions for the current project.
-#     Should only be used in settings where the system prompt cannot be set,
-#     e.g. in clients you have no control over, like Claude Desktop.
-#  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
-#  * `insert_at_line`: Inserts content at a given line in a file.
-#  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
-#  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).
-#  * `list_memories`: Lists memories in Serena's project-specific memory store.
-#  * `onboarding`: Performs onboarding (identifying the project structure and essential tasks, e.g. for testing or building).
-#  * `prepare_for_new_conversation`: Provides instructions for preparing for a new conversation (in order to continue with the necessary context).
-#  * `read_file`: Reads a file within the project directory.
-#  * `read_memory`: Reads the memory with the given name from Serena's project-specific memory store.
-#  * `remove_project`: Removes a project from the Serena configuration.
-#  * `replace_lines`: Replaces a range of lines within a file with new content.
-#  * `replace_symbol_body`: Replaces the full definition of a symbol.
-#  * `restart_language_server`: Restarts the language server, may be necessary when edits not through Serena happen.
-#  * `search_for_pattern`: Performs a search for a pattern in the project.
-#  * `summarize_changes`: Provides instructions for summarizing the changes made to the codebase.
-#  * `switch_modes`: Activates modes by providing a list of their names
-#  * `think_about_collected_information`: Thinking tool for pondering the completeness of collected information.
-#  * `think_about_task_adherence`: Thinking tool for determining whether the agent is still on track with the current task.
-#  * `think_about_whether_you_are_done`: Thinking tool for determining whether the task is truly completed.
-#  * `write_memory`: Writes a named memory (for future reference) to Serena's project-specific memory store.
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 excluded_tools: []
 
 # initial prompt for the project. It will always be given to the LLM upon activating the project
@@ -82,7 +60,9 @@ initial_prompt: ""
 # the name by which the project can be referenced within Serena
 project_name: "sophia"
 
-# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default)
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 included_optional_tools: []
 
 # list of mode names to that are always to be included in the set of active modes
@@ -93,13 +73,69 @@ included_optional_tools: []
 # Set this to a list of mode names to always include the respective modes for this project.
 base_modes:
 
-# list of mode names that are to be activated by default.
-# The full set of modes to be activated is base_modes + default_modes.
-# If the setting is undefined, the default_modes from the global configuration (serena_config.yml) apply.
+# list of mode names that are to be activated by default, overriding the setting in the global configuration.
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# If the setting is undefined/empty, the default_modes from the global configuration (serena_config.yml) apply.
 # Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# Therefore, you can set this to [] if you do not want the default modes defined in the global config to apply
+# for this project.
 # This setting can, in turn, be overridden by CLI parameters (--mode).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
 default_modes:
 
 # fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
 # This cannot be combined with non-empty excluded_tools or included_optional_tools.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 fixed_tools: []
+
+# list of mode names to be activated additionally for this project, e.g. ["query-projects"]
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+added_modes:
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}
+
+# list of additional workspace folder paths for cross-package reference support (e.g. in monorepos).
+# Paths can be absolute or relative to the project root.
+# Each folder is registered as an LSP workspace folder, enabling language servers to discover
+# symbols and references across package boundaries.
+# Currently supported for: TypeScript.
+# Example:
+#   additional_workspace_folders:
+#     - ../sibling-package
+#     - ../shared-lib
+additional_workspace_folders: []

--- a/src/sophia/ingestion/type_emergence.py
+++ b/src/sophia/ingestion/type_emergence.py
@@ -28,17 +28,22 @@ def _euclidean_distance_sq(a: list[float], b: list[float]) -> float:
 
 
 def _mean_vector(vectors: list[list[float]]) -> list[float]:
-    """Compute the element-wise mean of a list of vectors."""
-    dim = len(vectors[0])
-    n = len(vectors)
-    return [sum(v[d] for v in vectors) / n for d in range(dim)]
+    """Compute the element-wise mean of a list of vectors (vectorized, #177)."""
+    import numpy as np
+
+    return np.asarray(vectors, dtype=np.float64).mean(axis=0).tolist()
 
 
 def _variance(vectors: list[list[float]], centroid: list[float]) -> float:
-    """Mean squared distance from centroid."""
+    """Mean squared distance from centroid (vectorized, #177)."""
     if not vectors:
         return 0.0
-    return sum(_euclidean_distance_sq(v, centroid) for v in vectors) / len(vectors)
+    import numpy as np
+
+    x = np.asarray(vectors, dtype=np.float64)
+    c = np.asarray(centroid, dtype=np.float64)
+    diff = x - c[None, :]
+    return float(np.einsum("ij,ij->i", diff, diff).mean())
 
 
 def _kmeans_2(

--- a/src/sophia/ingestion/type_emergence.py
+++ b/src/sophia/ingestion/type_emergence.py
@@ -31,7 +31,7 @@ def _mean_vector(vectors: list[list[float]]) -> list[float]:
     """Compute the element-wise mean of a list of vectors (vectorized, #177)."""
     import numpy as np
 
-    return np.asarray(vectors, dtype=np.float64).mean(axis=0).tolist()
+    return [float(x) for x in np.asarray(vectors, dtype=np.float64).mean(axis=0)]
 
 
 def _variance(vectors: list[list[float]], centroid: list[float]) -> float:

--- a/src/sophia/maintenance/emergence_clustering.py
+++ b/src/sophia/maintenance/emergence_clustering.py
@@ -25,6 +25,8 @@ from __future__ import annotations
 from collections import Counter
 from dataclasses import dataclass, field
 
+import numpy as np
+
 from sophia.ingestion.type_emergence import _mean_vector, _variance
 from sophia.maintenance.emergence_types import EmergentCluster, Member
 
@@ -39,87 +41,94 @@ def _variance_of(members: list[Member]) -> float:
 
 
 def _euclidean(a: list[float], b: list[float]) -> float:
-    return float(sum((x - y) ** 2 for x, y in zip(a, b)) ** 0.5)
+    diff = np.asarray(a, dtype=np.float64) - np.asarray(b, dtype=np.float64)
+    return float(np.sqrt(diff @ diff))
 
 
-def _distance_matrix(vectors: list[list[float]]) -> list[list[float]]:
-    n = len(vectors)
-    d = [[0.0] * n for _ in range(n)]
-    for i in range(n):
-        for j in range(i + 1, n):
-            dist = _euclidean(vectors[i], vectors[j])
-            d[i][j] = d[j][i] = dist
-    return d
+def _distance_matrix(vectors: list[list[float]]) -> "np.ndarray":
+    """Pairwise euclidean distances via the Gram trick (vectorized, #177).
+
+    Returns an (n, n) ndarray; indexes exactly like the previous
+    list-of-lists. The naive broadcast (n, n, d) intermediate would need
+    hundreds of GB at production scale, so: ||x-y||^2 = |x|^2+|y|^2-2x.y.
+    """
+    x = np.asarray(vectors, dtype=np.float64)
+    sq = np.einsum("ij,ij->i", x, x)
+    d2 = sq[:, None] + sq[None, :] - 2.0 * (x @ x.T)
+    np.maximum(d2, 0.0, out=d2)  # clamp float negatives on the diagonal
+    return np.sqrt(d2)
 
 
-def _silhouette(dmat: list[list[float]], labels: list[int]) -> float:
-    """Mean silhouette over a precomputed distance matrix; -1 if < 2 clusters."""
-    uniq = sorted(set(labels))
-    if len(uniq) < 2:
+def _silhouette(dmat: "np.ndarray", labels: list[int]) -> float:
+    """Mean silhouette over a precomputed distance matrix; -1 if < 2 clusters.
+
+    Vectorized (#177): per-cluster mean distances come from one D @ onehot
+    product. Semantics preserved exactly, including the singleton rule:
+    silhouette of a lone point is 0, not (b - 0)/b = 1 -- scoring it 1.0
+    would bias k-selection toward partitions full of singletons (which are
+    then dropped by min_cluster_size, yielding "no clusters found"). See
+    #505 review.
+    """
+    lab = np.asarray(labels)
+    uniq = np.unique(lab)
+    if uniq.size < 2:
         return -1.0
-    members_by_label = {c: [i for i, v in enumerate(labels) if v == c] for c in uniq}
-    scores = []
-    for i, li in enumerate(labels):
-        same = [j for j in members_by_label[li] if j != i]
-        if not same:
-            # Singleton cluster: silhouette is defined as 0, not (b - 0)/b = 1.
-            # Scoring a lone point 1.0 would bias k-selection toward partitions
-            # full of singletons (which are then dropped by min_cluster_size,
-            # yielding "no clusters found"). See #505 review.
-            scores.append(0.0)
-            continue
-        a = sum(dmat[i][j] for j in same) / len(same)
-        b = min(
-            sum(dmat[i][j] for j in members_by_label[c]) / len(members_by_label[c])
-            for c in uniq
-            if c != li
-        )
-        scores.append((b - a) / max(a, b) if max(a, b) > 0 else 0.0)
-    return sum(scores) / len(labels)
+    d = np.asarray(dmat, dtype=np.float64)
+    n = lab.size
+    onehot = (lab[:, None] == uniq[None, :]).astype(np.float64)  # (n, k)
+    counts = onehot.sum(axis=0)  # (k,)
+    sums = d @ onehot  # (n, k): total distance from i to each cluster
+    own_idx = np.searchsorted(uniq, lab)
+    own_count = counts[own_idx]
+    own_sum = sums[np.arange(n), own_idx]
+    # a(i): mean distance to OWN cluster, self excluded.
+    with np.errstate(invalid="ignore", divide="ignore"):
+        a = own_sum / np.maximum(own_count - 1.0, 1.0)
+        means = sums / counts[None, :]  # mean distance to each cluster
+    means[np.arange(n), own_idx] = np.inf
+    b = means.min(axis=1)
+    denom = np.maximum(a, b)
+    s = np.where(denom > 0, (b - a) / np.where(denom > 0, denom, 1.0), 0.0)
+    s = np.where(own_count <= 1, 0.0, s)  # singleton rule
+    return float(s.mean())
 
 
 def _agglomerative_partitions(
-    dmat: list[list[float]], k_min: int, k_max: int
+    dmat: "np.ndarray", k_min: int, k_max: int
 ) -> dict[int, list[int]]:
-    """Average-linkage agglomeration; return {k: labels} for k in [k_min, k_max]."""
-    n = len(dmat)
-    members = {i: [i] for i in range(n)}
-    sizes = {i: 1 for i in range(n)}
-    dist = {(i, j): dmat[i][j] for i in range(n) for j in range(i + 1, n)}
+    """Average-linkage agglomeration; return {k: labels} for k in [k_min, k_max].
 
-    def key(a: int, b: int) -> tuple[int, int]:
-        return (a, b) if a < b else (b, a)
-
-    active = set(range(n))
-    next_id = n
+    Vectorized Lance-Williams (#177): the working distance matrix is updated
+    in place; the merge argmin is one masked scan instead of an O(n^2) dict
+    sweep per step. Same linkage formula, same tie behavior (first minimum
+    in row-major order, matching the previous insertion-ordered dict scan).
+    """
+    d = np.asarray(dmat, dtype=np.float64).copy()
+    n = d.shape[0]
+    np.fill_diagonal(d, np.inf)
+    sizes = np.ones(n)
+    cluster_of = np.arange(n)  # row index -> current cluster row
+    alive = np.ones(n, dtype=bool)
     partitions: dict[int, list[int]] = {}
-    while len(active) > 1:
-        best_pair = None
-        best_d = None
-        for (a, b), d in dist.items():
-            if a in active and b in active and (best_d is None or d < best_d):
-                best_d, best_pair = d, (a, b)
-        a, b = best_pair  # type: ignore[misc]
-        new = next_id
-        next_id += 1
-        members[new] = members[a] + members[b]
-        sizes[new] = sizes[a] + sizes[b]
-        for c in active:
-            if c in (a, b):
-                continue
-            dac = dist.get(key(a, c), 0.0)
-            dbc = dist.get(key(b, c), 0.0)
-            dist[key(new, c)] = (sizes[a] * dac + sizes[b] * dbc) / sizes[new]
-        active.discard(a)
-        active.discard(b)
-        active.add(new)
-        k = len(active)
+    for _step in range(n - 1):
+        masked = np.where(alive[:, None] & alive[None, :], d, np.inf)
+        flat = int(np.argmin(masked))
+        a, b = divmod(flat, n)
+        if a > b:
+            a, b = b, a
+        # Lance-Williams average-linkage update onto row/col a.
+        wa, wb = sizes[a], sizes[b]
+        new_row = (wa * d[a] + wb * d[b]) / (wa + wb)
+        d[a, :] = new_row
+        d[:, a] = new_row
+        d[a, a] = np.inf
+        sizes[a] = wa + wb
+        alive[b] = False
+        cluster_of[cluster_of == b] = a
+        k = int(alive.sum())
         if k_min <= k <= k_max:
-            labels = [0] * n
-            for ci, cid in enumerate(active):
-                for m in members[cid]:
-                    labels[m] = ci
-            partitions[k] = labels
+            live = {row: ci for ci, row in enumerate(np.flatnonzero(alive))}
+            partitions[k] = [live[row] for row in cluster_of]
     return partitions
 
 

--- a/src/sophia/maintenance/emergence_clustering.py
+++ b/src/sophia/maintenance/emergence_clustering.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 from collections import Counter
 from dataclasses import dataclass, field
+from typing import cast
 
 import numpy as np
 
@@ -56,7 +57,7 @@ def _distance_matrix(vectors: list[list[float]]) -> "np.ndarray":
     sq = np.einsum("ij,ij->i", x, x)
     d2 = sq[:, None] + sq[None, :] - 2.0 * (x @ x.T)
     np.maximum(d2, 0.0, out=d2)  # clamp float negatives on the diagonal
-    return np.sqrt(d2)
+    return cast("np.ndarray", np.sqrt(d2))
 
 
 def _silhouette(dmat: "np.ndarray", labels: list[int]) -> float:


### PR DESCRIPTION
Closes #177.

Vectorizes emergence-clustering geometry (numpy over Python loops) — hours to seconds at production scale. Pure performance change; 37 emergence-related tests pass (0 failures).

**Numerical-equivalence notes for review** (flagged by pre-PR verification; none blockers, all worth eyes):
1. `_distance_matrix` uses the Gram-matrix trick with clamp-to-zero — near-duplicate vectors can get exactly 0.0 distance where the direct method gave a tiny positive value.
2. `_silhouette`'s `own_sum` includes `d[i,i]`, correct only because the distance-matrix diagonal is 0 — a non-obvious invariant if other callers ever pass a non-zero diagonal.
3. `_agglomerative_partitions` tie-break: row-major `argmin` is argued (uncommented) to match the old dict-scan order on exact ties — a one-line comment would make it auditable.

Part of the naming-driven-typing v2 correction (vault CORRECTION-PLAN.md Phase 0.2). Orthogonal to the typing-model corrections.

**Do not merge without Chris's review.**