### PR TITLE
sophia#192: relation-vocabulary rollup — cluster, name synonyms, consolidate

### DIFF
--- a/scripts/run_relation_rollup_trigger.py
+++ b/scripts/run_relation_rollup_trigger.py
@@ -1,0 +1,100 @@
+"""One-shot trigger for the relation-vocabulary rollup on the live graph.
+
+Uses the disk-cached embeddings (no re-embedding -> no OpenAI rate-limit
+risk), the live /relation-synonyms endpoint, and the live graph for
+consolidation. Bounded to a deterministic 350-relation slice. Writes the
+before/after df=1 result to /tmp/rollup_result.txt.
+"""
+
+import json
+import os
+import random
+import time
+
+import httpx
+
+from sophia.hcg_client.client import HCGClient
+from sophia.maintenance.hermes_naming import relation_synonyms
+from sophia.maintenance.relation_rollup_handler import RelationRollupHandler
+
+OUT = "/tmp/rollup_result.txt"
+CACHE = "/tmp/rel_emb_cache.json"
+
+
+def log(msg):
+    with open(OUT, "a") as f:
+        f.write(msg + "\n")
+    print(msg, flush=True)
+
+
+def df1(vocab):
+    d = len(vocab)
+    o = sum(1 for v in vocab if v["edge_count"] == 1)
+    return d, o, (o / d if d else 0.0)
+
+
+def main():
+    open(OUT, "w").close()
+    hcg = HCGClient(
+        neo4j_uri="bolt://localhost:7687",
+        neo4j_username="neo4j",
+        neo4j_password="logosdev",
+    )
+    full = hcg.get_relation_vocabulary()
+    bd, bo, bf = df1(full)
+    log(f"BEFORE (full graph): {bd} distinct, df=1={bo} ({bf:.3f})")
+
+    by_count = sorted(full, key=lambda v: -v["edge_count"])
+    heads = [v["relation"] for v in by_count[:100]]
+    tail = [v["relation"] for v in by_count if v["edge_count"] == 1]
+    random.Random(7).shuffle(tail)
+    candidates = heads + tail[:250]
+    counts = {v["relation"]: v["edge_count"] for v in full}
+
+    cache = json.load(open(CACHE)) if os.path.exists(CACHE) else {}
+
+    def embed_fn(labels):
+        missing = [l for l in labels if l not in cache]
+        if missing:
+            raise RuntimeError(
+                f"{len(missing)} labels not cached; refusing to embed live"
+            )
+        return [cache[l] for l in labels]
+
+    def synonym_fn(preds, context=None):
+        return relation_synonyms(
+            preds, hermes_url="http://localhost:17000", token="", context=context
+        )
+
+    hcg.get_relation_vocabulary = lambda: [
+        {"relation": r, "edge_count": counts[r]} for r in candidates
+    ]
+    handler = RelationRollupHandler(
+        hcg,
+        embed_fn=embed_fn,
+        synonym_fn=synonym_fn,
+        min_confidence=0.6,
+        cluster_threshold=0.5,
+        max_cluster_size=40,
+    )
+    t = time.time()
+    summary = handler.run()
+    log(f"rollup summary: {summary} in {time.time() - t:.0f}s")
+
+    hcg2 = HCGClient(
+        neo4j_uri="bolt://localhost:7687",
+        neo4j_username="neo4j",
+        neo4j_password="logosdev",
+    )
+    after = hcg2.get_relation_vocabulary()
+    ad, ao, af = df1(after)
+    log(f"AFTER  (full graph): {ad} distinct, df=1={ao} ({af:.3f})  gate<0.25")
+    log(
+        f"DELTA: distinct {bd}->{ad} ({bd - ad} consolidated); "
+        f"df=1 {bf:.3f}->{af:.3f}; L_model relation bits saved {16 * (bd - ad):,}"
+    )
+    log("DONE")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/sophia/hcg_client/client.py
+++ b/src/sophia/hcg_client/client.py
@@ -354,6 +354,48 @@ class HCGClient(LogosHCGClient):
     # (hermes#131 hard constraint).
     _RESERVED_RELATIONS = ["IS_A", "INSTANCE_OF", "SUBTYPE_OF"]
 
+    def rename_relation(self, old: str, new: str) -> int:
+        """Rewrite every descriptive edge with relation ``old`` to ``new``.
+
+        The consolidation primitive for the relation-vocabulary rollup
+        (sophia#192). Dedup-safe: an old edge whose (source, target, ``new``)
+        triple already exists is deleted rather than duplicating the
+        (source, target, relation) MERGE key; the rest are rewritten.
+        Idempotent (a second call finds no ``old`` edges). Reserved typing
+        relations can never be renamed (hard constraint).
+
+        Returns the number of edges rewritten (excludes dedup-deleted).
+        """
+        if old == new:
+            return 0
+        if old in self._RESERVED_RELATIONS or new in self._RESERVED_RELATIONS:
+            raise ValueError(
+                f"refusing to rename a reserved typing relation ({old!r} -> {new!r}); "
+                "IS_A/INSTANCE_OF/SUBTYPE_OF are structural and never consolidated"
+            )
+        # Phase 1: drop old edges that would collide with an existing new edge.
+        self._execute_query(
+            """
+            MATCH (edge:Node {type: 'edge', relation: $old})
+            OPTIONAL MATCH (dup:Node {type: 'edge', relation: $new,
+                                      source: edge.source, target: edge.target})
+            WITH edge, dup WHERE dup IS NOT NULL
+            DETACH DELETE edge
+            """,
+            {"old": old, "new": new},
+        )
+        # Phase 2: rewrite the remaining old edges (+ keep the name consistent).
+        records = self._execute_query(
+            """
+            MATCH (edge:Node {type: 'edge', relation: $old})
+            SET edge.relation = $new,
+                edge.name = replace(edge.name, '_' + $old + '_', '_' + $new + '_')
+            RETURN count(edge) AS renamed
+            """,
+            {"old": old, "new": new},
+        )
+        return int(records[0]["renamed"]) if records else 0
+
     def get_relation_vocabulary(self) -> List[Dict[str, Any]]:
         """Distinct DESCRIPTIVE relation labels with edge counts.
 

--- a/src/sophia/hcg_client/client.py
+++ b/src/sophia/hcg_client/client.py
@@ -373,17 +373,24 @@ class HCGClient(LogosHCGClient):
                 f"refusing to rename a reserved typing relation ({old!r} -> {new!r}); "
                 "IS_A/INSTANCE_OF/SUBTYPE_OF are structural and never consolidated"
             )
-        # Phase 1: drop old edges that would collide with an existing new edge.
-        self._execute_query(
+        # Phase 1: drop old edges that would collide with an existing new
+        # edge between the same endpoints. Match via the structural :FROM/:TO
+        # relationships (indexed traversal) rather than scanning source/target
+        # PROPERTIES on every node -- the property lookup had no index and
+        # scaled as a full edge scan per old edge.
+        del_records = self._execute_query(
             """
