### PR TITLE
fix: ndt /type-cluster groups parse #37 + emergence same-name dedup #38

### DIFF
--- a/src/sophia/maintenance/emergence_handler.py
+++ b/src/sophia/maintenance/emergence_handler.py
@@ -273,27 +273,31 @@ class EmergenceHandler:
             logger.info("emergence: cluster all outliers, leaving in pool")
             return
 
-        # Cascade (DESIGN sec 6): resolvable parent -> mint under it; else reuse
-        # an in-realm type of the same name; else mint under the realm root.
+        # Cascade (DESIGN sec 6). Dedup FIRST: a same-named type already in this
+        # realm IS this type (identity = name + realm; IS_A defines type), so reuse
+        # it -- route members onto it, never mint a second node. This must run
+        # whether or not Hermes proposed a parent; otherwise a name minted by an
+        # earlier cluster (the uuid_by_name map is updated on each mint) or a prior
+        # pass gets duplicated (#38). Only when no same-name type exists do we
+        # resolve the proposed parent, falling back to the realm root.
         parent_uuid: str | None = None
         placed_by: str | None = None
         reuse_target: str | None = None
-        if tc.parent:
+        existing = uuid_by_name.get(tc.name.strip().lower())
+        if (
+            existing
+            and existing != source_type_uuid
+            and placement.realm_of(existing, hcg=self._hcg) == realm
+        ):
+            reuse_target, placed_by = existing, "name_reuse"
+        elif tc.parent:
             pu = placement.resolve_parent(
                 tc.parent, uuid_by_name=uuid_by_name, hcg=self._hcg, realm=realm
             )
             if pu:
                 parent_uuid, placed_by = pu, "parent_resolution"
-        if parent_uuid is None:
-            existing = uuid_by_name.get(tc.name.strip().lower())
-            if (
-                existing
-                and existing != source_type_uuid
-                and placement.realm_of(existing, hcg=self._hcg) == realm
-            ):
-                reuse_target, placed_by = existing, "name_reuse"
-            else:
-                parent_uuid, placed_by = realm_root_uuid, "root_fallback"
+        if reuse_target is None and parent_uuid is None:
+            parent_uuid, placed_by = realm_root_uuid, "root_fallback"
 
         # The cascade above always settles on a placement reason.
         assert placed_by is not None

