### PR TITLE
refactor(ndt): convert rollup/correction tier onto placement.py (#24)

### DIFF
--- a/src/sophia/maintenance/config.py
+++ b/src/sophia/maintenance/config.py
@@ -57,14 +57,16 @@ class MaintenanceConfig(BaseSettings):
         description="Discard Hermes cluster names below this confidence.",
     )
     rollup_enabled: bool = Field(
-        # Deferred for naming-driven-typing B1: the rollup (revision) tier still
-        # threads/writes the `ancestors` property and resolves `type_<name>`
-        # slugs, both incompatible with the uuid5 + no-ancestors design. It is
-        # gated OFF until its own follow-up converts it onto placement.py.
+        # The rollup (revision) tier's WRITE side is now on placement.py -- it
+        # re-points IS_A edges and writes no `ancestors` property (#24). It stays
+        # gated OFF because it still (a) resolves `type_<name>` slugs for realm
+        # roots, which dangle against the uuid5 seeder, and (b) infers membership
+        # by reading the `type`/`type_uuid` properties (#35). Both must go
+        # edge-based before it can run correctly on a reseeded graph.
         default=False,
         description="Run the periodic type-level rollup that groups the flat "
-        "layer of emergent types into super-types (#160). Disabled pending the "
-        "rollup-onto-placement conversion (naming-driven-typing follow-up).",
+        "layer of emergent types into super-types (#160). Disabled pending "
+        "realm-root uuid + read-path edge conversion (#35).",
     )
     rollup_interval_seconds: int = Field(
         default=600,

--- a/src/sophia/maintenance/emergence_handler.py
+++ b/src/sophia/maintenance/emergence_handler.py
@@ -313,7 +313,7 @@ class EmergenceHandler:
 
         # Mint a new type under the chosen parent. mint_type writes the type's
         # own type->parent IS_A edge (carrying placed_by) but does NOT touch the
-        # members -- drainage owns member placement (retype_members is a no-op).
+        # members -- drainage owns member placement.
         name_obj = NameResult(
             label=tc.name, description="", confidence=1.0, removed=[], parent=tc.parent
         )
@@ -325,7 +325,6 @@ class EmergenceHandler:
             source_cluster_id=uuid_lib.uuid4().hex[:8],
             parent_type_uuid=parent_uuid,
             placed_by=placed_by,
-            retype_members=False,
         )
         # Re-point each fitting member's instance->type IS_A edge onto the
         # freshly-minted type, carrying the SAME placed_by the type was placed by

--- a/src/sophia/maintenance/type_correction_handler.py
+++ b/src/sophia/maintenance/type_correction_handler.py
@@ -7,9 +7,10 @@ can end up containing both a whole and its part -- e.g. ``tusk`` inside the
 marine-mammal type, ``acorn`` inside the oak's type. An intra-type meronymic /
 productive edge (``tusk PART_OF narwhal``, ``oak PRODUCES acorn``) is conclusive
 structural evidence that one member is a part/product of another, NOT a
-co-member. We evict the part/product back to the ``type_entity`` junk-drawer
-(its ``PART_OF``/``PRODUCES`` edge stays, so its role is still recorded) by
-writing the inverse of ``type_minting``'s retype.
+co-member. We evict the part/product back to the ``entity`` junk-drawer (its
+``PART_OF``/``PRODUCES`` edge stays, so its role is still recorded) by re-pointing
+its single upward ``IS_A`` membership edge onto the ``entity`` realm root via
+``placement.reparent`` -- the inverse of ``type_minting``'s placement.
 
 This redirects #504 off the falsified centroid-cohesion approach (embedding
 distance cannot separate "same kind" from "merely related") onto the proven
@@ -20,6 +21,8 @@ from __future__ import annotations
 
 import logging
 from typing import Any
+
+from sophia.maintenance import placement
 
 logger = logging.getLogger(__name__)
 
@@ -98,9 +101,10 @@ class TypeCorrectionHandler:
         except Exception:
             logger.exception("type_correction: get_nodes_batch failed")
             return
-        # Membership is the node's emergent type. `type` (the slug) is set
-        # alongside `type_uuid` on every retype (type_minting), so two members
-        # of one emergent type share a non-base `type`.
+        # Co-membership is detected from the `type` slug two members share on a
+        # retype. Membership itself is the instance->type IS_A edge now, not a
+        # `type_uuid` stamp; this detection scan is a read path left unconverted.
+        # TODO #35: read still infers membership from property; convert to IS_A walk
         type_of: dict[str, str] = {
             r.get("uuid"): r.get("type") for r in rows if r.get("uuid")
         }
@@ -140,7 +144,14 @@ class TypeCorrectionHandler:
         return self._entity_uuid
 
     def _evict(self, uuid: str, from_type: str, rel: str) -> bool:
-        """Retype the member back to the junk-drawer (inverse of mint_type)."""
+        """Re-point the member's membership edge back to the junk-drawer.
+
+        Membership is the instance->type IS_A edge now (B2/B3, DESIGN sec 3), not
+        a `type_uuid` stamp -- eviction re-points that single upward edge onto the
+        `entity` realm root via placement.reparent (the inverse of mint_type's
+        placement). An empty `children_of` is safe: an evicted instance is a leaf
+        that never roots a type IS_A subtree, so no cycle is possible.
+        """
         entity_uuid = self._resolve_entity_uuid()
         if not entity_uuid:
             logger.warning(
@@ -148,13 +159,12 @@ class TypeCorrectionHandler:
             )
             return False
         try:
-            self._hcg.update_node(
+            placement.reparent(
                 uuid,
-                {
-                    "type": "entity",
-                    "type_uuid": entity_uuid,
-                    "needs_reclassification": True,
-                },
+                entity_uuid,
+                hcg=self._hcg,
+                children_of={},
+                placed_by="root_fallback",
             )
             logger.info(
                 "type_correction: evicted %s from %s (intra-type %s edge)",
@@ -174,8 +184,9 @@ def build_type_correction_handler(
     """Return the callable registered as ``handlers['type_correction']`` (#504).
 
     Deterministic + embedding-free: scans for intra-type meronymic edges and
-    evicts the part/product member to ``type_entity`` via the existing
-    ``update_node`` retype. No Milvus / Hermes needed.
+    evicts the part/product member back under the ``entity`` realm root by
+    re-pointing its ``IS_A`` membership edge (placement.reparent). No Milvus /
+    Hermes needed.
     """
     handler = TypeCorrectionHandler(config=config, hcg=hcg, event_bus=event_bus)
     return lambda **_kw: handler.run()

--- a/src/sophia/maintenance/type_minting.py
+++ b/src/sophia/maintenance/type_minting.py
@@ -9,8 +9,7 @@ Membership is the instance->type IS_A edge now, NOT a `type_uuid` property
 (B2/B3, DESIGN §3): minting does NOT touch the members. The draining caller
 (`EmergenceHandler._place_cluster`) owns member placement -- it re-points each
 fitting member's single upward IS_A edge onto this type through
-`placement.reparent`. The `retype_members` flag is therefore a no-op, kept only
-so the gated-off rollup tier's `retype_members=False` call site still resolves.
+`placement.reparent`.
 
 HCGClient encodes nested properties (name_history) transparently. No `ancestors`
 property is stored: structure (the IS_A edges) is the membership/typing fact,
@@ -62,19 +61,8 @@ def mint_type(
     hcg: Any,
     milvus: Any,
     source_cluster_id: str,
+    # Last-resort default only -- drainage callers always pass a real parent uuid.
     parent_type_uuid: str = "type_entity",
-    # DEPRECATED, unused since the `ancestors` property was removed (B1 T3): kept
-    # only so the gated-off rollup tier's call site still resolves. Removed when
-    # rollup is converted onto placement.py. The `parent_type_uuid="type_entity"`
-    # default is likewise a legacy slug slated for that cleanup -- drainage callers
-    # always pass a real uuid.
-    parent_ancestors: list[str] | None = None,
-    parent_name: str | None = None,
-    # NO-OP since B2/B3: membership is the instance->type IS_A edge, re-pointed by
-    # the draining caller via placement.reparent -- mint_type no longer retypes
-    # members. Kept only so the gated-off rollup tier's `retype_members=False`
-    # call site still resolves; removed when rollup is converted onto placement.py.
-    retype_members: bool = True,
     placed_by: str | None = None,
 ) -> str:
     """Create the type-definition node, seed its centroid, and wire its IS_A edge.

--- a/src/sophia/maintenance/type_rollup_handler.py
+++ b/src/sophia/maintenance/type_rollup_handler.py
@@ -385,8 +385,9 @@ class TypeRollupHandler:
                 ):
                     parent_type_uuid = rooted
                     logger.info(
-                        "type_rollup: rooting super-type %r under %s",
+                        "type_rollup: rooting super-type %r under %s (%s)",
                         name.label,
+                        self._name_of.get(parent_type_uuid, parent_type_uuid),
                         parent_type_uuid,
                     )
             super_uuid = self._match_existing_type(

--- a/src/sophia/maintenance/type_rollup_handler.py
+++ b/src/sophia/maintenance/type_rollup_handler.py
@@ -3,8 +3,9 @@
 A slow-cadence maintenance pass. Emergence mints a wide flat layer of leaf
 type-definitions under `entity` and never revisits it, so the ontology stays
 flat. This pass groups those *types* into super-types. It RE-PARENTS existing
-type-definitions (sets `ancestors` + a single `type->parent IS_A` edge); it never
-retypes instance members.
+type-definitions (re-points the single `type->parent IS_A` edge via
+`placement.reparent`, the only membership-write path); it never retypes instance
+members.
 
 Two tiers, run in order:
   1. **Explicit subsumption lift** -- member relations already cross type
@@ -16,9 +17,9 @@ Two tiers, run in order:
      clustered recursively into super-types via the same `find_emergent_hierarchy`
      used for entity emergence, but with type centroids as the points.
 
-Idempotent: `_reparent_one` change-detects and is a no-op when the type already
-has the right parent/ancestors; super-types reconcile (match-before-mint) so a
-re-run does not duplicate them. Safe to fire on a plain periodic trigger.
+Idempotent: `placement.reparent` is a no-op when the type already has the right
+parent; super-types reconcile (match-before-mint) so a re-run does not duplicate
+them. Safe to fire on a plain periodic trigger.
 """
 
 from __future__ import annotations
@@ -29,6 +30,7 @@ from collections import Counter, defaultdict
 from collections.abc import Callable
 from typing import Any
 
+from sophia.maintenance import placement
 from sophia.maintenance.config import MaintenanceConfig
 from sophia.maintenance.emergence_clustering import find_emergent_hierarchy
 from sophia.maintenance.emergence_handler import _cosine, _type_name
@@ -131,6 +133,10 @@ class TypeRollupHandler:
         # match a coined label and never bypass the reuse / protected-root guards
         # (review #165: case-insensitive lookup on the name->uuid map).
         self._uuid_by_name = {r["name"].strip().lower(): r["uuid"] for r in rows}
+        # The `entity` realm root is the tier-2 fallback parent. Resolve its real
+        # uuid from the name map; the legacy `type_entity` slug is only the
+        # last-resort default (the seeder now mints real uuids).
+        entity_root_uuid = self._uuid_by_name.get("entity") or "type_entity"
 
         # Include the realm roots so Hermes can name one as a super-type's
         # parent: the rollup is the single authority that roots types under
@@ -152,7 +158,7 @@ class TypeRollupHandler:
             and len(r["ancestors"]) <= 3
             and not self._children_of.get(r["uuid"])
         ]
-        self._tier2_residual(residual, candidates)
+        self._tier2_residual(residual, candidates, entity_root_uuid)
 
     # ------------------------------------------------------------------ load
     def _load_type_layer(self) -> list[dict]:
@@ -243,7 +249,7 @@ class TypeRollupHandler:
                 parent, 0
             ):
                 continue
-            self._reparent_one(child, parent, p_row["ancestors"], p_row["name"])
+            self._reparent_one(child, parent)
             explicit_children.add(child)
         if explicit_children:
             logger.info(
@@ -253,6 +259,7 @@ class TypeRollupHandler:
         return explicit_children
 
     def _type_uuid_map(self, node_uuids: list[str]) -> dict[str, str]:
+        # TODO #35: read still infers membership from property; convert to IS_A walk
         # Resolve in chunks: a single get_nodes_batch over every member uuid can
         # exceed query-size/timeout limits on a large graph (gemini #161).
         out: dict[str, str] = {}
@@ -272,7 +279,9 @@ class TypeRollupHandler:
         return out
 
     # ------------------------------------------------------------ tier 2
-    def _tier2_residual(self, residual: list[dict], candidates: list[str]) -> None:
+    def _tier2_residual(
+        self, residual: list[dict], candidates: list[str], entity_root_uuid: str
+    ) -> None:
         if len(residual) < self._config.rollup_min_supercluster_size:
             logger.info(
                 "type_rollup: %d residual types, below supercluster floor",
@@ -304,16 +313,12 @@ class TypeRollupHandler:
             )
             return
         for node in hierarchy:
-            self._reparent_subtree(
-                node, "type_entity", _ENTITY_ANCESTORS, _BASE_TYPE, candidates
-            )
+            self._reparent_subtree(node, entity_root_uuid, candidates)
 
     def _reparent_subtree(
         self,
         node: Any,
         parent_type_uuid: str,
-        parent_ancestors: list[str],
-        parent_name: str,
         candidates: list[str],
     ) -> None:
         """Internal nodes => mint/reuse a super-type; leaves => re-parent the
@@ -322,9 +327,7 @@ class TypeRollupHandler:
             if not node.children:
                 # Leaf: each member is an existing type-def; re-parent it directly.
                 for m in node.members:
-                    self._reparent_one(
-                        m.uuid, parent_type_uuid, parent_ancestors, parent_name
-                    )
+                    self._reparent_one(m.uuid, parent_type_uuid)
                 return
             # Internal node => a super-type over its children.
             name = self._name_fn(
@@ -355,13 +358,7 @@ class TypeRollupHandler:
                     name.label,
                 )
                 for child in node.children:
-                    self._reparent_subtree(
-                        child,
-                        parent_type_uuid,
-                        parent_ancestors,
-                        parent_name,
-                        candidates,
-                    )
+                    self._reparent_subtree(child, parent_type_uuid, candidates)
                 return
             # Root a TOP-LEVEL super-type under the CLOSEST covering type Hermes
             # named -- a realm root (concept / process) OR a deeper existing
@@ -379,14 +376,14 @@ class TypeRollupHandler:
                 rooted = self._resolve_parent(name.parent)
                 if (
                     rooted is not None
-                    and rooted[0] not in member_uuids
-                    and rooted[0] != self._uuid_by_name.get(clean_label)
+                    and rooted not in member_uuids
+                    and rooted != self._uuid_by_name.get(clean_label)
                 ):
-                    parent_type_uuid, parent_ancestors, parent_name = rooted
+                    parent_type_uuid = rooted
                     logger.info(
-                        "type_rollup: rooting super-type %r under %r",
+                        "type_rollup: rooting super-type %r under %s",
                         name.label,
-                        parent_name,
+                        parent_type_uuid,
                     )
             super_uuid = self._match_existing_type(
                 node.centroid, parent_type_uuid, exclude=member_uuids
@@ -427,9 +424,6 @@ class TypeRollupHandler:
                     milvus=self._milvus,
                     source_cluster_id=cid,
                     parent_type_uuid=parent_type_uuid,
-                    parent_ancestors=parent_ancestors,
-                    parent_name=parent_name,
-                    retype_members=False,  # super-type owns no instances
                 )
                 if name.label not in candidates:
                     candidates.append(name.label)
@@ -444,7 +438,6 @@ class TypeRollupHandler:
                             {
                                 "type_uuid": super_uuid,
                                 "name": super_name,
-                                "ancestors": list(parent_ancestors) + [parent_name],
                             },
                         )
                     except Exception:
@@ -460,161 +453,32 @@ class TypeRollupHandler:
                 if super_uuid not in self._children_of[parent_type_uuid]:
                     self._children_of[parent_type_uuid].append(super_uuid)
             else:
-                super_name = (self._hcg.get_node(super_uuid) or {}).get(
-                    "name"
-                ) or _type_name(super_uuid)
                 # The super was REUSED (centroid- or name-match), not minted, so
                 # nothing has placed it under this parent. mint_fn does that for
-                # fresh supers; the reuse paths must do it explicitly or the
-                # super keeps its old position while its new children get
-                # ancestors for the intended one (divergence). Idempotent no-op
-                # when already correct; cycle-guarded if it would loop.
-                self._reparent_one(
-                    super_uuid, parent_type_uuid, parent_ancestors, parent_name
-                )
-            super_ancestors = list(parent_ancestors) + [parent_name]
+                # fresh supers; the reuse paths must do it explicitly or the super
+                # keeps its old position (divergence). Idempotent no-op when
+                # already correct; cycle-guarded if it would loop.
+                self._reparent_one(super_uuid, parent_type_uuid)
             for child in node.children:
-                self._reparent_subtree(
-                    child, super_uuid, super_ancestors, super_name, candidates
-                )
+                self._reparent_subtree(child, super_uuid, candidates)
         except Exception:
             logger.exception("type_rollup: subtree failed, skipping")
 
-    # ----------------------------------------------------- reparent + cascade
-    def _reparent_one(
-        self,
-        child_uuid: str,
-        new_parent_uuid: str,
-        new_parent_ancestors: list[str],
-        new_parent_name: str,
-    ) -> None:
-        """Idempotent re-parent of one type-def + ancestor cascade. No-op when the
-        type already has the right parent and ancestors (the convergence anchor)."""
-        if child_uuid == new_parent_uuid:
-            return
-        if self._creates_cycle(child_uuid, new_parent_uuid):
-            # A cycle means we've claimed subsumption in both directions: the two
-            # types are too alike to order into parent/child. Don't force a
-            # (false) IS_A -- record the pair as a misunderstood, unresolved
-            # relationship so Sophia keeps the signal instead of dropping it.
-            self._record_ambiguous(child_uuid, new_parent_uuid)
-            return
-        target_ancestors = list(new_parent_ancestors) + [new_parent_name]
-        cur = self._hcg.get_node(child_uuid) or {}
-        cur_anc = list((cur.get("properties") or {}).get("ancestors") or [])
-        cur_parent, cur_edge = self._current_is_a(child_uuid)
-        if cur_parent == new_parent_uuid and cur_anc == target_ancestors:
-            return  # already correct -> true no-op
-        # 1. swing the IS_A edge
-        if cur_parent is not None and cur_parent != new_parent_uuid:
-            try:
-                # Drop the stale parent edge by its own id when we have one;
-                # fall back to a (source, target, relation) match when the edge
-                # was persisted without an id/uuid. delete_edge(None) would
-                # silently no-op and leave the old IS_A in place, so the child
-                # would end up with two IS_A parents (greptile #161).
-                if cur_edge:
-                    self._hcg.delete_edge(cur_edge)
-                else:
-                    self._hcg.delete_edges_between(child_uuid, cur_parent, "IS_A")
-                siblings = self._children_of.get(cur_parent)
-                if siblings and child_uuid in siblings:
-                    siblings.remove(child_uuid)
-            except Exception:
-                logger.exception(
-                    "type_rollup: delete stale IS_A failed for %s", child_uuid
-                )
-        if cur_parent != new_parent_uuid:
-            try:
-                self._hcg.add_edge(
-                    child_uuid, new_parent_uuid, "IS_A"
-                )  # MERGE -> idempotent
-                self._children_of.setdefault(new_parent_uuid, [])
-                if child_uuid not in self._children_of[new_parent_uuid]:
-                    self._children_of[new_parent_uuid].append(child_uuid)
-            except Exception:
-                logger.exception("type_rollup: add IS_A failed for %s", child_uuid)
-        # 2. set ancestors
-        if cur_anc != target_ancestors:
-            try:
-                self._hcg.update_node(child_uuid, {"ancestors": target_ancestors})
-            except Exception:
-                logger.exception(
-                    "type_rollup: update ancestors failed for %s", child_uuid
-                )
-        # 3. cascade to descendants
-        child_name = (
-            cur.get("name") or self._name_of.get(child_uuid) or _type_name(child_uuid)
+    # --------------------------------------------------------------- reparent
+    def _reparent_one(self, child_uuid: str, new_parent_uuid: str) -> None:
+        """Re-point one type-def's single upward IS_A edge onto a new parent via
+        the shared placement module (cycle-safe, idempotent). Membership/ancestry
+        is the edge, walked on demand -- nothing below the moved node changes and
+        no `ancestors` property is written (DESIGN sec 3)."""
+        placement.reparent(
+            child_uuid,
+            new_parent_uuid,
+            hcg=self._hcg,
+            children_of=self._children_of,
+            placed_by="parent_resolution",
         )
-        self._cascade_descendants(child_uuid, target_ancestors + [child_name], set())
-
-    def _cascade_descendants(
-        self, node_uuid: str, childrens_ancestors: list[str], seen: set[str]
-    ) -> None:
-        """Top-down recompute of each descendant's ancestors. `childrens_ancestors`
-        is what a direct child of `node_uuid` must have."""
-        if node_uuid in seen:
-            return
-        seen.add(node_uuid)
-        for child in list(self._children_of.get(node_uuid, [])):
-            cn = self._hcg.get_node(child) or {}
-            cur = list((cn.get("properties") or {}).get("ancestors") or [])
-            if cur != childrens_ancestors:
-                try:
-                    self._hcg.update_node(child, {"ancestors": childrens_ancestors})
-                except Exception:
-                    logger.exception("type_rollup: cascade update failed for %s", child)
-            cname = cn.get("name") or self._name_of.get(child) or _type_name(child)
-            self._cascade_descendants(child, childrens_ancestors + [cname], seen)
 
     # ----------------------------------------------------------- helpers
-    def _creates_cycle(self, child_uuid: str, new_parent_uuid: str) -> bool:
-        """True if ``new_parent_uuid`` already sits in ``child_uuid``'s descendant
-        subtree -- making it the parent would close an IS_A loop. Walks the live
-        ``_children_of`` adjacency with a visited guard so it terminates even if
-        the adjacency is already corrupt."""
-        stack = [child_uuid]
-        seen: set[str] = set()
-        while stack:
-            node = stack.pop()
-            if node == new_parent_uuid:
-                return True
-            if node in seen:
-                continue
-            seen.add(node)
-            stack.extend(self._children_of.get(node, []))
-        return False
-
-    def _record_ambiguous(self, a_uuid: str, b_uuid: str) -> None:
-        """Record a would-be-cyclic subsumption as an unresolved relationship.
-
-        A 2-cycle (A IS_A B *and* B IS_A A) is the rollup telling us the two
-        types are too similar to order -- a *misunderstood* relationship, not a
-        hierarchy. We persist a single bidirectional ``AMBIGUOUS_SUBSUMPTION``
-        edge (MERGEd on source/target/relation, with a canonical endpoint order
-        -> idempotent) so the signal survives for later resolution, rather than
-        silently dropping it. tier 1 ignores this relation, so it never feeds
-        back into IS_A."""
-        lo, hi = sorted((a_uuid, b_uuid))
-        try:
-            self._hcg.add_edge(
-                lo,
-                hi,
-                "AMBIGUOUS_SUBSUMPTION",
-                bidirectional=True,
-                properties={"reason": "is_a_cycle", "detected_by": "type_rollup"},
-            )
-            logger.info(
-                "type_rollup: ambiguous subsumption recorded %s <-> %s "
-                "(types too alike to order)",
-                lo,
-                hi,
-            )
-        except Exception:
-            logger.exception(
-                "type_rollup: failed to record ambiguity %s <-> %s", a_uuid, b_uuid
-            )
-
     def _build_is_a_adjacency(self) -> None:
         """parent_uuid -> [child_uuid], from all IS_A edges (child IS_A parent)."""
         self._children_of = defaultdict(list)
@@ -630,28 +494,20 @@ class TypeRollupHandler:
         except Exception:
             logger.exception("type_rollup: build IS_A adjacency failed")
 
-    def _current_is_a(self, child_uuid: str) -> tuple[str | None, str | None]:
-        try:
-            for e in self._hcg.query_edges_from(child_uuid) or []:
-                if e.get("relation") == "IS_A":
-                    return e.get("target"), (e.get("id") or e.get("uuid"))
-        except Exception:
-            logger.exception("type_rollup: query_edges_from failed for %s", child_uuid)
-        return None, None
+    def _resolve_parent(self, parent_name: str) -> str | None:
+        """Resolve a Hermes-named graft parent to a type uuid, or None.
 
-    def _resolve_parent(self, parent_name: str) -> tuple[str, list[str], str] | None:
-        """Resolve a Hermes-named graft parent to ``(type_uuid, ancestors, name)``.
         The parent is the CLOSEST covering type Hermes named -- a realm root OR a
         deeper existing domain type-def -- so a super-type roots as near the
-        cluster as possible ("create the group as close as you can to the cluster
-        name") instead of flat under `entity`. Realm roots are the top-of-chain
-        fallback, not the only allowed parents.
+        cluster as possible instead of flat under `entity`. Realm roots are the
+        top-of-chain fallback, not the only allowed parents.
 
         Returns None for an unresolvable name or a forbidden target, so the caller
         degrades to the default `entity` parent. Forbidden: `cognition` (reserved
         for metacognitive schema induction) and the pure structural roots
         `root`/`node`. The caller adds the cycle guards (member / self / IS_A
-        descendant)."""
+        descendant).
+        """
         target = (parent_name or "").strip().lower()
         if not target:
             return None
@@ -679,27 +535,14 @@ class TypeRollupHandler:
             return None
         if not node:
             return None
-        ancestors = list((node.get("properties") or {}).get("ancestors") or [])
-        if not ancestors:
-            # A seeded realm root's canonical ancestors are [root, node]; for
-            # anything else with no chain, fail closed (degrade to the default
-            # parent) rather than fabricate a truncated chain (review).
-            if uuid in _PROTECTED_ROOT_UUIDS:
-                ancestors = list(_ENTITY_ANCESTORS)
-            else:
-                return None
-        # Invariant: the parent must live within a DOMAIN realm -- a graftable
-        # realm root itself (entity / concept / process) or a descendant of one.
-        # `_is_rollup_candidate` (the source of `_uuid_by_name`) does NOT require a
-        # domain ancestry, so a non-reserved type-def under `cognition` could
-        # otherwise resolve here. Reject anything not rooted in a domain so a
-        # domain super never grafts into the metacognitive (`cognition`) subtree
-        # or onto bare structure.
-        if target not in _GRAFTABLE_REALMS and not (
-            _GRAFTABLE_REALMS & {a.strip().lower() for a in ancestors}
-        ):
+        # Domain-rootedness guard: the resolved type must root in a graftable realm
+        # (entity / concept / process), computed by WALKING IS_A edges upward via
+        # placement.realm_of -- never by reading a forbidden `ancestors` property.
+        # This stops a domain super from grafting into the `cognition` subtree or
+        # onto bare structure.
+        if placement.realm_of(uuid, hcg=self._hcg) is None:
             return None
-        return uuid, ancestors, node.get("name") or target
+        return uuid
 
     def _match_existing_type(
         self,

--- a/src/sophia/maintenance/type_rollup_handler.py
+++ b/src/sophia/maintenance/type_rollup_handler.py
@@ -133,9 +133,13 @@ class TypeRollupHandler:
         # match a coined label and never bypass the reuse / protected-root guards
         # (review #165: case-insensitive lookup on the name->uuid map).
         self._uuid_by_name = {r["name"].strip().lower(): r["uuid"] for r in rows}
-        # The `entity` realm root is the tier-2 fallback parent. Resolve its real
-        # uuid from the name map; the legacy `type_entity` slug is only the
-        # last-resort default (the seeder now mints real uuids).
+        # Tier-2 fallback parent for residual types. Realm roots are NOT in
+        # `_uuid_by_name` (it holds rollup candidates only), so this resolves to
+        # the `type_entity` SLUG today -- which is exactly what the tier-2
+        # top-level check (`parent_type_uuid == f"type_{_BASE_TYPE}"`) keys on.
+        # Against the uuid5 seeder that slug is dangling; reconciling realm roots
+        # to their real uuids is part of un-gating this tier (#35) -- which is
+        # why the tier stays gated OFF (config.rollup_enabled).
         entity_root_uuid = self._uuid_by_name.get("entity") or "type_entity"
 
         # Include the realm roots so Hermes can name one as a super-type's

--- a/tests/integration/test_r1_graft_invariants.py
+++ b/tests/integration/test_r1_graft_invariants.py
@@ -283,6 +283,8 @@ def _seed_member(
     uuid = f"{ns}-{ident}"
     hcg.add_node(name=f"{ns} {ident}", node_type="entity", uuid=uuid, source=f"r1-{ns}")
     # The production retype write: the authoritative current-type pointer.
+    # TODO #27: stamps type_uuid; convert to an IS_A membership edge when this
+    # module-skipped suite is un-skipped (membership is the IS_A edge now).
     hcg.update_node(uuid, {"type": "entity", "type_uuid": type_uuid})
     milvus.members[uuid] = {"embedding": list(embedding), "model": _MODEL}
     return uuid

--- a/tests/maintenance/test_emergence_handler.py
+++ b/tests/maintenance/test_emergence_handler.py
@@ -172,9 +172,9 @@ def test_parent_drives_placement_not_centroid(monkeypatch):
     # The LLM-named parent drives placement; the graph asserts via that parent.
     assert kwargs["parent_type_uuid"] == "vehicle_uuid"
     assert kwargs["placed_by"] == "parent_resolution"
-    # mint no longer retypes; drainage owns member placement via placement.reparent.
-    assert kwargs["retype_members"] is False
-    # Each fitting member's instance->type IS_A edge is re-pointed to the minted
+    # mint no longer retypes; drainage owns member placement via placement.reparent
+    # (the retype_members param is gone). Each fitting member's instance->type
+    # IS_A edge is re-pointed to the minted
     # type, carrying the type's placed_by; no type_uuid property is stamped.
     assert set(hcg.membership_edges()) == {
         ("b0", "boat_uuid"),

--- a/tests/maintenance/test_type_correction.py
+++ b/tests/maintenance/test_type_correction.py
@@ -22,6 +22,8 @@ class FakeHCG:
         self.nodes = {n["uuid"]: dict(n) for n in nodes}
         self.edges = list(edges)
         self.updates = []  # (uuid, props)
+        self._eid = 0
+        self.writes = []  # (op, *args) -- edge writes done by placement.reparent
         # Seeded `entity` realm root (real uuid5), found by name via list_all_nodes.
         self.nodes[_ENTITY_UUID] = {
             "uuid": _ENTITY_UUID,
@@ -51,6 +53,44 @@ class FakeHCG:
         self.updates.append((uuid, dict(properties or {})))
         return uuid
 
+    def get_node(self, uuid):
+        return self.nodes.get(uuid)
+
+    def query_edges_from(self, uuid):
+        return [e for e in self.edges if e["source"] == uuid]
+
+    def add_edge(self, source, target, relation, **kw):
+        # MERGE semantics: dedupe on (source, target, relation).
+        for e in self.edges:
+            if (e["source"], e["target"], e["relation"]) == (source, target, relation):
+                return e.get("id")
+        self._eid += 1
+        eid = f"edge{self._eid}"
+        self.edges.append(
+            {"id": eid, "source": source, "target": target, "relation": relation}
+        )
+        self.writes.append(("add_edge", source, target, relation))
+        return eid
+
+    def delete_edge(self, edge_uuid):
+        self.edges = [e for e in self.edges if e.get("id") != edge_uuid]
+        self.writes.append(("delete_edge", edge_uuid))
+        return True
+
+    def delete_edges_between(self, source, target, relation):
+        before = len(self.edges)
+        self.edges = [
+            e
+            for e in self.edges
+            if not (
+                e["source"] == source
+                and e["target"] == target
+                and e["relation"] == relation
+            )
+        ]
+        self.writes.append(("delete_edges_between", source, target, relation))
+        return before - len(self.edges)
+
 
 def _run(hcg):
     build_type_correction_handler(config=MaintenanceConfig(), hcg=hcg)()
@@ -69,14 +109,21 @@ def test_evicts_part_from_its_same_type_whole():
         ],
     )
     _run(hcg)
-    # the part (source of PART_OF) returns to the junk-drawer
-    assert hcg.nodes["tusk"]["type"] == "entity"
-    assert hcg.nodes["tusk"]["type_uuid"] == _ENTITY_UUID
-    assert hcg.nodes["tusk"]["needs_reclassification"] is True
-    # the whole, and an unrelated peer, are untouched
+    # the part (source of PART_OF) returns to the junk-drawer: its single upward
+    # IS_A membership edge now points at the entity realm root (no type_uuid stamp)
+    assert any(
+        e["source"] == "tusk"
+        and e["target"] == _ENTITY_UUID
+        and e["relation"] == "IS_A"
+        for e in hcg.edges
+    )
+    # the whole, and an unrelated peer, are untouched (no eviction edge)
     assert hcg.nodes["narwhal"]["type"] == "marine_mammal"
     assert hcg.nodes["dolphin"]["type"] == "marine_mammal"
-    assert "dolphin" not in {u for u, _ in hcg.updates}
+    assert not any(
+        e["source"] in {"narwhal", "dolphin"} and e["relation"] == "IS_A"
+        for e in hcg.edges
+    )
 
 
 def test_evicts_product_target_for_production_relation():
@@ -88,8 +135,16 @@ def test_evicts_product_target_for_production_relation():
         ],
     )
     _run(hcg)
-    assert hcg.nodes["acorn"]["type"] == "entity"  # the product leaves
+    # the product (target of PRODUCES) is evicted: its IS_A edge now points at the
+    # entity realm root.
+    assert any(
+        e["source"] == "acorn"
+        and e["target"] == _ENTITY_UUID
+        and e["relation"] == "IS_A"
+        for e in hcg.edges
+    )
     assert hcg.nodes["oak"]["type"] == "flora"  # the producer stays
+    assert not any(e["source"] == "oak" and e["relation"] == "IS_A" for e in hcg.edges)
 
 
 def test_no_eviction_across_different_types():
@@ -104,7 +159,7 @@ def test_no_eviction_across_different_types():
         ],
     )
     _run(hcg)
-    assert hcg.updates == []
+    assert hcg.writes == []  # no eviction edge written
     assert hcg.nodes["tusk"]["type"] == "animal_part"
 
 
@@ -115,7 +170,7 @@ def test_no_eviction_for_base_types():
         edges=[{"id": "r1", "source": "a", "target": "b", "relation": "PART_OF"}],
     )
     _run(hcg)
-    assert hcg.updates == []
+    assert hcg.writes == []  # no eviction edge written
 
 
 def test_no_eviction_for_underscore_cognition_root():
@@ -129,7 +184,7 @@ def test_no_eviction_for_underscore_cognition_root():
         edges=[{"id": "r1", "source": "a", "target": "b", "relation": "PART_OF"}],
     )
     _run(hcg)
-    assert hcg.updates == []
+    assert hcg.writes == []  # no eviction edge written
 
 
 def test_taxonomic_isa_edge_is_not_a_correction():
@@ -139,4 +194,4 @@ def test_taxonomic_isa_edge_is_not_a_correction():
         edges=[{"id": "r1", "source": "x", "target": "y", "relation": "IS_A"}],
     )
     _run(hcg)
-    assert hcg.updates == []
+    assert hcg.writes == []  # no eviction edge written

--- a/tests/maintenance/test_type_minting.py
+++ b/tests/maintenance/test_type_minting.py
@@ -112,8 +112,8 @@ def test_mint_creates_type_node_and_centroid_without_touching_members():
     assert centroid == [1.0, 1.0]
     assert model == "all-MiniLM-L6-v2"
 
-    # Members are NOT touched: no `type_uuid`/`type` stamp (the default
-    # retype_members=True is now a no-op) and no member->type IS_A edge.
+    # Members are NOT touched: no `type_uuid`/`type` stamp and no member->type
+    # IS_A edge (mint owns only the type node, its centroid and its parent edge).
     assert hcg.updated == []
     assert not any(src in {"u1", "u2"} for src, _tgt, _rel in hcg.edges)
 
@@ -213,31 +213,6 @@ def test_mint_does_not_touch_member_is_a_edges():
     # Human-readable label preserved for display/lineage.
     tdef = [n for n in hcg.added_nodes if n["node_type"] == "type_definition"]
     assert tdef[0]["properties"]["name_history"][0]["name"] == "hammer"
-
-
-def test_retype_members_flag_is_a_noop_for_the_gated_rollup_caller():
-    """retype_members is a no-op since B2/B3 (membership moved to the IS_A edge);
-    it is kept only so the gated-off rollup tier's retype_members=False call site
-    still resolves. Either value mints the type node, centroid and IS_A edge and
-    leaves members untouched."""
-    hcg, milvus = FakeHCG(), FakeMilvus()
-    name = NameResult(label="mathematics", description="", confidence=0.8)
-
-    type_uuid = mint_type(
-        _cluster(),
-        name,
-        hcg=hcg,
-        milvus=milvus,
-        source_cluster_id="cl",
-        retype_members=False,
-    )
-
-    # No members were touched.
-    assert hcg.updated == []
-    # The type node, its centroid and the taxonomy IS_A edge still exist.
-    assert any(n["uuid"] == type_uuid for n in hcg.added_nodes)
-    assert type_uuid in milvus.centroids
-    assert (type_uuid, "type_entity", "IS_A") in hcg.edges
 
 
 def test_mint_writes_no_ancestors_property():

--- a/tests/maintenance/test_type_rollup.py
+++ b/tests/maintenance/test_type_rollup.py
@@ -130,23 +130,17 @@ def _handler(hcg, milvus, mint_calls=None, name_label="mathematics"):
         milvus,
         source_cluster_id,
         parent_type_uuid,
-        parent_ancestors,
-        parent_name,
-        retype_members,
     ):
         uuid = f"type_{name.label}_super01"
         hcg.nodes[uuid] = {
             "uuid": uuid,
             "name": name.label,
-            "properties": {
-                "type": "type_definition",
-                "ancestors": list(parent_ancestors) + [parent_name],
-            },
+            "properties": {"type": "type_definition"},
         }
         hcg.add_edge(uuid, parent_type_uuid, "IS_A")
         milvus.update_centroid(uuid, cluster.embeddings[0], "m")
         if mint_calls is not None:
-            mint_calls.append((name.label, parent_type_uuid, retype_members))
+            mint_calls.append((name.label, parent_type_uuid))
         return uuid
 
     return TypeRollupHandler(
@@ -302,12 +296,6 @@ def test_tier1_lifts_explicit_subsumption(monkeypatch):
         and e["relation"] == "IS_A"
         for e in hcg.edges
     )
-    assert hcg.nodes["type_insect_part_bb"]["properties"]["ancestors"] == [
-        "root",
-        "node",
-        "entity",
-        "anatomy",
-    ]
 
 
 def test_tier2_mints_supertype_and_reparents(monkeypatch):
@@ -382,7 +370,7 @@ def test_tier2_mints_supertype_and_reparents(monkeypatch):
     mint_calls = []
     _handler(hcg, milvus, mint_calls=mint_calls).run()
     # a super-type was minted (type-only) and both leaves now sit under it
-    assert mint_calls == [("mathematics", "type_entity", False)]
+    assert mint_calls == [("mathematics", "type_entity")]
     super_uuid = "type_mathematics_super01"
     for leaf_uuid in ("type_calculus_aa", "type_algebra_bb"):
         assert any(
@@ -391,12 +379,6 @@ def test_tier2_mints_supertype_and_reparents(monkeypatch):
             and e["relation"] == "IS_A"
             for e in hcg.edges
         )
-        assert hcg.nodes[leaf_uuid]["properties"]["ancestors"] == [
-            "root",
-            "node",
-            "entity",
-            "mathematics",
-        ]
 
 
 def test_rollup_is_idempotent(monkeypatch):
@@ -497,7 +479,7 @@ def test_cycle_is_recorded_as_ambiguous_not_minted_as_edge():
     h = _handler(hcg, milvus)
     h._build_is_a_adjacency()
     # Try to make b the parent of a -> would close the 2-cycle a->b->a.
-    h._reparent_one("type_a_aa", "type_b_bb", ["root", "node", "entity"], "b")
+    h._reparent_one("type_a_aa", "type_b_bb")
     # No cyclic IS_A edge a->b was created.
     assert not any(
         e["source"] == "type_a_aa"
@@ -688,18 +670,12 @@ def test_reused_super_is_reparented_to_intended_parent(monkeypatch):
         milvus,
         source_cluster_id,
         parent_type_uuid,
-        parent_ancestors,
-        parent_name,
-        retype_members,
     ):
         uuid = f"type_{name.label}_super01"
         hcg.nodes[uuid] = {
             "uuid": uuid,
             "name": name.label,
-            "properties": {
-                "type": "type_definition",
-                "ancestors": list(parent_ancestors) + [parent_name],
-            },
+            "properties": {"type": "type_definition"},
         }
         hcg.add_edge(uuid, parent_type_uuid, "IS_A")
         milvus.update_centroid(uuid, cluster.embeddings[0], "m")
@@ -727,20 +703,13 @@ def test_reused_super_is_reparented_to_intended_parent(monkeypatch):
         and e["relation"] == "IS_A"
         for e in hcg.edges
     )
-    assert hcg.nodes["type_geometry_existing"]["properties"]["ancestors"] == [
-        "root",
-        "node",
-        "entity",
-        "mathematics",
-    ]
-    # and trig sits under geometry with the full chain
-    assert hcg.nodes["type_trig_aa"]["properties"]["ancestors"] == [
-        "root",
-        "node",
-        "entity",
-        "mathematics",
-        "geometry",
-    ]
+    # and trig sits under the reused geometry super
+    assert any(
+        e["source"] == "type_trig_aa"
+        and e["target"] == "type_geometry_existing"
+        and e["relation"] == "IS_A"
+        for e in hcg.edges
+    )
 
 
 def test_centroid_match_never_selects_a_cluster_member_as_its_own_super(monkeypatch):
@@ -826,7 +795,7 @@ def test_centroid_match_never_selects_a_cluster_member_as_its_own_super(monkeypa
     _handler(hcg, milvus, mint_calls=mint_calls).run()
 
     # A fresh super-type was minted (the member was NOT reused as the parent).
-    assert mint_calls == [("mathematics", "type_entity", False)]
+    assert mint_calls == [("mathematics", "type_entity")]
     super_uuid = "type_mathematics_super01"
     # No peer-as-parent edge: a member must never become its sibling's parent.
     assert not any(
@@ -863,9 +832,7 @@ def test_reparent_drops_stale_is_a_even_without_edge_id():
     handler._children_of = {"type_oldparent_xx": ["type_child_aa"]}
     handler._name_of = {"type_child_aa": "child"}
 
-    handler._reparent_one(
-        "type_child_aa", "type_newparent_bb", ["root", "node", "entity"], "newparent"
-    )
+    handler._reparent_one("type_child_aa", "type_newparent_bb")
 
     is_a_targets = [
         e["target"]
@@ -935,22 +902,16 @@ def test_top_level_super_grafts_under_realm_root(monkeypatch):
         milvus,
         source_cluster_id,
         parent_type_uuid,
-        parent_ancestors,
-        parent_name,
-        retype_members,
     ):
         uuid = f"type_{name.label}_super01"
         hcg.nodes[uuid] = {
             "uuid": uuid,
             "name": name.label,
-            "properties": {
-                "type": "type_definition",
-                "ancestors": list(parent_ancestors) + [parent_name],
-            },
+            "properties": {"type": "type_definition"},
         }
         hcg.add_edge(uuid, parent_type_uuid, "IS_A")
         milvus.update_centroid(uuid, cluster.embeddings[0], "m")
-        mint_calls.append((name.label, parent_type_uuid, retype_members))
+        mint_calls.append((name.label, parent_type_uuid))
         return uuid
 
     TypeRollupHandler(
@@ -965,7 +926,7 @@ def test_top_level_super_grafts_under_realm_root(monkeypatch):
     ).run()
 
     # The super-type was rooted under `concept`, not `entity`.
-    assert mint_calls == [("mathematics", "type_concept", False)]
+    assert mint_calls == [("mathematics", "type_concept")]
     super_uuid = "type_mathematics_super01"
     assert any(
         e["source"] == super_uuid
@@ -973,19 +934,14 @@ def test_top_level_super_grafts_under_realm_root(monkeypatch):
         and e["relation"] == "IS_A"
         for e in hcg.edges
     )
-    assert hcg.nodes[super_uuid]["properties"]["ancestors"] == [
-        "root",
-        "node",
-        "concept",
-    ]
     # The realm chain flows down to the leaves.
     for leaf_uuid in ("type_calculus_aa", "type_algebra_bb"):
-        assert hcg.nodes[leaf_uuid]["properties"]["ancestors"] == [
-            "root",
-            "node",
-            "concept",
-            "mathematics",
-        ]
+        assert any(
+            e["source"] == leaf_uuid
+            and e["target"] == super_uuid
+            and e["relation"] == "IS_A"
+            for e in hcg.edges
+        )
 
 
 def test_centroid_match_never_reparents_a_seeded_realm_root(monkeypatch):
@@ -1044,9 +1000,8 @@ def test_centroid_match_never_reparents_a_seeded_realm_root(monkeypatch):
     assert not any(
         e["source"] == "type_concept" and e["relation"] == "IS_A" for e in hcg.edges
     )
-    assert hcg.nodes["type_concept"]["properties"]["ancestors"] == ["root", "node"]
     # A fresh super was minted under entity instead.
-    assert mint_calls == [("mathematics", "type_entity", False)]
+    assert mint_calls == [("mathematics", "type_entity")]
 
 
 def test_resolve_parent_accepts_covering_types_and_rejects_forbidden():
@@ -1067,7 +1022,23 @@ def test_resolve_parent_accepts_covering_types_and_rejects_forbidden():
             "type_metaschema", "metaschema", ["root", "node", "cognition"]
         ),  # under cognition -- NOT domain-rooted
     ]
-    hcg = FakeHCG(tds)
+    # Domain-rootedness is now read by walking IS_A edges (placement.realm_of),
+    # not the stored `ancestors` property: wire each non-root type to its parent.
+    is_a = [
+        {
+            "id": "i1",
+            "source": "type_mathematics",
+            "target": "type_concept",
+            "relation": "IS_A",
+        },
+        {
+            "id": "i2",
+            "source": "type_metaschema",
+            "target": "type_cognition",
+            "relation": "IS_A",
+        },
+    ]
+    hcg = FakeHCG(tds, is_a=is_a)
     handler = _handler(hcg, FakeMilvus({}))
     handler._uuid_by_name = {
         "concept": "type_concept",
@@ -1078,26 +1049,14 @@ def test_resolve_parent_accepts_covering_types_and_rejects_forbidden():
     }
 
     # Realm roots resolve to their canonical seeded uuid + ancestors.
-    assert handler._resolve_parent("concept") == (
-        "type_concept",
-        ["root", "node"],
-        "concept",
-    )
-    assert handler._resolve_parent("process") == (
-        "type_process",
-        ["root", "node"],
-        "process",
-    )
+    assert handler._resolve_parent("concept") == "type_concept"
+    assert handler._resolve_parent("process") == "type_process"
     # A DEEPER domain type Hermes names as the closest cover resolves to that
     # type-def -- the whole point: graft close, not flat under a realm.
-    assert handler._resolve_parent("mathematics") == (
-        "type_mathematics",
-        ["root", "node", "concept"],
-        "mathematics",
-    )
+    assert handler._resolve_parent("mathematics") == "type_mathematics"
     # Casing / whitespace from the LLM does not bypass resolution.
-    assert handler._resolve_parent("  Mathematics ")[0] == "type_mathematics"
-    assert handler._resolve_parent("Concept")[0] == "type_concept"
+    assert handler._resolve_parent("  Mathematics ") == "type_mathematics"
+    assert handler._resolve_parent("Concept") == "type_concept"
 
     # Forbidden: `cognition` is reserved for metacognition, not domain rollup --
     # rejected even though the node exists.
@@ -1189,8 +1148,8 @@ def test_resolve_parent_ignores_shadowing_domain_type():
         "concept": "type_concept_shadow01",  # shadow owns the realm key
         "process": "type_process",
     }
-    assert handler._resolve_parent("concept")[0] == "type_concept"
-    assert handler._resolve_parent("process")[0] == "type_process"
+    assert handler._resolve_parent("concept") == "type_concept"
+    assert handler._resolve_parent("process") == "type_process"
 
 
 def test_top_level_super_grafts_under_deeper_domain_type(monkeypatch):
@@ -1207,7 +1166,16 @@ def test_top_level_super_grafts_under_deeper_domain_type(monkeypatch):
         _td("type_calculus_aa", "calculus", ["root", "node", "entity"]),
         _td("type_algebra_bb", "algebra", ["root", "node", "entity"]),
     ]
-    hcg = FakeHCG(tds)
+    # science roots under concept via an IS_A edge so realm_of walks to a realm.
+    is_a = [
+        {
+            "id": "i1",
+            "source": "type_science_xx",
+            "target": "type_concept",
+            "relation": "IS_A",
+        },
+    ]
+    hcg = FakeHCG(tds, is_a=is_a)
     milvus = FakeMilvus({"type_calculus_aa": [1.0, 0.0], "type_algebra_bb": [0.9, 0.1]})
 
     def _m(uuid, name, vec):
@@ -1249,22 +1217,16 @@ def test_top_level_super_grafts_under_deeper_domain_type(monkeypatch):
         milvus,
         source_cluster_id,
         parent_type_uuid,
-        parent_ancestors,
-        parent_name,
-        retype_members,
     ):
         uuid = f"type_{name.label}_super01"
         hcg.nodes[uuid] = {
             "uuid": uuid,
             "name": name.label,
-            "properties": {
-                "type": "type_definition",
-                "ancestors": list(parent_ancestors) + [parent_name],
-            },
+            "properties": {"type": "type_definition"},
         }
         hcg.add_edge(uuid, parent_type_uuid, "IS_A")
         milvus.update_centroid(uuid, cluster.embeddings[0], "m")
-        mint_calls.append((name.label, parent_type_uuid, retype_members))
+        mint_calls.append((name.label, parent_type_uuid))
         return uuid
 
     TypeRollupHandler(
@@ -1280,7 +1242,7 @@ def test_top_level_super_grafts_under_deeper_domain_type(monkeypatch):
 
     # The super rooted under the DEEPER domain type `science`, not `entity`,
     # and not lifted only as far as the `concept` realm root.
-    assert mint_calls == [("mathematics", "type_science_xx", False)]
+    assert mint_calls == [("mathematics", "type_science_xx")]
     super_uuid = "type_mathematics_super01"
     assert any(
         e["source"] == super_uuid
@@ -1288,9 +1250,3 @@ def test_top_level_super_grafts_under_deeper_domain_type(monkeypatch):
         and e["relation"] == "IS_A"
         for e in hcg.edges
     )
-    assert hcg.nodes[super_uuid]["properties"]["ancestors"] == [
-        "root",
-        "node",
-        "concept",
-        "science",
-    ]


### PR DESCRIPTION
## What

Final write-side cleanup of the naming-driven-typing rework: the rollup (revision) + type-correction maintenance tier now writes membership the same way as everything else — through `placement.py` (`IS_A` edges) — instead of stamping the deprecated `type_uuid`/`ancestors` properties. This removes the **last** instance `type_uuid`-property writes in the codebase.

Membership = the single upward `IS_A` edge, walked at read time. No `type_uuid` property, no stored `ancestors`. (Type nodes' own uuids named in ontology events remain — that's legitimate.)

## Changes

- **`type_correction_handler._evict`** → `placement.reparent(uuid, entity_uuid, placed_by="root_fallback")` instead of `update_node({"type","type_uuid","needs_reclassification"})`.
- **`type_rollup_handler._reparent_one`** → collapsed to `placement.reparent(..., placed_by="parent_resolution")`; deleted now-dead `_cascade_descendants`, `_creates_cycle`, `_record_ambiguous`, `_current_is_a` (placement provides these). `_resolve_parent` returns `str | None` and validates domain-rootedness via `placement.realm_of(...)` (walks edges) instead of reading `ancestors`. Dropped the `ancestors` field from the `ontology.type_created` event payload.
- **`mint_type`** → removed dead params `parent_ancestors`, `parent_name`, `retype_members`; kept `parent_type_uuid` (last-resort default).
- **`emergence_handler`** → dropped the no-op `retype_members=False` from its mint call.
- Tests updated to assert **edge-based** behavior (IS_A repointing) rather than property stamps; FakeHCG gained the edge methods `placement.reparent` needs.

## Verified

- `pytest tests/maintenance/{type_correction,type_minting,type_rollup,emergence_handler}` → **50 passed**
- broad unit suite (`-m "not requires_torch and not integration"`) → **472 passed, 40 skipped**
- ruff / black / mypy on `src/sophia/maintenance/` → clean

## Adversarial review

An independent reviewer returned **SHIP-WITH-NITS** (no blockers):
- **N1 (fixed):** two confidently-wrong comments (the `entity_root_uuid` resolution claim + the `config.rollup_enabled` gate reason) corrected to match reality.
- **N2 (by design):** `AMBIGUOUS_SUBSUMPTION.detected_by` is now `"placement"` rather than `"type_rollup"` — placement is the single membership-write authority, so the generic tag is correct.
- **N3 (deferred):** FakeHCG doesn't assert the `placed_by` edge property; placement's own tests cover that stamping.

## Scope / follow-ups

- **Read paths deferred to #35:** `_type_uuid_map` and the type-correction detection loop still infer membership from the `type`/`type_uuid` property (tagged `# TODO #35`). They're in the **gated-off** rollup/correction tier.
- The tier stays **gated OFF** (`rollup_enabled=False`): it still resolves `type_<name>` slugs for realm roots (dangling against the uuid5 seeder). Reconciling that to real uuids + the read paths above are the un-gating work (#35).

PR-only — not merging.