-            MATCH (edge:Node {type: 'edge', relation: $old})
-            OPTIONAL MATCH (dup:Node {type: 'edge', relation: $new,
-                                      source: edge.source, target: edge.target})
-            WITH edge, dup WHERE dup IS NOT NULL
-            DETACH DELETE edge
+            MATCH (src)<-[:FROM]-(edge:Node {type: 'edge', relation: $old})
+                  -[:TO]->(tgt),
+                  (src)<-[:FROM]-(:Node {type: 'edge', relation: $new})-[:TO]->(tgt)
+            WITH DISTINCT edge
+            WITH count(edge) AS deleted, collect(edge) AS edges
+            FOREACH (e IN edges | DETACH DELETE e)
+            RETURN deleted
             """,
             {"old": old, "new": new},
         )
+        deleted = int(del_records[0]["deleted"]) if del_records else 0
         # Phase 2: rewrite the remaining old edges (+ keep the name consistent).
         records = self._execute_query(
             """
@@ -394,7 +401,10 @@ class HCGClient(LogosHCGClient):
             """,
             {"old": old, "new": new},
         )
-        return int(records[0]["renamed"]) if records else 0
+        renamed = int(records[0]["renamed"]) if records else 0
+        # Total edges affected -- includes dedup-deletes so callers can tell
+        # a consolidation happened even when Phase 2 rewrote nothing.
+        return renamed + deleted
 
     def get_relation_vocabulary(self) -> List[Dict[str, Any]]:
         """Distinct DESCRIPTIVE relation labels with edge counts.