--- a/src/sophia/maintenance/hermes_naming.py
+++ b/src/sophia/maintenance/hermes_naming.py
@@ -131,19 +131,35 @@ def type_cluster(
         if not isinstance(data, dict):
             logger.warning("type_cluster returned non-dict JSON: %r", data)
             return None
-        name = str(data.get("name") or "").strip()
-        if not name:
-            logger.warning("type_cluster returned an empty name; treating as failure")
+        # Hermes v2 returns exactly ONE group (the most-specific type it can form
+        # for the cluster; members that blur it are excluded as residuals) under
+        # `groups`, NOT a top-level `name`. The group's IS_A `chain` runs
+        # specific->general with chain[0]==name, so the proposed parent is
+        # chain[1] -- and it is guaranteed to already exist. `parent` is None only
+        # when the group reuses an existing type (assign_to != "NEW"); the handler
+        # then re-points members onto the existing same-name type rather than
+        # minting.
+        groups = data.get("groups")
+        if not isinstance(groups, list) or not groups:
+            logger.warning("type_cluster returned no groups; treating as failure")
             return None
-        parent = data.get("parent")
+        group = groups[0]
+        if not isinstance(group, dict):
+            logger.warning("type_cluster group is not an object; treating as failure")
+            return None
+        name = str(group.get("name") or "").strip()
+        if not name:
+            logger.warning("type_cluster group has no name; treating as failure")
+            return None
+        assign_to = str(group.get("assign_to") or "NEW").strip()
+        chain = group.get("chain")
+        parent: str | None = None
+        if assign_to == "NEW" and isinstance(chain, list) and len(chain) > 1:
+            parent = str(chain[1]).strip() or None
         residual = data.get("residual_ids") or []
         return TypeClusterResult(
             name=name,
-            parent=(
-                str(parent).strip()
-                if isinstance(parent, str) and parent.strip()
-                else None
-            ),
+            parent=parent,
             residual_ids=[str(r) for r in residual if r],
         )
     except (httpx.HTTPError, KeyError, ValueError) as exc:

--- a/src/sophia/maintenance/hermes_naming.py
+++ b/src/sophia/maintenance/hermes_naming.py
@@ -144,6 +144,14 @@ def type_cluster(
             logger.warning("type_cluster returned no groups; treating as failure")
             return None
         group = groups[0]
+        if len(groups) > 1:
+            # Hermes v2 guarantees exactly one group; surface a contract
+            # violation (e.g. a partial batch) rather than silently dropping the
+            # rest.
+            logger.warning(
+                "type_cluster returned %d groups; using only the first",
+                len(groups),
+            )
         if not isinstance(group, dict):
             logger.warning("type_cluster group is not an object; treating as failure")
             return None
@@ -151,12 +159,21 @@ def type_cluster(
         if not name:
             logger.warning("type_cluster group has no name; treating as failure")
             return None
-        assign_to = str(group.get("assign_to") or "NEW").strip()
+        # Coerce to str + strip BEFORE defaulting, so a whitespace-only or
+        # non-string assign_to falls back to "NEW" instead of slipping through
+        # as a falsy value on the existing-type-reuse path.
+        assign_to = str(group.get("assign_to") or "").strip() or "NEW"
         chain = group.get("chain")
         parent: str | None = None
         if assign_to == "NEW" and isinstance(chain, list) and len(chain) > 1:
-            parent = str(chain[1]).strip() or None
-        residual = data.get("residual_ids") or []
+            # chain[1] may be JSON null; guard so it never becomes the literal
+            # string "None" used as a parent name.
+            parent = None if chain[1] is None else (str(chain[1]).strip() or None)
+        residual = data.get("residual_ids")
+        if not isinstance(residual, list):
+            # A non-list residual_ids (string/int from a serialisation glitch)
+            # would iterate char-by-char or raise; treat anything non-list as none.
+            residual = []
         return TypeClusterResult(
             name=name,
             parent=parent,

--- a/tests/integration/test_maintenance_scheduler.py
+++ b/tests/integration/test_maintenance_scheduler.py
@@ -1,11 +1,17 @@
 """Integration test for MaintenanceScheduler with real Redis.
 
-Requires: Redis running on localhost:6379
+Requires: Redis running on localhost:6379.
+
+Uses a dedicated Redis DB (15 by default, override with SOPHIA_TEST_REDIS_URL)
+so the test queue is isolated from a live Sophia instance: its maintenance
+dispatch loop runs on db 0 and would otherwise brpop the jobs these tests
+enqueue out from under them, making pending_count assertions flaky.
 """
 
 from __future__ import annotations
 
 import asyncio
+import os
 from unittest.mock import MagicMock
 
 import pytest
@@ -15,9 +21,13 @@ from sophia.maintenance.config import MaintenanceConfig
 from sophia.maintenance.job_queue import MaintenanceQueue, PRIORITY_ORDER
 from sophia.maintenance.scheduler import MaintenanceScheduler
 
+# Dedicated test DB so a running Sophia (which uses db 0) cannot drain the
+# queue mid-test; override with SOPHIA_TEST_REDIS_URL if db 15 is taken.
+TEST_REDIS_URL = os.environ.get("SOPHIA_TEST_REDIS_URL", "redis://localhost:6379/15")
+
 REDIS_AVAILABLE = False
 try:
-    _r = redis_lib.from_url("redis://localhost:6379/0")
+    _r = redis_lib.from_url(TEST_REDIS_URL)
     _r.ping()
     REDIS_AVAILABLE = True
     _r.close()
@@ -31,7 +41,7 @@ class TestMaintenanceSchedulerIntegration:
     """Integration tests for MaintenanceScheduler against real Redis."""
 
     def setup_method(self) -> None:
-        self.redis = redis_lib.from_url("redis://localhost:6379/0")
+        self.redis = redis_lib.from_url(TEST_REDIS_URL)
         # Clean up all priority queue keys and failed key before each test
         for key in PRIORITY_ORDER:
             self.redis.delete(key)

--- a/tests/maintenance/test_emergence_handler.py
+++ b/tests/maintenance/test_emergence_handler.py
@@ -482,6 +482,56 @@ def test_in_pass_dedup_reuses_fresh_mint(monkeypatch):
     assert hcg.updated == []
 
 
+def test_dedup_reuses_in_realm_type_even_when_parent_proposed(monkeypatch):
+    """#38 regression: a same-name in-realm type is REUSED -- members re-pointed
+    onto it -- even when Hermes proposes a (resolvable) parent. The same-name dedup
+    check runs BEFORE parent resolution, so no duplicate type is minted."""
+    cluster = EmergentCluster(members=[_m("c0"), _m("c1")])
+    monkeypatch.setattr(eh, "find_emergent_clusters", lambda *a, **k: [cluster])
+    # Both the proposed parent (vehicle) AND the same-name type (boat) already
+    # exist in the entity realm. Pre-fix, the resolvable parent would mint a second
+    # boat under vehicle; post-fix the existing boat is reused, never duplicated.
+    hcg = _entity_pool_hcg(
+        extra_type_defs=[
+            {"name": "vehicle", "uuid": "vehicle_uuid"},
+            {"name": "boat", "uuid": "boat_existing_uuid"},
+        ],
+        extra_nodes={
+            "vehicle_uuid": {"uuid": "vehicle_uuid", "name": "vehicle"},
+            "boat_existing_uuid": {"uuid": "boat_existing_uuid", "name": "boat"},
+        },
+        extra_edges={
+            "vehicle_uuid": [{"relation": "IS_A", "target": "entity_root"}],
+            "boat_existing_uuid": [{"relation": "IS_A", "target": "entity_root"}],
+        },
+    )
+    _park(hcg, "c0", "c1")
+    minted = []
+    handler = _handler(
+        hcg,
+        _RecordingMilvus(),
+        name_fn=lambda c: TypeClusterResult(
+            name="boat", parent="vehicle", residual_ids=[]
+        ),
+        mint_fn=lambda *a, **k: minted.append(1),
+    )
+    handler.run(type_uuid="entity_root")
+
+    # A parent WAS proposed, but the same-name in-realm boat already exists ->
+    # reuse it (re-point member edges); never mint a duplicate (#38).
+    assert minted == []
+    assert set(hcg.membership_edges()) == {
+        ("c0", "boat_existing_uuid"),
+        ("c1", "boat_existing_uuid"),
+    }
+    assert all(
+        props == {"placed_by": "name_reuse"}
+        for _s, _t, rel, props in hcg.added_edges
+        if rel == "IS_A"
+    )
+    assert hcg.updated == []
+
+
 def test_mint_publishes_event_without_ancestors(monkeypatch):
     cluster = EmergentCluster(members=[_m("a0"), _m("a1")])
     monkeypatch.setattr(eh, "find_emergent_clusters", lambda *a, **k: [cluster])

--- a/tests/maintenance/test_hermes_naming.py
+++ b/tests/maintenance/test_hermes_naming.py
@@ -145,12 +145,25 @@ def test_name_cluster_sends_all_when_under_max(monkeypatch):
 
 
 def test_type_cluster_posts_and_parses(monkeypatch):
+    """A NEW group: name + parent chain index 1 + TOP-LEVEL residual_ids parsed out
+    of the hermes v2 groups envelope, not a flat top-level name."""
     captured = {}
 
     def fake_post(url, json=None, headers=None, timeout=None):
         captured.update(url=url, json=json, headers=headers)
         return _FakeResp(
-            {"name": "vehicle", "parent": "entity", "residual_ids": ["m3"]}
+            {
+                "groups": [
+                    {
+                        "assign_to": "NEW",
+                        "name": "vehicle",
+                        "chain": ["vehicle", "object", "entity"],
+                        "member_ids": ["m1", "m2"],
+                    }
+                ],
+                "residual_ids": ["m3"],
+                "raw_partition_ok": True,
+            }
         )
 
     monkeypatch.setattr(hn.httpx, "post", fake_post)
@@ -161,8 +174,10 @@ def test_type_cluster_posts_and_parses(monkeypatch):
         token="t",
     )
 
+    # name == the group name; parent == chain index 1 (proposed guaranteed-existing
+    # super); residual_ids come from the TOP level, not the group.
     assert result == TypeClusterResult(
-        name="vehicle", parent="entity", residual_ids=["m3"]
+        name="vehicle", parent="object", residual_ids=["m3"]
     )
     assert captured["url"].endswith("/type-cluster")
     assert captured["headers"]["Authorization"] == "Bearer t"
@@ -176,9 +191,41 @@ def test_type_cluster_posts_and_parses(monkeypatch):
     assert member["hermes_type_hint"] == "concept"
 
 
-def test_type_cluster_parent_null_and_missing_residuals(monkeypatch):
+def test_type_cluster_existing_type_reuse_has_no_parent(monkeypatch):
+    """An EXISTING-type group (assign_to is a uuid, not NEW) proposes no parent:
+    the handler re-points members onto the existing same-name type rather than
+    minting, so chain index 1 is ignored and parent is None."""
+
     def fake_post(url, json=None, headers=None, timeout=None):
-        return _FakeResp({"name": "concept", "parent": None})
+        return _FakeResp(
+            {
+                "groups": [
+                    {
+                        "assign_to": "11111111-2222-3333-4444-555555555555",
+                        "name": "vehicle",
+                        "chain": ["vehicle"],
+                    }
+                ],
+                "residual_ids": [],
+            }
+        )
+
+    monkeypatch.setattr(hn.httpx, "post", fake_post)
+
+    result = hn.type_cluster(_cluster(), hermes_url="http://h", token="t")
+    assert result is not None
+    assert result.name == "vehicle"
+    assert result.parent is None
+    assert result.residual_ids == []
+
+
+def test_type_cluster_new_group_single_element_chain_has_no_parent(monkeypatch):
+    """A NEW group whose chain holds only the type itself (no super) gives None."""
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        return _FakeResp(
+            {"groups": [{"assign_to": "NEW", "name": "concept", "chain": ["concept"]}]}
+        )
 
     monkeypatch.setattr(hn.httpx, "post", fake_post)
 
@@ -189,15 +236,33 @@ def test_type_cluster_parent_null_and_missing_residuals(monkeypatch):
     assert result.residual_ids == []
 
 
+def test_type_cluster_no_groups_key_returns_none(monkeypatch):
+    def fake_post(url, json=None, headers=None, timeout=None):
+        return _FakeResp({"residual_ids": [], "raw_partition_ok": True})
+
+    monkeypatch.setattr(hn.httpx, "post", fake_post)
+    assert hn.type_cluster(_cluster(), hermes_url="http://h", token="t") is None
+
+
+def test_type_cluster_empty_groups_returns_none(monkeypatch):
+    def fake_post(url, json=None, headers=None, timeout=None):
+        return _FakeResp({"groups": [], "residual_ids": []})
+
+    monkeypatch.setattr(hn.httpx, "post", fake_post)
+    assert hn.type_cluster(_cluster(), hermes_url="http://h", token="t") is None
+
+
 def test_type_cluster_empty_name_returns_none(monkeypatch):
     def fake_post(url, json=None, headers=None, timeout=None):
-        return _FakeResp({"name": "", "parent": "entity"})
+        return _FakeResp(
+            {"groups": [{"assign_to": "NEW", "name": "", "chain": ["", "entity"]}]}
+        )
 
     monkeypatch.setattr(hn.httpx, "post", fake_post)
     # Spy on the module logger directly rather than via caplog: in a full-suite
-    # run the app's logging config can disable propagation to caplog's root
-    # handler, so the (emitted) warning isn't captured -- a CI-only flake. The
-    # contract is `result is None` AND a warning was logged.
+    # run the app logging config can disable propagation to caplog root handler,
+    # so the (emitted) warning is not captured -- a CI-only flake. The contract
+    # is result is None AND a warning was logged.
     warnings: list[tuple] = []
     monkeypatch.setattr(hn.logger, "warning", lambda *a, **k: warnings.append((a, k)))
     result = hn.type_cluster(_cluster(), hermes_url="http://h", token="t")
@@ -213,9 +278,11 @@ def test_type_cluster_returns_none_on_non_dict_json(monkeypatch):
     assert hn.type_cluster(_cluster(), hermes_url="http://h", token="t") is None
 
 
-def test_type_cluster_missing_name_returns_none(monkeypatch):
+def test_type_cluster_group_missing_name_returns_none(monkeypatch):
     def fake_post(url, json=None, headers=None, timeout=None):
-        return _FakeResp({"parent": "entity", "residual_ids": []})
+        return _FakeResp(
+            {"groups": [{"assign_to": "NEW", "chain": ["vehicle"]}], "residual_ids": []}
+        )
 
     monkeypatch.setattr(hn.httpx, "post", fake_post)
     assert hn.type_cluster(_cluster(), hermes_url="http://h", token="t") is None
@@ -235,7 +302,7 @@ def test_type_cluster_returns_none_on_http_status_error(monkeypatch):
             raise httpx.HTTPError("500 server error")
 
         def json(self):
-            return {"name": "vehicle"}
+            return {"groups": [{"assign_to": "NEW", "name": "vehicle"}]}
 
     def fake_post(*args, **kwargs):
         return _FakeBadStatusResp()

--- a/tests/maintenance/test_hermes_naming.py
+++ b/tests/maintenance/test_hermes_naming.py
@@ -309,3 +309,99 @@ def test_type_cluster_returns_none_on_http_status_error(monkeypatch):
 
     monkeypatch.setattr(hn.httpx, "post", fake_post)
     assert hn.type_cluster(_cluster(), hermes_url="http://h", token="t") is None
+
+
+def test_type_cluster_null_chain_entry_yields_no_parent(monkeypatch):
+    """A JSON null at chain[1] must NOT become the literal string "None" as a
+    parent name; it should resolve to parent=None."""
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        return _FakeResp(
+            {
+                "groups": [
+                    {
+                        "assign_to": "NEW",
+                        "name": "vehicle",
+                        "chain": ["vehicle", None, "entity"],
+                    }
+                ],
+                "residual_ids": [],
+            }
+        )
+
+    monkeypatch.setattr(hn.httpx, "post", fake_post)
+    result = hn.type_cluster(_cluster(), hermes_url="http://h", token="t")
+    assert result == TypeClusterResult(name="vehicle", parent=None, residual_ids=[])
+
+
+def test_type_cluster_non_list_residual_ids_ignored(monkeypatch):
+    """A non-list residual_ids (e.g. a bare string from a serialisation glitch)
+    must not be iterated char-by-char; it is treated as no residuals."""
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        return _FakeResp(
+            {
+                "groups": [
+                    {
+                        "assign_to": "NEW",
+                        "name": "vehicle",
+                        "chain": ["vehicle", "object"],
+                    }
+                ],
+                "residual_ids": "m3",
+            }
+        )
+
+    monkeypatch.setattr(hn.httpx, "post", fake_post)
+    result = hn.type_cluster(_cluster(), hermes_url="http://h", token="t")
+    assert result == TypeClusterResult(name="vehicle", parent="object", residual_ids=[])
+
+
+def test_type_cluster_whitespace_assign_to_treated_as_new(monkeypatch):
+    """A whitespace-only assign_to is a missing value, not an existing-type
+    reuse: it must default to NEW so the parent is taken from the chain."""
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        return _FakeResp(
+            {
+                "groups": [
+                    {
+                        "assign_to": "   ",
+                        "name": "vehicle",
+                        "chain": ["vehicle", "object", "entity"],
+                    }
+                ],
+                "residual_ids": [],
+            }
+        )
+
+    monkeypatch.setattr(hn.httpx, "post", fake_post)
+    result = hn.type_cluster(_cluster(), hermes_url="http://h", token="t")
+    assert result == TypeClusterResult(name="vehicle", parent="object", residual_ids=[])
+
+
+def test_type_cluster_multiple_groups_uses_first_and_warns(monkeypatch):
+    """Hermes v2 guarantees one group; if more arrive, use the first but log a
+    warning so the contract violation is observable."""
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        return _FakeResp(
+            {
+                "groups": [
+                    {
+                        "assign_to": "NEW",
+                        "name": "vehicle",
+                        "chain": ["vehicle", "object"],
+                    },
+                    {"assign_to": "NEW", "name": "boat", "chain": ["boat", "object"]},
+                ],
+                "residual_ids": [],
+            }
+        )
+
+    monkeypatch.setattr(hn.httpx, "post", fake_post)
+    warnings: list[tuple] = []
+    monkeypatch.setattr(hn.logger, "warning", lambda *a, **k: warnings.append((a, k)))
+    result = hn.type_cluster(_cluster(), hermes_url="http://h", token="t")
+    assert result == TypeClusterResult(name="vehicle", parent="object", residual_ids=[])
+    assert warnings  # the >1-group contract violation was logged


### PR DESCRIPTION
## Summary

Two fixes that together unblocked Naming-Driven Typing emergence. Both were validated live by emergence runs that produced a clean 214-type ontology.

### #37 -- Sophia /type-cluster client parses the Hermes v2 groups[] contract

`src/sophia/maintenance/hermes_naming.py` `type_cluster` now parses the Hermes v2 response envelope `{groups: [{assign_to, name, chain, member_ids, ...}], residual_ids, raw_partition_ok}` instead of a flat top-level `{name, parent, residual_ids}` that Hermes never sent.

- Reads `groups[0]` -- Hermes returns exactly one group.
- `name = groups[0].name`.
- `parent = chain[1]` when `assign_to == NEW` and `len(chain) > 1`; otherwise `None`. An existing-type reuse where `assign_to != NEW` proposes no parent.
- `residual_ids` is taken from the top level.
- Returns `None` on: no `groups` key, empty `groups`, non-object group, or missing/empty group name -- plus the existing connect-error / HTTP-status / non-dict-JSON guards.

### #38 -- Emergence reuses a same-name in-realm type instead of minting a duplicate

`src/sophia/maintenance/emergence_handler.py` `_place_cluster`: the same-name-in-realm reuse check is hoisted to run BEFORE the parent cascade. An existing in-realm type of the same name is now reused -- members re-pointed onto it with `placed_by=name_reuse` -- regardless of whether Hermes proposed a parent. A new type is minted only when no same-name in-realm type exists. This stops duplicate type nodes when a name was minted by an earlier cluster in the same pass or a prior pass.

## Tests

`tests/maintenance/test_hermes_naming.py` -- rewrote the `type_cluster` tests to the v2 groups[] shape: NEW group gives name + parent from chain[1] + top-level residual_ids; existing-type reuse group gives parent None; new-group single-element chain gives parent None; no groups key / empty groups give None; empty group name / group missing name give None; kept the connect-error / HTTP-status / non-dict-JSON guards.

`tests/maintenance/test_emergence_handler.py` -- added `test_dedup_reuses_in_realm_type_even_when_parent_proposed`: a same-name in-realm type is reused with members re-pointed and `placed_by=name_reuse`, and `mint_fn` is NOT called even though a parent was proposed.

## Verification

- `pytest tests/maintenance/` -- 148 passed.
- broad `pytest -m \"not requires_torch and not integration\"` -- 471 passed. The only reds are 6 pre-existing Redis-dependent integration tests in `test_maintenance_scheduler.py`, unrelated to this change; they fail identically with these test edits stashed.
- ruff / black --check / mypy on the touched modules -- clean.