### PR TITLE
chore(a1): seed-skeleton companions — align seeder/scripts, sweep constants (#515)

### DIFF
--- a/scripts/seed_test_data.py
+++ b/scripts/seed_test_data.py
@@ -32,7 +32,6 @@ from sophia.hcg_client.seeder import (  # noqa: E402
     seed_persona_entries,
     seed_pick_and_place_data,
     seed_plan_data,
-    seed_type_definitions,
 )
 
 
@@ -81,9 +80,8 @@ def seed_data(uri: str, user: str, password: str) -> bool:
         logger.info("Clearing existing data...")
         client.clear_all()
 
-        # Seed type definitions first (required for auto-compute ancestors)
-        logger.info("Seeding type definitions...")
-        seed_type_definitions(client)
+        # Type definitions / bootstrap skeleton are seeded by the foundry
+        # (logos_hcg.seeder); this script seeds demo/test data only.
 
         # Seed pick-and-place scenario
         logger.info("Seeding pick-and-place scenario...")

--- a/src/sophia/hcg_client/seeder.py
+++ b/src/sophia/hcg_client/seeder.py
@@ -26,7 +26,7 @@ def seed_pick_and_place_data(hcg_client: HCGClient) -> None:
     hcg_client.add_node(
         uuid="table",
         name="Table",
-        node_type="location",
+        node_type="entity",
         properties={"location_type": "surface"},
         source="bootstrap",
         derivation="observed",
@@ -34,7 +34,7 @@ def seed_pick_and_place_data(hcg_client: HCGClient) -> None:
     hcg_client.add_node(
         uuid="bin",
         name="Bin",
-        node_type="location",
+        node_type="entity",
         properties={"location_type": "container"},
         source="bootstrap",
         derivation="observed",
@@ -44,7 +44,7 @@ def seed_pick_and_place_data(hcg_client: HCGClient) -> None:
     hcg_client.add_node(
         uuid="red_block",
         name="Red Block",
-        node_type="object",
+        node_type="entity",
         properties={"color": "red", "object_type": "block"},
         source="bootstrap",
         derivation="observed",
@@ -52,7 +52,7 @@ def seed_pick_and_place_data(hcg_client: HCGClient) -> None:
     hcg_client.add_node(
         uuid="blue_block",
         name="Blue Block",
-        node_type="object",
+        node_type="entity",
         properties={"color": "blue", "object_type": "block"},
         source="bootstrap",
         derivation="observed",

--- a/src/sophia/maintenance/emergence_handler.py
+++ b/src/sophia/maintenance/emergence_handler.py
@@ -28,11 +28,6 @@ ONTOLOGY_CHANGED_CHANNEL = "ontology.type_created"
 # authoritative `type_uuid` property (no instance->type IS_A edges -- #505).
 _BASE_TYPE = "entity"
 
-# Lineage of the `entity` junk-drawer (root -> node -> entity). Emergence mints
-# directly under `type_entity`, so a minted type's parent ancestors are these
-# two prefixes and its own full ancestors append "entity" (#505).
-_ENTITY_ANCESTORS = ["root", "node"]
-
 # Durable neutral home for evicted/residual members (SPEC 5.13 / R8, #175).
 # A dedicated sentinel rather than `type_entity`: emergence clusters the
 # `entity` junk drawer itself (the `_BASE_TYPE` branches in `run` and
@@ -211,13 +206,13 @@ class EmergenceHandler:
         # `entity` (#505).
         if _type_name(type_uuid) == _BASE_TYPE:
             parent_type_uuid = f"type_{_BASE_TYPE}"
-            parent_ancestors = _ENTITY_ANCESTORS
+            parent_ancestors = ["root", "node"]
             parent_name = _BASE_TYPE
         else:
             parent_type_uuid = type_uuid
             parent_node = self._hcg.get_node(type_uuid) or {}
             parent_props = parent_node.get("properties") or {}
-            parent_ancestors = list(parent_props.get("ancestors") or _ENTITY_ANCESTORS)
+            parent_ancestors = list(parent_props.get("ancestors") or ["root", "node"])
             # Clean name of the type being subdivided. Never derive it from the
             # uuid -- minted type uuids carry a random `_<hex>` suffix that would
             # leak into descendants' ancestors (greptile #159).

--- a/src/sophia/maintenance/type_correction_handler.py
+++ b/src/sophia/maintenance/type_correction_handler.py
@@ -27,7 +27,7 @@ _BIG = 100000
 
 # Node ``type`` values that are NOT emergent types (base ontology + plan
 # scaffold). Correction only fires when two members share a *non-base* type.
-_BASE_TYPES = frozenset({"entity", "concept", "process"})
+_BASE_TYPES = frozenset({"entity", "concept", "process", "cognition"})
 
 # Relations meaning "different KIND of thing": a member linked to a same-type
 # peer by one of these is a part/product, not a co-member.

--- a/src/sophia/maintenance/type_correction_handler.py
+++ b/src/sophia/maintenance/type_correction_handler.py
@@ -27,21 +27,7 @@ _BIG = 100000
 
 # Node ``type`` values that are NOT emergent types (base ontology + plan
 # scaffold). Correction only fires when two members share a *non-base* type.
-_BASE_TYPES = frozenset(
-    {
-        "entity",
-        "edge",
-        "type_definition",
-        "object",
-        "action",
-        "location",
-        "state",
-        "goal",
-        "plan",
-        "reserved_state",
-        "",
-    }
-)
+_BASE_TYPES = frozenset({"entity", "concept", "process"})
 
 # Relations meaning "different KIND of thing": a member linked to a same-type
 # peer by one of these is a part/product, not a co-member.

--- a/src/sophia/maintenance/type_correction_handler.py
+++ b/src/sophia/maintenance/type_correction_handler.py
@@ -69,6 +69,7 @@ class TypeCorrectionHandler:
         self._config = config
         self._hcg = hcg
         self._event_bus = event_bus
+        self._entity_uuid: str | None = None
 
     def run(self) -> None:
         try:
@@ -117,14 +118,38 @@ class TypeCorrectionHandler:
         if evicted:
             logger.info("type_correction: evicted %d part/product member(s)", evicted)
 
+    def _resolve_entity_uuid(self) -> str | None:
+        """Resolve the real ``entity`` realm-root uuid (cached).
+
+        Skeleton type-defs carry real uuids (uuid5), not the legacy
+        ``type_<name>`` slug, so the eviction target is looked up by name
+        rather than hard-coded -- a literal ``"type_entity"`` would dangle
+        against a reseeded graph.
+        """
+        if self._entity_uuid is None:
+            try:
+                for n in self._hcg.list_all_nodes(node_type="type_definition"):
+                    if n.get("name") == "entity":
+                        self._entity_uuid = n.get("uuid")
+                        break
+            except Exception:
+                logger.exception("type_correction: failed to resolve entity uuid")
+        return self._entity_uuid
+
     def _evict(self, uuid: str, from_type: str, rel: str) -> bool:
         """Retype the member back to the junk-drawer (inverse of mint_type)."""
+        entity_uuid = self._resolve_entity_uuid()
+        if not entity_uuid:
+            logger.warning(
+                "type_correction: cannot evict %s -- entity realm root not found", uuid
+            )
+            return False
         try:
             self._hcg.update_node(
                 uuid,
                 {
                     "type": "entity",
-                    "type_uuid": "type_entity",
+                    "type_uuid": entity_uuid,
                     "needs_reclassification": True,
                 },
             )

--- a/src/sophia/maintenance/type_rollup_handler.py
+++ b/src/sophia/maintenance/type_rollup_handler.py
@@ -77,12 +77,6 @@ def _is_rollup_candidate(td: dict) -> bool:
     if name in _PROTECTED_ROOT_NAMES or name.startswith("reserved_"):
         return False
     props = td.get("properties") or {}
-    anc = props.get("ancestors")
-    # Edge-type-defs are not entity types: minted ones carry `edge_type` in
-    # their ancestors; the seeded edge-type ROOT (`type_edge_type`) carries no
-    # ancestors at all, so it is excluded by name.
-    if name == "edge_type" or (isinstance(anc, list) and "edge_type" in anc):
-        return False
     # Structural type-layer detection (#171). The foundry is structure-not-
     # flags: add_node/the seeder never write an `is_type_definition` flag, so
     # filtering on it dropped every seeded root. The node `type` is set to

--- a/tests/integration/test_r1_graft_invariants.py
+++ b/tests/integration/test_r1_graft_invariants.py
@@ -41,7 +41,7 @@ Disposable-graph policy: every uuid this suite creates embeds a per-test
 namespace token, and the stub namer embeds the token in every label so
 minted type uuids (type_<slug>_<hex8>) inherit it. Teardown DETACH-DELETEs
 every node and reified edge node carrying the token. The only shared key
-touched is the seeded type_entity realm root (the graft terminal), created
+touched is the seeded entity realm root (the graft terminal), created
 only when absent and removed again only if this suite created it.
 """
 
@@ -75,6 +75,13 @@ _DIM = 8
 _JITTER_AXIS = 6
 # Axis layout for the synthetic embeddings: 0/1 = rollup super groups,
 # 2/3 = rollup fine-group offsets, 4/5 = emergence member groups, 6 = jitter.
+
+# Graft terminal for the entity realm root. A real uuid4 (never a ^type_ slug,
+# per the seeded-skeleton design), held as a module constant so the fixture and
+# the frozen invariant bodies share one identity. B7 (the invariant-body
+# rewrite to the live-edge skeleton) will fold this into the seeded realm uuid;
+# until then this de-couples the previously-hardcoded slug.
+_ENTITY_REALM_UUID = "3c73215f-2f7c-4c66-b31f-b744b8e369f0"
 
 
 def _vec(
@@ -348,27 +355,27 @@ def hcg():
 
 @pytest.fixture(scope="module")
 def entity_root(hcg):
-    """Ensure the seeded type_entity realm root (rollup graft terminal) exists.
+    """Ensure the seeded entity realm root (rollup graft terminal) exists.
 
     Created only when absent (routinely-wiped dev graphs); deleted again in
     teardown only if THIS suite created it, so a seeded shared root is never
     touched.
     """
     marker = "r1-gate-fixture"
-    created = hcg.get_node("type_entity") is None
+    created = hcg.get_node(_ENTITY_REALM_UUID) is None
     if created:
         hcg.add_node(
             name="entity",
             node_type="type_definition",
-            uuid="type_entity",
+            uuid=_ENTITY_REALM_UUID,
             properties={"is_type_definition": True, "ancestors": ["root", "node"]},
             source=marker,
         )
-    yield "type_entity"
+    yield _ENTITY_REALM_UUID
     if created:
         hcg._execute_query(
             "MATCH (n:Node {uuid: $u, source: $s}) DETACH DELETE n",
-            {"u": "type_entity", "s": marker},
+            {"u": _ENTITY_REALM_UUID, "s": marker},
         )
 
 
@@ -428,7 +435,7 @@ def test_run_twice_zero_churn(hcg, entity_root, ns):
                 f"{ro_ns} t{gi}{j}",
                 ["root", "node", "entity"],
                 f"r1-{ns}",
-                parent_uuid="type_entity",
+                parent_uuid=_ENTITY_REALM_UUID,
             )
             milvus.update_centroid(
                 type_uuid=uuid,
@@ -489,7 +496,7 @@ def test_two_writer_arbitration_no_loop(hcg, entity_root, ns):
         f"{ns} alpha",
         ["root", "node", "entity"],
         f"r1-{ns}",
-        parent_uuid="type_entity",
+        parent_uuid=_ENTITY_REALM_UUID,
     )
     b_uuid = _seed_type_def(
         hcg,
@@ -497,7 +504,7 @@ def test_two_writer_arbitration_no_loop(hcg, entity_root, ns):
         f"{ns} beta",
         ["root", "node", "entity"],
         f"r1-{ns}",
-        parent_uuid="type_entity",
+        parent_uuid=_ENTITY_REALM_UUID,
     )
     ma = _seed_member(hcg, milvus, ns, "ma", a_uuid, _vec(4))
     mb = _seed_member(hcg, milvus, ns, "mb", b_uuid, _vec(5))
@@ -530,7 +537,7 @@ def test_two_writer_arbitration_no_loop(hcg, entity_root, ns):
     # The loser was NOT force-reparented: it keeps its original root parent.
     (winner_child, winner_parent) = next(iter(between))
     loser = b_uuid if winner_child == a_uuid else a_uuid
-    assert {t for (s, t, _e) in is_a if s == loser} == {"type_entity"}
+    assert {t for (s, t, _e) in is_a if s == loser} == {_ENTITY_REALM_UUID}
     assert {t for (s, t, _e) in is_a if s == winner_child} == {winner_parent}
 
     # Second writer pass over the same evidence: zero churn, still one record.

--- a/tests/maintenance/test_type_correction.py
+++ b/tests/maintenance/test_type_correction.py
@@ -2,10 +2,16 @@
 
 from __future__ import annotations
 
+from uuid import NAMESPACE_DNS, uuid5
+
 from sophia.maintenance.config import MaintenanceConfig
 from sophia.maintenance.type_correction_handler import (
     build_type_correction_handler,
 )
+
+# The seeded `entity` realm root's real uuid5 (NOT the legacy `type_entity`
+# slug). `_evict` resolves the eviction target by name and writes this uuid.
+_ENTITY_UUID = str(uuid5(NAMESPACE_DNS, "logos.hcg.type.entity"))
 
 
 class FakeHCG:
@@ -16,6 +22,19 @@ class FakeHCG:
         self.nodes = {n["uuid"]: dict(n) for n in nodes}
         self.edges = list(edges)
         self.updates = []  # (uuid, props)
+        # Seeded `entity` realm root (real uuid5), found by name via list_all_nodes.
+        self.nodes[_ENTITY_UUID] = {
+            "uuid": _ENTITY_UUID,
+            "type": "type_definition",
+            "name": "entity",
+        }
+
+    def list_all_nodes(self, node_type=None):
+        return [
+            n
+            for n in self.nodes.values()
+            if node_type is None or n.get("type") == node_type
+        ]
 
     def list_all_edges(self, relation_type=None, limit=1000):
         return [
@@ -52,7 +71,7 @@ def test_evicts_part_from_its_same_type_whole():
     _run(hcg)
     # the part (source of PART_OF) returns to the junk-drawer
     assert hcg.nodes["tusk"]["type"] == "entity"
-    assert hcg.nodes["tusk"]["type_uuid"] == "type_entity"
+    assert hcg.nodes["tusk"]["type_uuid"] == _ENTITY_UUID
     assert hcg.nodes["tusk"]["needs_reclassification"] is True
     # the whole, and an unrelated peer, are untouched
     assert hcg.nodes["narwhal"]["type"] == "marine_mammal"

--- a/tests/maintenance/test_type_rollup.py
+++ b/tests/maintenance/test_type_rollup.py
@@ -256,26 +256,6 @@ def test_candidate_protected_and_reserved_exclusions_hold():
     assert not _is_rollup_candidate(reserved)
 
 
-def test_candidate_edge_type_defs_stay_excluded():
-    """Edge-type defs (edge_type in ancestors) AND the seeded edge-type root
-    itself (name=edge_type, no ancestors) are not entity types."""
-    minted = {
-        "uuid": "type_edge_blocks",
-        "name": "BLOCKS",
-        "properties": {
-            "type": "type_definition",
-            "ancestors": ["root", "node", "edge_type"],
-        },
-    }
-    assert not _is_rollup_candidate(minted)
-    root = {
-        "uuid": "type_edge_type",
-        "name": "edge_type",
-        "properties": {"type": "type_definition"},
-    }
-    assert not _is_rollup_candidate(root)
-
-
 def test_seeded_root_flows_through_load_type_layer():
     """End-to-end through the fake client: a seeded-shaped root (no flag, no
     ancestors) is part of the loaded type layer alongside minted types."""


### PR DESCRIPTION
**A1** companion sweep in sophia (vault `PHASE-2-PLAN.md`). Part of #515 / epic #553.

## What changed
- `scripts/seed_test_data.py` + `src/sophia/hcg_client/seeder.py`: aligned to the 6-node uuid4 skeleton (root ← node ← entity/concept/process/cognition); no `type_` slugs, no cruft.
- `src/sophia/maintenance/type_correction_handler.py`: `_BASE_TYPES` reduced.
- `src/sophia/maintenance/emergence_handler.py`: `_ENTITY_ANCESTORS` ghost removed.
- `src/sophia/maintenance/type_rollup_handler.py`: vestigial `edge_type` exclusion guard removed.
- `tests/integration/test_r1_graft_invariants.py`: **fixture/constant** alignment only — `type_entity` slug replaced by a real-uuid4 module constant `_ENTITY_REALM_UUID`.

## Scope note (read before reviewing)
The R1 change is a **deferred-to-B7 stopgap**, accepted by the designer: A1's scope was "fixtures only, don't rewrite the invariant bodies," but the bodies contained the literal `type_entity` slug (forbidden under the new design). Minimal de-slug, no invariant *logic* changed; B7 rewrites the whole suite against the new entry points. `proposal_processor.py`'s `type_def_uuid` fabrication is **intentionally untouched** (B3's scope).

Verified via implement → spec-review → fix → verify workflow (net-negative diff, greps clean modulo the deferred items). **Do not merge without Chris's review.**