### PR TITLE
sophia#190: publish descriptive-relation snapshot to Redis (logos:ontology:relations)

### DIFF
--- a/src/sophia/hcg_client/client.py
+++ b/src/sophia/hcg_client/client.py
@@ -374,8 +374,7 @@ class HCGClient(LogosHCGClient):
         """
         records = self._execute_read(query, {"reserved": self._RESERVED_RELATIONS})
         return [
-            {"relation": r["relation"], "edge_count": r["edge_count"]}
-            for r in records
+            {"relation": r["relation"], "edge_count": r["edge_count"]} for r in records
         ]
 
     def get_node(self, uuid: str) -> Optional[Dict[str, Any]]:

--- a/src/sophia/hcg_client/client.py
+++ b/src/sophia/hcg_client/client.py
@@ -349,6 +349,31 @@ class HCGClient(LogosHCGClient):
             return str(result[0]["uuid"])
         return edge_id
 
+    # Reserved typing relations: structural type-system scaffolding, never
+    # part of the descriptive-relation vocabulary that Hermes consolidates
+    # (hermes#131 hard constraint).
+    _RESERVED_RELATIONS = ["IS_A", "INSTANCE_OF", "SUBTYPE_OF"]
+
+    def get_relation_vocabulary(self) -> List[Dict[str, Any]]:
+        """Distinct DESCRIPTIVE relation labels with edge counts.
+
+        Reads the reified edge layer (edge nodes carry a ``relation``
+        property) and excludes the reserved typing relations. Powers the
+        ``logos:ontology:relations`` Redis snapshot consumed by Hermes for
+        cross-process match-before-mint (sophia#190 / hermes#137).
+        """
+        query = """
+        MATCH (e:Node)
+        WHERE e.relation IS NOT NULL AND NOT e.relation IN $reserved
+        RETURN e.relation AS relation, count(*) AS edge_count
+        ORDER BY edge_count DESC
+        """
+        records = self._execute_read(query, {"reserved": self._RESERVED_RELATIONS})
+        return [
+            {"relation": r["relation"], "edge_count": r["edge_count"]}
+            for r in records
+        ]
+
     def get_node(self, uuid: str) -> Optional[Dict[str, Any]]:
         """Fetch a content node by uuid.
 

--- a/src/sophia/hcg_client/client.py
+++ b/src/sophia/hcg_client/client.py
@@ -362,9 +362,13 @@ class HCGClient(LogosHCGClient):
         ``logos:ontology:relations`` Redis snapshot consumed by Hermes for
         cross-process match-before-mint (sophia#190 / hermes#137).
         """
+        # e.type = 'edge' is redundant with `relation IS NOT NULL` (the
+        # codebase convention) but makes the intent explicit and guards
+        # against a content node ever acquiring a `relation` property.
         query = """
         MATCH (e:Node)
-        WHERE e.relation IS NOT NULL AND NOT e.relation IN $reserved
+        WHERE e.type = 'edge' AND e.relation IS NOT NULL
+              AND NOT e.relation IN $reserved
         RETURN e.relation AS relation, count(*) AS edge_count
         ORDER BY edge_count DESC
         """

--- a/src/sophia/ingestion/proposal_processor.py
+++ b/src/sophia/ingestion/proposal_processor.py
@@ -216,6 +216,28 @@ class ProposalProcessor:
         except Exception:
             logger.exception("Failed to write type snapshot to Redis")
 
+    def _write_relation_snapshot(self) -> None:
+        """Write the descriptive-relation vocabulary to Redis for Hermes sync.
+
+        Edge-axis analog of _write_type_snapshot: publishes the distinct
+        descriptive relations (reserved typing relations excluded by the HCG
+        query) to ``logos:ontology:relations`` so Hermes can seed
+        match-before-mint cross-process (sophia#190 / hermes#137). Fail-soft.
+        """
+        if self._redis is None:
+            return
+        try:
+            records = self._hcg.get_relation_vocabulary()
+            snapshot: dict[str, dict[str, Any]] = {}
+            for record in records:
+                relation = record.get("relation", "")
+                if not relation:
+                    continue
+                snapshot[relation] = {"edge_count": record.get("edge_count", 0)}
+            self._redis.set("logos:ontology:relations", json.dumps(snapshot))
+        except Exception:
+            logger.exception("Failed to write relation snapshot to Redis")
+
     def process(self, proposal: dict) -> dict:
         """Process a proposal: search for context, decide what to ingest."""
         stored_ids: list[str] = []
@@ -640,10 +662,14 @@ class ProposalProcessor:
                     failures=embedding_failures,
                 )
 
-            # Write type snapshot BEFORE publishing event so subscribers
-            # see up-to-date data when they react to the event.
+            # Write type + relation snapshots BEFORE publishing event so
+            # subscribers see up-to-date data when they react to the event.
             if new_types or updated_types:
                 self._write_type_snapshot()
+            # New edges may introduce new descriptive relations -> refresh the
+            # relation vocabulary snapshot Hermes seeds from (sophia#190).
+            if stored_edge_ids:
+                self._write_relation_snapshot()
 
             # Publish batch event summarising what changed.
             if stored_ids or stored_edge_ids or new_types or updated_types:

--- a/tests/unit/hcg_client/test_client_wrapper.py
+++ b/tests/unit/hcg_client/test_client_wrapper.py
@@ -496,6 +496,7 @@ def test_get_relation_vocabulary_excludes_reserved_and_returns_counts(
         {"relation": "PRODUCES", "edge_count": 5},
     ]
     query, params = read.call_args[0][0], read.call_args[0][1]
+    assert "e.type = 'edge'" in query
     assert "e.relation IS NOT NULL" in query
     assert "NOT e.relation IN $reserved" in query
     assert params["reserved"] == ["IS_A", "INSTANCE_OF", "SUBTYPE_OF"]

--- a/tests/unit/hcg_client/test_client_wrapper.py
+++ b/tests/unit/hcg_client/test_client_wrapper.py
@@ -474,3 +474,36 @@ def test_delete_edges_between_returns_zero_when_no_match(
     """No matching edge -> zero removed (empty result is handled)."""
     monkeypatch.setattr(client, "_execute_query", MagicMock(return_value=[]))
     assert client.delete_edges_between("src", "tgt", "IS_A") == 0
+
+
+def test_get_relation_vocabulary_excludes_reserved_and_returns_counts(
+    monkeypatch: pytest.MonkeyPatch, client: HCGClient
+) -> None:
+    """get_relation_vocabulary queries descriptive relations with counts and
+    excludes the reserved typing relations (sophia#190 / hermes#137)."""
+    read = MagicMock(
+        return_value=[
+            {"relation": "LOCATED_IN", "edge_count": 12},
+            {"relation": "PRODUCES", "edge_count": 5},
+        ]
+    )
+    monkeypatch.setattr(client, "_execute_read", read)
+
+    vocab = client.get_relation_vocabulary()
+
+    assert vocab == [
+        {"relation": "LOCATED_IN", "edge_count": 12},
+        {"relation": "PRODUCES", "edge_count": 5},
+    ]
+    query, params = read.call_args[0][0], read.call_args[0][1]
+    assert "e.relation IS NOT NULL" in query
+    assert "NOT e.relation IN $reserved" in query
+    assert params["reserved"] == ["IS_A", "INSTANCE_OF", "SUBTYPE_OF"]
+
+
+def test_get_relation_vocabulary_handles_empty(
+    monkeypatch: pytest.MonkeyPatch, client: HCGClient
+) -> None:
+    """No descriptive edges -> empty list, no error."""
+    monkeypatch.setattr(client, "_execute_read", MagicMock(return_value=[]))
+    assert client.get_relation_vocabulary() == []

--- a/tests/unit/ingestion/test_proposal_processor.py
+++ b/tests/unit/ingestion/test_proposal_processor.py
@@ -1318,6 +1318,58 @@ class TestProposalProcessorRedisSnapshot:
         assert value["concept"]["uuid"] == "type_concept"
         assert value["concept"]["member_count"] == 3
 
+    def test_write_relation_snapshot_writes_descriptive_relations(self):
+        """_write_relation_snapshot writes the descriptive-relation vocabulary
+        to logos:ontology:relations (sophia#190 / hermes#131)."""
+        import json
+
+        processor, mock_hcg, _, _, mock_redis = self._make_processor_with_redis()
+        mock_hcg.get_relation_vocabulary.return_value = [
+            {"relation": "LOCATED_IN", "edge_count": 12},
+            {"relation": "PRODUCES", "edge_count": 5},
+        ]
+
+        processor._write_relation_snapshot()
+
+        mock_redis.set.assert_called_once()
+        key = mock_redis.set.call_args[0][0]
+        assert key == "logos:ontology:relations"
+        value = json.loads(mock_redis.set.call_args[0][1])
+        assert value["LOCATED_IN"]["edge_count"] == 12
+        assert value["PRODUCES"]["edge_count"] == 5
+
+    def test_write_relation_snapshot_skips_without_redis(self):
+        """No Redis client -> no relation snapshot, no HCG query."""
+        from sophia.ingestion.proposal_processor import ProposalProcessor
+
+        mock_hcg = MagicMock()
+        processor = ProposalProcessor(mock_hcg, MagicMock())
+        processor._write_relation_snapshot()
+        mock_hcg.get_relation_vocabulary.assert_not_called()
+
+    def test_write_relation_snapshot_survives_redis_failure(self):
+        """A Redis failure during the relation snapshot is swallowed."""
+        processor, mock_hcg, _, _, mock_redis = self._make_processor_with_redis()
+        mock_hcg.get_relation_vocabulary.return_value = [
+            {"relation": "LOCATED_IN", "edge_count": 1}
+        ]
+        mock_redis.set.side_effect = RuntimeError("Redis down")
+        # must not raise
+        processor._write_relation_snapshot()
+
+    def test_relation_snapshot_drops_blank_relations(self):
+        """Defensive: a record with an empty relation name is skipped."""
+        import json
+
+        processor, mock_hcg, _, _, mock_redis = self._make_processor_with_redis()
+        mock_hcg.get_relation_vocabulary.return_value = [
+            {"relation": "", "edge_count": 9},
+            {"relation": "USED_IN", "edge_count": 2},
+        ]
+        processor._write_relation_snapshot()
+        value = json.loads(mock_redis.set.call_args[0][1])
+        assert "USED_IN" in value and "" not in value
+
     def test_process_no_redis_client_skips_snapshot(self):
         """process() skips type snapshot when redis_client is None."""
         from sophia.ingestion.proposal_processor import ProposalProcessor


### PR DESCRIPTION
Closes #190. Program: c-daly/logos#557 · Unblocks c-daly/hermes#137 (H4) of epic c-daly/hermes#131. First PR against sophia `epic/nl-extraction`.

## What

The edge-axis counterpart of `_write_type_snapshot`. Sophia already syncs the type catalog to Hermes via Redis (`logos:ontology:types` → Hermes `TypeRegistry`, reloaded on the `proposal_processed` event). This gives the **relation** vocabulary the same closed, cross-process, event-fresh loop — no new transport.

- `HCGClient.get_relation_vocabulary()` — distinct descriptive relations + edge counts from the reified edge layer (`Node{type:'edge'}` `relation`), **excluding** the reserved typing relations `IS_A`/`INSTANCE_OF`/`SUBTYPE_OF` (epic hermes#131 hard constraint — those are structural, never consolidated).
- `proposal_processor._write_relation_snapshot()` — publishes `{relation: {edge_count: N}}` to `logos:ontology:relations`, written in the batch path **when edges were stored**, before the `proposal_processed` event (same snapshot-before-event ordering the type path uses). Fail-soft on Redis/HCG error.

## Why this shape (not an HTTP fetch)

Hermes consumes the type snapshot from Redis and reloads on the EventBus event; publishing relations the same way means H4's seeding is cross-process for free and stays fresh as new relations are minted — the loop closes through Redis. (Credit: the HTTP-fetch design was caught and corrected during ticketing.)

## Tests

6 snapshot tests (writes descriptive relations, skips without Redis, survives Redis failure, drops blank names) + 2 client tests (reserved excluded, empty handled). 75 passed in the proposal-processor + client suites.

## Next

H4 (hermes#137) consumes this key: a `RelationRegistry` mirroring `TypeRegistry` seeds `PredicateVocabulary` at startup and reloads on `proposal_processed`.