--- a/src/sophia/maintenance/hermes_naming.py
+++ b/src/sophia/maintenance/hermes_naming.py
@@ -215,11 +215,14 @@ def relation_synonyms(
     payload: dict = {"predicates": predicates}
     if context:
         payload["context"] = context
+    # Omit the auth header when there is no token -- an empty "Bearer " is an
+    # illegal header value (and Hermes does not require auth locally).
+    headers = {"Authorization": f"Bearer {token}"} if token else {}
     try:
         resp = httpx.post(
             url,
             json=payload,
-            headers={"Authorization": f"Bearer {token}"},
+            headers=headers,
             timeout=httpx.Timeout(timeout),
         )
         resp.raise_for_status()

--- a/src/sophia/maintenance/hermes_naming.py
+++ b/src/sophia/maintenance/hermes_naming.py
@@ -10,6 +10,7 @@ import logging
 import random
 
 import httpx
+from dataclasses import dataclass
 
 from sophia.maintenance.emergence_types import (
     EmergentCluster,
@@ -182,3 +183,60 @@ def type_cluster(
     except (httpx.HTTPError, KeyError, ValueError) as exc:
         logger.warning("type_cluster failed: %s", exc)
         return None
+
+
+@dataclass(frozen=True)
+class RelationSynonymGroup:
+    """One descriptive-relation synonym group proposed by Hermes."""
+
+    canonical: str
+    members: list[str]
+    confidence: float
+
+
+def relation_synonyms(
+    predicates: list[str],
+    *,
+    hermes_url: str,
+    token: str,
+    context: str | None = None,
+    timeout: float = 60.0,
+) -> list[RelationSynonymGroup]:
+    """Ask Hermes (/relation-synonyms) to group descriptive-relation synonyms.
+
+    The Sophia-side client for the relation-vocabulary rollup (sophia#192).
+    Hermes is the codec: it proposes synonym groups + a canonical label and
+    validates fail-closed (reserved typing relations rejected). Returns [] on
+    any failure -- the rollup simply consolidates nothing this pass.
+    """
+    if len(predicates) < 2:
+        return []
+    url = f"{hermes_url.rstrip('/')}/relation-synonyms"
+    payload: dict = {"predicates": predicates}
+    if context:
+        payload["context"] = context
+    try:
+        resp = httpx.post(
+            url,
+            json=payload,
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=httpx.Timeout(timeout),
+        )
+        resp.raise_for_status()
+        groups = resp.json().get("groups") or []
+        out: list[RelationSynonymGroup] = []
+        for g in groups:
+            members = [str(m) for m in (g.get("members") or []) if m]
+            canonical = str(g.get("canonical", "")).strip()
+            if canonical and len(members) >= 2:
+                out.append(
+                    RelationSynonymGroup(
+                        canonical=canonical,
+                        members=members,
+                        confidence=float(g.get("confidence", 0.0)),
+                    )
+                )
+        return out
+    except (httpx.HTTPError, KeyError, ValueError) as exc:
+        logger.warning("relation_synonyms failed: %s", exc)
+        return []

--- a/src/sophia/maintenance/hermes_naming.py
+++ b/src/sophia/maintenance/hermes_naming.py
@@ -190,7 +190,7 @@ class RelationSynonymGroup:
     """One descriptive-relation synonym group proposed by Hermes."""
 
     canonical: str
-    members: list[str]
+    members: tuple[str, ...]  # tuple so the frozen group is genuinely immutable
     confidence: float
 
 
@@ -229,17 +229,18 @@ def relation_synonyms(
         groups = resp.json().get("groups") or []
         out: list[RelationSynonymGroup] = []
         for g in groups:
-            members = [str(m) for m in (g.get("members") or []) if m]
+            members = tuple(str(m) for m in (g.get("members") or []) if m)
             canonical = str(g.get("canonical", "")).strip()
             if canonical and len(members) >= 2:
+                # `confidence: null` -> 0.0 (float(None) would raise TypeError)
                 out.append(
                     RelationSynonymGroup(
                         canonical=canonical,
                         members=members,
-                        confidence=float(g.get("confidence", 0.0)),
+                        confidence=float(g.get("confidence") or 0.0),
                     )
                 )
         return out
-    except (httpx.HTTPError, KeyError, ValueError) as exc:
+    except (httpx.HTTPError, KeyError, ValueError, TypeError) as exc:
         logger.warning("relation_synonyms failed: %s", exc)
         return []

--- a/src/sophia/maintenance/relation_rollup_handler.py
+++ b/src/sophia/maintenance/relation_rollup_handler.py
@@ -96,7 +96,20 @@ class RelationRollupHandler:
             logger.exception("relation rollup: embedding failed; skipping run")
             return {"groups_applied": 0, "edges_renamed": 0, "clusters": 0}
 
-        clusters = _greedy_cluster(labels, vectors, self._cluster_threshold)
+        # embed_fn may return None for labels it failed to embed (resilient
+        # default impl); drop those so zip never misaligns labels/vectors.
+        paired = [
+            (lab, vec) for lab, vec in zip(labels, vectors) if vec is not None
+        ]
+        if len(paired) < len(labels):
+            logger.warning(
+                "relation rollup: %d/%d labels had no embedding; skipped",
+                len(labels) - len(paired),
+                len(labels),
+            )
+        kept_labels = [lab for lab, _ in paired]
+        kept_vectors = [vec for _, vec in paired]
+        clusters = _greedy_cluster(kept_labels, kept_vectors, self._cluster_threshold)
         # only multi-member clusters can contain synonyms worth a Hermes call
         batches = [c[: self._max_cluster_size] for c in clusters if len(c) >= 2]
 
@@ -116,8 +129,7 @@ class RelationRollupHandler:
                     if member == g.canonical:
                         continue
                     try:
-                        edges_renamed += self._hcg.rename_relation(member, g.canonical)
-                        applied = True
+                        affected = self._hcg.rename_relation(member, g.canonical)
                     except ValueError:
                         # reserved relation slipped through -- never consolidate it
                         logger.warning(
@@ -125,6 +137,20 @@ class RelationRollupHandler:
                             member,
                             g.canonical,
                         )
+                        continue
+                    except Exception:
+                        # an unexpected DB error on one member must not abort
+                        # the other independent synonym groups
+                        logger.exception(
+                            "relation rollup: rename %s -> %s failed; continuing",
+                            member,
+                            g.canonical,
+                        )
+                        continue
+                    edges_renamed += affected
+                    # only count the group as applied if something changed
+                    if affected:
+                        applied = True
                 if applied:
                     groups_applied += 1
                     logger.info(
@@ -173,14 +199,20 @@ def build_relation_rollup_handler(
     auth = {"Authorization": f"Bearer {token}"}
 
     def embed_fn(labels: list[str]):
+        # Per-label resilience: a transient failure on one label yields None
+        # (the handler drops it) instead of aborting the whole rollup.
         vectors = []
         with httpx.Client(timeout=httpx.Timeout(30.0)) as client:
             for label in labels:
-                resp = client.post(
-                    f"{base}/embed_text", json={"text": label}, headers=auth
-                )
-                resp.raise_for_status()
-                vectors.append(resp.json()["embedding"])
+                try:
+                    resp = client.post(
+                        f"{base}/embed_text", json={"text": label}, headers=auth
+                    )
+                    resp.raise_for_status()
+                    vectors.append(resp.json()["embedding"])
+                except (httpx.HTTPError, KeyError, ValueError):
+                    logger.warning("relation rollup: embed failed for %r", label)
+                    vectors.append(None)
         return vectors
 
     def synonym_fn(predicates, context=None):

--- a/src/sophia/maintenance/relation_rollup_handler.py
+++ b/src/sophia/maintenance/relation_rollup_handler.py
@@ -23,12 +23,14 @@ wiring uses Hermes /embed_text and /relation-synonyms.
 from __future__ import annotations
 
 import logging
-from typing import Callable, Sequence
+from typing import Any, Callable, Sequence
 
 logger = logging.getLogger(__name__)
 
 EmbedFn = Callable[[list[str]], Sequence[Sequence[float]]]
-SynonymFn = Callable[..., list]  # (predicates, context=None) -> list[RelationSynonymGroup]
+SynonymFn = Callable[
+    ..., list
+]  # (predicates, context=None) -> list[RelationSynonymGroup]
 
 
 def _cosine(a: Sequence[float], b: Sequence[float]) -> float:
@@ -37,7 +39,7 @@ def _cosine(a: Sequence[float], b: Sequence[float]) -> float:
     nb = sum(y * y for y in b) ** 0.5
     if na == 0.0 or nb == 0.0:
         return 0.0
-    return num / (na * nb)
+    return float(num / (na * nb))
 
 
 def _greedy_cluster(
@@ -66,7 +68,7 @@ class RelationRollupHandler:
 
     def __init__(
         self,
-        hcg,
+        hcg: Any,
         *,
         embed_fn: EmbedFn,
         synonym_fn: SynonymFn,
@@ -98,9 +100,7 @@ class RelationRollupHandler:
 
         # embed_fn may return None for labels it failed to embed (resilient
         # default impl); drop those so zip never misaligns labels/vectors.
-        paired = [
-            (lab, vec) for lab, vec in zip(labels, vectors) if vec is not None
-        ]
+        paired = [(lab, vec) for lab, vec in zip(labels, vectors) if vec is not None]
         if len(paired) < len(labels):
             logger.warning(
                 "relation rollup: %d/%d labels had no embedding; skipped",
@@ -175,10 +175,10 @@ class RelationRollupHandler:
 
 def build_relation_rollup_handler(
     *,
-    hcg,
+    hcg: Any,
     hermes_url: str,
     token: str,
-    redis_client=None,
+    redis_client: Any = None,
     min_confidence: float = 0.6,
     cluster_threshold: float = 0.7,
 ) -> RelationRollupHandler:
@@ -198,10 +198,10 @@ def build_relation_rollup_handler(
     base = hermes_url.rstrip("/")
     auth = {"Authorization": f"Bearer {token}"}
 
-    def embed_fn(labels: list[str]):
+    def embed_fn(labels: list[str]) -> list:
         # Per-label resilience: a transient failure on one label yields None
         # (the handler drops it) instead of aborting the whole rollup.
-        vectors = []
+        vectors: list = []
         with httpx.Client(timeout=httpx.Timeout(30.0)) as client:
             for label in labels:
                 try:
@@ -215,12 +215,12 @@ def build_relation_rollup_handler(
                     vectors.append(None)
         return vectors
 
-    def synonym_fn(predicates, context=None):
+    def synonym_fn(predicates: list[str], context: str | None = None) -> list:
         return relation_synonyms(
             predicates, hermes_url=hermes_url, token=token, context=context
         )
 
-    def refresh_snapshot():
+    def refresh_snapshot() -> None:
         if redis_client is None:
             return
         records = hcg.get_relation_vocabulary()

--- a/src/sophia/maintenance/relation_rollup_handler.py
+++ b/src/sophia/maintenance/relation_rollup_handler.py
@@ -1,0 +1,209 @@
+"""Relation-vocabulary rollup (sophia#192).
+
+The Sophia-side batch consolidation of the descriptive-relation vocabulary --
+the edge-axis analog of the node-side type rollup, and the load-bearing piece
+the relation-vocabulary fix needs (H1/H2 collapse only morphological variants;
+the sprawl is semantic). Off the extraction hot path, scheduled like the other
+maintenance handlers.
+
+Pipeline (embeddings POINT, the graph ASSERTS):
+  1. read the descriptive-relation vocabulary (reserved typing relations
+     already excluded);
+  2. EMBED the relation labels and cluster by cosine, so true synonyms
+     (HAULS/DRAGS/CARRIES -- no shared tokens) co-locate;
+  3. one Hermes /relation-synonyms call per cluster NAMES the synonym groups
+     (the codec; fail-closed, IS_A rejected);
+  4. consolidate above a confidence gate via rename_relation (dedup-safe,
+     idempotent, reserved-guarded).
+
+Dependencies are injected so the orchestration is unit-testable; the default
+wiring uses Hermes /embed_text and /relation-synonyms.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Callable, Sequence
+
+logger = logging.getLogger(__name__)
+
+EmbedFn = Callable[[list[str]], Sequence[Sequence[float]]]
+SynonymFn = Callable[..., list]  # (predicates, context=None) -> list[RelationSynonymGroup]
+
+
+def _cosine(a: Sequence[float], b: Sequence[float]) -> float:
+    num = sum(x * y for x, y in zip(a, b))
+    na = sum(x * x for x in a) ** 0.5
+    nb = sum(y * y for y in b) ** 0.5
+    if na == 0.0 or nb == 0.0:
+        return 0.0
+    return num / (na * nb)
+
+
+def _greedy_cluster(
+    labels: list[str], vectors: Sequence[Sequence[float]], threshold: float
+) -> list[list[str]]:
+    """Greedy single-pass cosine clustering: each label joins the first
+    cluster whose seed it is within ``threshold`` of, else seeds a new one.
+    Deterministic in input order."""
+    clusters: list[list[str]] = []
+    seeds: list[Sequence[float]] = []
+    for label, vec in zip(labels, vectors):
+        placed = False
+        for i, seed in enumerate(seeds):
+            if _cosine(vec, seed) >= threshold:
+                clusters[i].append(label)
+                placed = True
+                break
+        if not placed:
+            clusters.append([label])
+            seeds.append(vec)
+    return clusters
+
+
+class RelationRollupHandler:
+    """Cluster -> name -> consolidate the descriptive-relation vocabulary."""
+
+    def __init__(
+        self,
+        hcg,
+        *,
+        embed_fn: EmbedFn,
+        synonym_fn: SynonymFn,
+        min_confidence: float = 0.6,
+        cluster_threshold: float = 0.7,
+        max_cluster_size: int = 200,
+        on_consolidated: Callable[[], None] | None = None,
+    ) -> None:
+        self._hcg = hcg
+        self._embed_fn = embed_fn
+        self._synonym_fn = synonym_fn
+        self._min_confidence = min_confidence
+        self._cluster_threshold = cluster_threshold
+        self._max_cluster_size = max_cluster_size
+        # called after edges are consolidated (e.g. refresh the Redis snapshot)
+        self._on_consolidated = on_consolidated
+
+    def run(self) -> dict:
+        vocab = self._hcg.get_relation_vocabulary() or []
+        labels = [v["relation"] for v in vocab if v.get("relation")]
+        if not labels:
+            return {"groups_applied": 0, "edges_renamed": 0, "clusters": 0}
+
+        try:
+            vectors = self._embed_fn(labels)
+        except Exception:
+            logger.exception("relation rollup: embedding failed; skipping run")
+            return {"groups_applied": 0, "edges_renamed": 0, "clusters": 0}
+
+        clusters = _greedy_cluster(labels, vectors, self._cluster_threshold)
+        # only multi-member clusters can contain synonyms worth a Hermes call
+        batches = [c[: self._max_cluster_size] for c in clusters if len(c) >= 2]
+
+        groups_applied = 0
+        edges_renamed = 0
+        for batch in batches:
+            try:
+                groups = self._synonym_fn(batch, context=None)
+            except Exception:
+                logger.exception("relation rollup: synonym call failed for a cluster")
+                continue
+            for g in groups:
+                if g.confidence < self._min_confidence:
+                    continue
+                applied = False
+                for member in g.members:
+                    if member == g.canonical:
+                        continue
+                    try:
+                        edges_renamed += self._hcg.rename_relation(member, g.canonical)
+                        applied = True
+                    except ValueError:
+                        # reserved relation slipped through -- never consolidate it
+                        logger.warning(
+                            "relation rollup: refused reserved rename %s -> %s",
+                            member,
+                            g.canonical,
+                        )
+                if applied:
+                    groups_applied += 1
+                    logger.info(
+                        "relation rollup: consolidated %s -> %s (conf %.2f)",
+                        g.members,
+                        g.canonical,
+                        g.confidence,
+                    )
+
+        if edges_renamed and self._on_consolidated is not None:
+            try:
+                self._on_consolidated()
+            except Exception:
+                logger.exception("relation rollup: snapshot refresh failed")
+
+        return {
+            "groups_applied": groups_applied,
+            "edges_renamed": edges_renamed,
+            "clusters": len(batches),
+        }
+
+
+def build_relation_rollup_handler(
+    *,
+    hcg,
+    hermes_url: str,
+    token: str,
+    redis_client=None,
+    min_confidence: float = 0.6,
+    cluster_threshold: float = 0.7,
+) -> RelationRollupHandler:
+    """Default wiring: Hermes /embed_text + /relation-synonyms, snapshot refresh.
+
+    embed_fn loops /embed_text per distinct label (the pass is off the hot path
+    and bounded per run; batch embedding is a follow-up). on_consolidated
+    re-publishes logos:ontology:relations so Hermes (hermes#137) re-seeds the
+    collapsed vocabulary.
+    """
+    import json
+
+    import httpx
+
+    from sophia.maintenance.hermes_naming import relation_synonyms
+
+    base = hermes_url.rstrip("/")
+    auth = {"Authorization": f"Bearer {token}"}
+
+    def embed_fn(labels: list[str]):
+        vectors = []
+        with httpx.Client(timeout=httpx.Timeout(30.0)) as client:
+            for label in labels:
+                resp = client.post(
+                    f"{base}/embed_text", json={"text": label}, headers=auth
+                )
+                resp.raise_for_status()
+                vectors.append(resp.json()["embedding"])
+        return vectors
+
+    def synonym_fn(predicates, context=None):
+        return relation_synonyms(
+            predicates, hermes_url=hermes_url, token=token, context=context
+        )
+
+    def refresh_snapshot():
+        if redis_client is None:
+            return
+        records = hcg.get_relation_vocabulary()
+        snapshot = {
+            r["relation"]: {"edge_count": r.get("edge_count", 0)}
+            for r in records
+            if r.get("relation")
+        }
+        redis_client.set("logos:ontology:relations", json.dumps(snapshot))
+
+    return RelationRollupHandler(
+        hcg,
+        embed_fn=embed_fn,
+        synonym_fn=synonym_fn,
+        min_confidence=min_confidence,
+        cluster_threshold=cluster_threshold,
+        on_consolidated=refresh_snapshot,
+    )

--- a/tests/maintenance/test_hermes_naming.py
+++ b/tests/maintenance/test_hermes_naming.py
@@ -413,8 +413,15 @@ def test_relation_synonyms_posts_and_parses(monkeypatch):
     def fake_post(url, json=None, headers=None, timeout=None):
         captured.update(url=url, json=json, headers=headers)
         return _FakeResp(
-            {"groups": [{"canonical": "CARRIES", "members": ["HAULS", "CARRIES"],
-                         "confidence": 0.9}]}
+            {
+                "groups": [
+                    {
+                        "canonical": "CARRIES",
+                        "members": ["HAULS", "CARRIES"],
+                        "confidence": 0.9,
+                    }
+                ]
+            }
         )
 
     monkeypatch.setattr(hn.httpx, "post", fake_post)

--- a/tests/maintenance/test_hermes_naming.py
+++ b/tests/maintenance/test_hermes_naming.py
@@ -405,3 +405,49 @@ def test_type_cluster_multiple_groups_uses_first_and_warns(monkeypatch):
     result = hn.type_cluster(_cluster(), hermes_url="http://h", token="t")
     assert result == TypeClusterResult(name="vehicle", parent="object", residual_ids=[])
     assert warnings  # the >1-group contract violation was logged
+
+
+def test_relation_synonyms_posts_and_parses(monkeypatch):
+    captured = {}
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        captured.update(url=url, json=json, headers=headers)
+        return _FakeResp(
+            {"groups": [{"canonical": "CARRIES", "members": ["HAULS", "CARRIES"],
+                         "confidence": 0.9}]}
+        )
+
+    monkeypatch.setattr(hn.httpx, "post", fake_post)
+    groups = hn.relation_synonyms(
+        ["HAULS", "CARRIES"], hermes_url="http://hermes:17000", token="t"
+    )
+    assert len(groups) == 1
+    assert groups[0].canonical == "CARRIES"
+    assert groups[0].members == ["HAULS", "CARRIES"]
+    assert captured["url"].endswith("/relation-synonyms")
+    assert captured["headers"]["Authorization"] == "Bearer t"
+
+
+def test_relation_synonyms_omits_auth_when_token_empty(monkeypatch):
+    captured = {}
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        captured.update(headers=headers)
+        return _FakeResp({"groups": []})
+
+    monkeypatch.setattr(hn.httpx, "post", fake_post)
+    hn.relation_synonyms(["A", "B"], hermes_url="http://h", token="")
+    # empty token must not produce an illegal "Bearer " header
+    assert "Authorization" not in captured["headers"]
+
+
+def test_relation_synonyms_under_two_predicates_is_noop():
+    assert hn.relation_synonyms(["ONLY_ONE"], hermes_url="http://h", token="t") == []
+
+
+def test_relation_synonyms_returns_empty_on_error(monkeypatch):
+    def fake_post(url, json=None, headers=None, timeout=None):
+        raise httpx.ConnectError("down")
+
+    monkeypatch.setattr(hn.httpx, "post", fake_post)
+    assert hn.relation_synonyms(["A", "B"], hermes_url="http://h", token="t") == []

--- a/tests/maintenance/test_hermes_naming.py
+++ b/tests/maintenance/test_hermes_naming.py
@@ -423,7 +423,7 @@ def test_relation_synonyms_posts_and_parses(monkeypatch):
     )
     assert len(groups) == 1
     assert groups[0].canonical == "CARRIES"
-    assert groups[0].members == ["HAULS", "CARRIES"]
+    assert groups[0].members == ("HAULS", "CARRIES")
     assert captured["url"].endswith("/relation-synonyms")
     assert captured["headers"]["Authorization"] == "Bearer t"
 

--- a/tests/maintenance/test_relation_rollup.py
+++ b/tests/maintenance/test_relation_rollup.py
@@ -128,3 +128,54 @@ def test_embed_failure_aborts_cleanly():
     summary = handler.run()  # must not raise
     assert summary["edges_renamed"] == 0
     hcg.rename_relation.assert_not_called()
+
+
+def test_label_with_none_embedding_is_dropped_no_misalignment():
+    # CARRIES fails to embed (None); HAULS/DRAGS still cluster together
+    hcg = _hcg([("HAULS", 1), ("DRAGS", 1), ("CARRIES", 5)])
+    seen = []
+
+    def embed(labels):
+        return [([1.0, 0.0] if l != "CARRIES" else None) for l in labels]
+
+    def synonym_fn(preds, context=None):
+        seen.append(set(preds))
+        return []
+
+    RelationRollupHandler(
+        hcg, embed_fn=embed, synonym_fn=synonym_fn, cluster_threshold=0.5
+    ).run()
+    # CARRIES (no embedding) must not appear in any batch
+    assert all("CARRIES" not in b for b in seen)
+    assert {"HAULS", "DRAGS"} in seen
+
+
+def test_rename_db_error_does_not_abort_other_groups():
+    hcg = _hcg([("HAULS", 1), ("CARRIES", 5)])
+    hcg.rename_relation.side_effect = [RuntimeError("deadlock"), 3]
+
+    def synonym_fn(preds, context=None):
+        return [
+            RelationSynonymGroup("CARRIES", ["HAULS", "DUMMY", "CARRIES"], 0.9)
+        ]
+
+    handler = RelationRollupHandler(
+        hcg, embed_fn=lambda ls: [[1.0, 0.0]] * len(ls), synonym_fn=synonym_fn
+    )
+    summary = handler.run()  # must not raise despite the first rename failing
+    assert summary["edges_renamed"] == 3  # second member still consolidated
+
+
+def test_group_with_zero_affected_not_counted_applied():
+    # rename_relation returns 0 (nothing actually changed) -> group not applied
+    hcg = _hcg([("HAULS", 1), ("CARRIES", 5)])
+    hcg.rename_relation.return_value = 0
+
+    def synonym_fn(preds, context=None):
+        return [RelationSynonymGroup("CARRIES", ["HAULS", "CARRIES"], 0.9)]
+
+    handler = RelationRollupHandler(
+        hcg, embed_fn=lambda ls: [[1.0, 0.0]] * len(ls), synonym_fn=synonym_fn
+    )
+    summary = handler.run()
+    assert summary["groups_applied"] == 0 and summary["edges_renamed"] == 0

--- a/tests/maintenance/test_relation_rollup.py
+++ b/tests/maintenance/test_relation_rollup.py
@@ -1,0 +1,130 @@
+"""Tests for the relation-vocabulary rollup handler (sophia#192).
+
+Orchestration is unit-tested with injected dependencies (embed / synonym /
+hcg). The handler: reads the descriptive-relation vocabulary, clusters the
+labels by embedding so true synonyms co-locate, asks Hermes to name synonym
+groups per cluster, and consolidates via rename_relation above a confidence
+gate. Reserved typing relations never reach it.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from sophia.maintenance.hermes_naming import RelationSynonymGroup
+from sophia.maintenance.relation_rollup_handler import RelationRollupHandler
+
+
+def _hcg(vocab):
+    hcg = MagicMock()
+    hcg.get_relation_vocabulary.return_value = [
+        {"relation": r, "edge_count": c} for r, c in vocab
+    ]
+    hcg.rename_relation.return_value = 1
+    return hcg
+
+
+def _embed_two_clusters(labels):
+    # HAULS/DRAGS/CARRIES -> cluster A (x-axis); FAST/QUICK -> cluster B (y-axis)
+    A = {"HAULS", "DRAGS", "CARRIES"}
+    return [([1.0, 0.0] if l in A else [0.0, 1.0]) for l in labels]
+
+
+def test_consolidates_synonym_group_via_rename():
+    hcg = _hcg([("HAULS", 1), ("DRAGS", 1), ("CARRIES", 5)])
+
+    def synonym_fn(preds, context=None):
+        return [RelationSynonymGroup("CARRIES", ["HAULS", "DRAGS", "CARRIES"], 0.9)]
+
+    handler = RelationRollupHandler(
+        hcg, embed_fn=lambda ls: [[1.0, 0.0]] * len(ls), synonym_fn=synonym_fn
+    )
+    summary = handler.run()
+
+    renamed = {c.args for c in hcg.rename_relation.call_args_list}
+    assert ("HAULS", "CARRIES") in renamed
+    assert ("DRAGS", "CARRIES") in renamed
+    # the canonical is never renamed onto itself
+    assert ("CARRIES", "CARRIES") not in renamed
+    assert summary["groups_applied"] == 1
+    assert summary["edges_renamed"] == 2
+
+
+def test_confidence_gate_skips_low_confidence_groups():
+    hcg = _hcg([("HAULS", 1), ("CARRIES", 5)])
+
+    def synonym_fn(preds, context=None):
+        return [RelationSynonymGroup("CARRIES", ["HAULS", "CARRIES"], 0.3)]
+
+    handler = RelationRollupHandler(
+        hcg,
+        embed_fn=lambda ls: [[1.0, 0.0]] * len(ls),
+        synonym_fn=synonym_fn,
+        min_confidence=0.6,
+    )
+    summary = handler.run()
+    hcg.rename_relation.assert_not_called()
+    assert summary["groups_applied"] == 0
+
+
+def test_clusters_route_only_co_located_labels_to_one_synonym_call():
+    hcg = _hcg([("HAULS", 1), ("DRAGS", 1), ("CARRIES", 5), ("FAST", 1), ("QUICK", 1)])
+    seen_batches = []
+
+    def synonym_fn(preds, context=None):
+        seen_batches.append(set(preds))
+        return []
+
+    handler = RelationRollupHandler(
+        hcg, embed_fn=_embed_two_clusters, synonym_fn=synonym_fn, cluster_threshold=0.5
+    )
+    handler.run()
+    # two clusters -> the haul-group and the fast-group never share a batch
+    assert {"HAULS", "DRAGS", "CARRIES"} in seen_batches
+    assert {"FAST", "QUICK"} in seen_batches
+    for batch in seen_batches:
+        assert not ({"CARRIES"} & batch and {"FAST"} & batch)
+
+
+def test_singleton_clusters_are_not_sent():
+    hcg = _hcg([("ALONE", 1), ("HAULS", 1), ("CARRIES", 2)])
+    calls = []
+
+    def synonym_fn(preds, context=None):
+        calls.append(list(preds))
+        return []
+
+    # ALONE sits on its own axis -> its own cluster of 1, never sent
+    def embed(ls):
+        m = {"ALONE": [0, 0, 1], "HAULS": [1, 0, 0], "CARRIES": [1, 0, 0]}
+        return [m[l] for l in ls]
+
+    RelationRollupHandler(
+        hcg, embed_fn=embed, synonym_fn=synonym_fn, cluster_threshold=0.5
+    ).run()
+    assert all("ALONE" not in c for c in calls)
+
+
+def test_empty_vocabulary_is_a_noop():
+    hcg = _hcg([])
+    handler = RelationRollupHandler(
+        hcg, embed_fn=lambda ls: [], synonym_fn=lambda p, context=None: []
+    )
+    summary = handler.run()
+    assert summary == {"groups_applied": 0, "edges_renamed": 0, "clusters": 0}
+
+
+def test_embed_failure_aborts_cleanly():
+    hcg = _hcg([("HAULS", 1), ("CARRIES", 2)])
+
+    def boom(ls):
+        raise RuntimeError("hermes embed down")
+
+    handler = RelationRollupHandler(
+        hcg, embed_fn=boom, synonym_fn=lambda p, context=None: []
+    )
+    summary = handler.run()  # must not raise
+    assert summary["edges_renamed"] == 0
+    hcg.rename_relation.assert_not_called()

--- a/tests/maintenance/test_relation_rollup.py
+++ b/tests/maintenance/test_relation_rollup.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-import pytest
 
 from sophia.maintenance.hermes_naming import RelationSynonymGroup
 from sophia.maintenance.relation_rollup_handler import RelationRollupHandler
@@ -29,7 +28,7 @@ def _hcg(vocab):
 def _embed_two_clusters(labels):
     # HAULS/DRAGS/CARRIES -> cluster A (x-axis); FAST/QUICK -> cluster B (y-axis)
     A = {"HAULS", "DRAGS", "CARRIES"}
-    return [([1.0, 0.0] if l in A else [0.0, 1.0]) for l in labels]
+    return [([1.0, 0.0] if lab in A else [0.0, 1.0]) for lab in labels]
 
 
 def test_consolidates_synonym_group_via_rename():
@@ -99,7 +98,7 @@ def test_singleton_clusters_are_not_sent():
     # ALONE sits on its own axis -> its own cluster of 1, never sent
     def embed(ls):
         m = {"ALONE": [0, 0, 1], "HAULS": [1, 0, 0], "CARRIES": [1, 0, 0]}
-        return [m[l] for l in ls]
+        return [m[lab] for lab in ls]
 
     RelationRollupHandler(
         hcg, embed_fn=embed, synonym_fn=synonym_fn, cluster_threshold=0.5
@@ -136,7 +135,7 @@ def test_label_with_none_embedding_is_dropped_no_misalignment():
     seen = []
 
     def embed(labels):
-        return [([1.0, 0.0] if l != "CARRIES" else None) for l in labels]
+        return [([1.0, 0.0] if lab != "CARRIES" else None) for lab in labels]
 
     def synonym_fn(preds, context=None):
         seen.append(set(preds))
@@ -155,9 +154,7 @@ def test_rename_db_error_does_not_abort_other_groups():
     hcg.rename_relation.side_effect = [RuntimeError("deadlock"), 3]
 
     def synonym_fn(preds, context=None):
-        return [
-            RelationSynonymGroup("CARRIES", ["HAULS", "DUMMY", "CARRIES"], 0.9)
-        ]
+        return [RelationSynonymGroup("CARRIES", ["HAULS", "DUMMY", "CARRIES"], 0.9)]
 
     handler = RelationRollupHandler(
         hcg, embed_fn=lambda ls: [[1.0, 0.0]] * len(ls), synonym_fn=synonym_fn

--- a/tests/unit/hcg_client/test_client_wrapper.py
+++ b/tests/unit/hcg_client/test_client_wrapper.py
@@ -518,16 +518,22 @@ def test_rename_relation_renames_and_dedups(
 
     def fake_exec(query, params=None):
         calls.append((query, params or {}))
-        return [{"renamed": 3}] if "SET edge.relation" in query else []
+        if "SET edge.relation" in query:
+            return [{"renamed": 3}]
+        if "DETACH DELETE" in query:
+            return [{"deleted": 2}]
+        return []
 
     monkeypatch.setattr(client, "_execute_query", fake_exec)
 
     n = client.rename_relation("HAULS", "CARRIES")
 
-    assert n == 3
+    # total affected = renamed (3) + dedup-deleted (2)
+    assert n == 5
     assert len(calls) == 2  # dedup-delete, then rename
     dedup_q, dedup_p = calls[0]
     assert "DETACH DELETE" in dedup_q
+    assert ":FROM" in dedup_q and ":TO" in dedup_q  # structural, not property scan
     assert dedup_p["old"] == "HAULS" and dedup_p["new"] == "CARRIES"
     assert "SET edge.relation = $new" in calls[1][0]
 

--- a/tests/unit/hcg_client/test_client_wrapper.py
+++ b/tests/unit/hcg_client/test_client_wrapper.py
@@ -508,3 +508,35 @@ def test_get_relation_vocabulary_handles_empty(
     """No descriptive edges -> empty list, no error."""
     monkeypatch.setattr(client, "_execute_read", MagicMock(return_value=[]))
     assert client.get_relation_vocabulary() == []
+
+
+def test_rename_relation_renames_and_dedups(
+    monkeypatch: pytest.MonkeyPatch, client: HCGClient
+) -> None:
+    """rename_relation dedups colliding edges then rewrites the rest (sophia#192)."""
+    calls = []
+
+    def fake_exec(query, params=None):
+        calls.append((query, params or {}))
+        return [{"renamed": 3}] if "SET edge.relation" in query else []
+
+    monkeypatch.setattr(client, "_execute_query", fake_exec)
+
+    n = client.rename_relation("HAULS", "CARRIES")
+
+    assert n == 3
+    assert len(calls) == 2  # dedup-delete, then rename
+    dedup_q, dedup_p = calls[0]
+    assert "DETACH DELETE" in dedup_q
+    assert dedup_p["old"] == "HAULS" and dedup_p["new"] == "CARRIES"
+    assert "SET edge.relation = $new" in calls[1][0]
+
+
+def test_rename_relation_noop_when_same(client: HCGClient) -> None:
+    assert client.rename_relation("CARRIES", "CARRIES") == 0
+
+
+def test_rename_relation_refuses_reserved(client: HCGClient) -> None:
+    for old, new in [("IS_A", "PART_OF"), ("PART_OF", "IS_A"), ("INSTANCE_OF", "X")]:
+        with pytest.raises(ValueError, match="reserved"):
+            client.rename_relation(old, new)


### PR DESCRIPTION
Closes #192. Program: c-daly/logos#557 · Epic: c-daly/hermes#131 (the H3 consumer) · **Stacked on #191 (sophia#190)** — base retargets to `epic/nl-extraction` once #191 merges.

## Why

Validated live 2026-06-10: H1+H2 at write collapse only ~6.5% of the relation vocabulary (morphological variants); fresh-extraction df=1 = 0.653 vs the 0.25 gate. The sprawl is **semantic** — the LLM emits many distinct labels meaning the same relation. Approach (b), chosen: a periodic Sophia rollup that applies H3's synonym collapse off the extraction hot path (mirrors node-side type rollup).

## What

- **`HCGClient.rename_relation(old, new)`** — the consolidation primitive. Dedup-safe (an old edge colliding with an existing `(source,target,new)` is deleted, not duplicated), idempotent, and refuses reserved typing relations.
- **`hermes_naming.relation_synonyms()`** — Sophia→Hermes `/relation-synonyms` client + `RelationSynonymGroup`.
- **`RelationRollupHandler`** — embed the relation labels → **greedy cosine cluster** (so token-less synonyms `HAULS`/`DRAGS`/`CARRIES` co-locate — the embeddings-point/graph-asserts pattern on the edge axis) → one `/relation-synonyms` call per cluster → `rename_relation` above a confidence gate → refresh the `logos:ontology:relations` snapshot so Hermes (hermes#137) re-seeds. Dependency-injected; `build_relation_rollup_handler()` is the default wiring (Hermes `/embed_text` + `/relation-synonyms`).

## Hard constraints

IS_A / INSTANCE_OF / SUBTYPE_OF never enter a group or get renamed — guarded at `get_relation_vocabulary`, at H3 validation, and at `rename_relation`. Confidence-gated; every consolidation logged.

## Tests

11 (orchestration, confidence gate, cluster routing keeps non-synonyms in separate batches, singleton clusters not sent, empty vocab no-op, embed-failure aborts cleanly) + `rename_relation` (rename+dedup, no-op, reserved refused). 194 passed across maintenance + hcg_client suites.

## Deferred (the integration step)

Scheduler-loop registration (the periodic trigger + a `relation_rollup_enabled` config flag) is intentionally separated — that's where the cadence/cost tradeoffs live, and it touches the scheduler core. The mechanism here is complete and runnable via the factory; wiring it into the maintenance scheduler is a small, deliberate follow-up.