### PR TITLE
fix(sophia#195): publish the type snapshot at ProposalProcessor init

### DIFF
--- a/src/sophia/ingestion/proposal_processor.py
+++ b/src/sophia/ingestion/proposal_processor.py
@@ -162,6 +162,12 @@ class ProposalProcessor:
         self._milvus = milvus_sync
         self._event_bus = event_bus
         self._redis = redis_client
+        # Publish the current type snapshot immediately: ingest stopped
+        # minting types (#505), so the per-batch `new_types` gate below never
+        # fires in production and a freshly reseeded stack would leave
+        # logos:ontology:types absent — hermes's TypeRegistry then boots
+        # empty (sophia#195). Fail-soft inside _write_type_snapshot.
+        self._write_type_snapshot()
 
     def _publish_batch_event(
         self,

--- a/tests/unit/ingestion/test_proposal_processor.py
+++ b/tests/unit/ingestion/test_proposal_processor.py
@@ -1343,9 +1343,15 @@ class TestProposalProcessorRedisSnapshot:
         mock_hcg.get_all_type_definitions.assert_not_called()
 
     def test_process_redis_write_failure_does_not_break_processing(self):
-        """If Redis write fails, process() still returns results."""
-        processor, mock_hcg, _, _, mock_redis = self._make_processor_with_redis()
+        """If the Redis snapshot write fails, neither construction nor
+        process() breaks.
 
+        The failing ``set`` is wired *before* construction so the init-time
+        publish (sophia#195) genuinely hits it — the per-batch publish gate
+        in process() is dead in production since ingest stopped minting
+        types (#505).
+        """
+        mock_hcg = MagicMock()
         mock_hcg.get_all_type_definitions.return_value = [
             {
                 "uuid": "type_entity",
@@ -1353,7 +1359,14 @@ class TestProposalProcessorRedisSnapshot:
                 "properties": {"member_count": 1},
             },
         ]
+        mock_redis = MagicMock()
         mock_redis.set.side_effect = RuntimeError("Redis connection lost")
+
+        # Construction publishes the snapshot and must swallow the failure.
+        processor, _, _, _, _ = self._make_processor_with_redis(
+            mock_hcg=mock_hcg, mock_redis=mock_redis
+        )
+        mock_redis.set.assert_called_once()
 
         result = processor.process(self._make_proposal())
         assert "stored_node_ids" in result

--- a/tests/unit/ingestion/test_proposal_processor.py
+++ b/tests/unit/ingestion/test_proposal_processor.py
@@ -1302,7 +1302,10 @@ class TestProposalProcessorRedisSnapshot:
         ]
 
         # Ingest no longer mints types, so the snapshot is exercised directly
-        # rather than through process() (#505).
+        # rather than through process() (#505). Construction already published
+        # once with the then-unconfigured mock (sophia#195) — reset so the
+        # assertion sees only the call under test.
+        mock_redis.set.reset_mock()
         processor._write_type_snapshot()
 
         # Verify Redis write
@@ -1361,6 +1364,9 @@ class TestProposalProcessorRedisSnapshot:
         processor, mock_hcg, _, _, mock_redis = self._make_processor_with_redis()
 
         mock_hcg.get_all_type_definitions.side_effect = RuntimeError("Neo4j down")
+        # Construction already published once before the failure was wired
+        # (sophia#195) — reset so the assertion covers only process().
+        mock_redis.set.reset_mock()
 
         result = processor.process(self._make_proposal())
         assert "stored_node_ids" in result
@@ -1493,3 +1499,49 @@ class TestRealmTriage:
         assert batch_calls
         assert batch_calls[0].kwargs.get("node_type") == "Entity"
         assert batch_calls[0].kwargs["embeddings"][0]["uuid"] == "node-1"
+
+
+class TestSnapshotPublishOnInit:
+    def test_init_publishes_type_snapshot(self):
+        """Constructing the processor publishes the type snapshot (sophia#195).
+
+        Ingest stopped minting types in #505, so the `if new_types or
+        updated_types` per-batch gate never fires in production — without an
+        init-time publish, logos:ontology:types never exists after a
+        wipe+reseed and hermes's TypeRegistry stays empty.
+        """
+        import json
+
+        from sophia.ingestion.proposal_processor import ProposalProcessor
+
+        mock_hcg = MagicMock()
+        mock_hcg.get_all_type_definitions.return_value = [
+            {
+                "uuid": "type_entity",
+                "name": "entity",
+                "properties": {"member_count": 5},
+            },
+        ]
+        mock_redis = MagicMock()
+
+        ProposalProcessor(
+            hcg_client=mock_hcg,
+            milvus_sync=MagicMock(),
+            event_bus=MagicMock(),
+            redis_client=mock_redis,
+        )
+
+        mock_redis.set.assert_called_once()
+        key, raw = mock_redis.set.call_args[0]
+        assert key == "logos:ontology:types"
+        assert json.loads(raw)["entity"]["uuid"] == "type_entity"
+
+    def test_init_without_redis_does_not_publish_or_raise(self):
+        from sophia.ingestion.proposal_processor import ProposalProcessor
+
+        ProposalProcessor(
+            hcg_client=MagicMock(),
+            milvus_sync=MagicMock(),
+            event_bus=None,
+            redis_client=None,
+        )


### PR DESCRIPTION
Ingest stopped minting types in #505, so the per-batch publish gate (`if new_types or updated_types`, proposal_processor.py) never fires in production. Consequence: after any wipe+reseed, `logos:ontology:types` never exists — hermes's TypeRegistry boots empty and extraction prompts never see live ontology types (hermes#146/#147 wired the consumer side; this is the producer side).

**Change:** publish the snapshot unconditionally at ProposalProcessor construction — idempotent, fail-soft (`_write_type_snapshot` already catches everything), mirrors the relation snapshot's effective always-on behavior. Two existing tests gained a `reset_mock` after construction since init now legitimately publishes once.

**Validation (live, 2026-06-11):**
- TDD red→green; sophia unit suite 319 passed / 6 skipped; ruff/black clean.
- After restart: `logos:ontology:types` exists immediately at boot with the 18 seeded skeleton types.
- 16-block smoke: hermes logged `TypeRegistry loaded 18 types from Redis` on proposal events mid-run — first time extraction prompts have ever received live types. Window clean, queue drained.

Next measurement: a bakeoff row for type_accuracy (chronically ~0.12 with fallback defaults) once this + hermes#147 are merged.

Fixes #195