### PR TITLE
feat(sophia#197): server-side 2D embedding projection for /hcg/snapshot

### DIFF
--- a/src/sophia/api/app.py
+++ b/src/sophia/api/app.py
@@ -1946,6 +1946,13 @@ def create_app() -> FastAPI:
             default=False,
             description="Attach each entity's stored vector (for semantic layout)",
         ),
+        embedding_projection: Optional[str] = Query(
+            default=None,
+            pattern="^pca2d$",
+            description="Project entity vectors server-side and attach "
+            "embedding_2d=[x, y] per node INSTEAD of raw vectors (overrides "
+            "include_embeddings). 'pca2d' is the only mode (sophia#197).",
+        ),
     ) -> HCGGraphSnapshotResponse:
         """Get a snapshot of the entire HCG graph for visualization.
 
@@ -1978,7 +1985,7 @@ def create_app() -> FastAPI:
             # which would throw and (via the except) null *everything*. uuid is
             # a VARCHAR primary key, so each value is double-quoted.
             emb_by_uuid: Dict[str, Any] = {}
-            if include_embeddings and nodes:
+            if (include_embeddings or embedding_projection) and nodes:
                 try:
                     # Default Milvus connection is established at startup.
                     from pymilvus import Collection
@@ -2004,6 +2011,21 @@ def create_app() -> FastAPI:
                 except Exception as _e:
                     logger.warning(f"snapshot embeddings unavailable: {_e}")
 
+            # Server-side projection (sophia#197): two floats per node instead
+            # of the raw vector. Centered thin SVD == PCA; fine at 10k x 3072.
+            coords_by_uuid: Dict[str, List[float]] = {}
+            if embedding_projection and emb_by_uuid:
+                import numpy as _np
+
+                _ids = list(emb_by_uuid)
+                _X = _np.asarray([emb_by_uuid[u] for u in _ids], dtype=_np.float32)
+                _X = _X - _X.mean(axis=0, keepdims=True)
+                _vt = _np.linalg.svd(_X, full_matrices=False)[2]
+                _xy = _X @ _vt[: min(2, _vt.shape[0])].T
+                coords_by_uuid = {
+                    u: [float(c) for c in row] for u, row in zip(_ids, _xy)
+                }
+
             # Convert to response format
             entities: List[HCGEntityResponse] = []
             for node in nodes:
@@ -2016,7 +2038,14 @@ def create_app() -> FastAPI:
                         properties=props,
                         labels=[],
                         created_at=props.get("created"),
-                        embedding=emb_by_uuid.get(node["uuid"]),
+                        # Projection mode never ships raw vectors — shipping
+                        # both would defeat the point (sophia#197).
+                        embedding=(
+                            None
+                            if embedding_projection
+                            else emb_by_uuid.get(node["uuid"])
+                        ),
+                        embedding_2d=coords_by_uuid.get(node["uuid"]),
                     )
                 )
 

--- a/src/sophia/api/models.py
+++ b/src/sophia/api/models.py
@@ -621,6 +621,13 @@ class HCGEntityResponse(BaseModel):
         description="Entity vector; populated only when include_embeddings=true, "
         "for semantic (embedding-positioned) layout in the explorer",
     )
+    embedding_2d: Optional[List[float]] = Field(
+        default=None,
+        description="Server-side 2D projection of the entity vector "
+        "(embedding_projection=pca2d): two floats per node instead of the "
+        "raw vector — raw 3072-dim JSON reached 343MB/28s on a 5.5k-node "
+        "graph and broke the explorer's fetch (sophia#197)",
+    )
 
 
 class HCGEdgeResponse(BaseModel):

--- a/tests/unit/api/test_hcg_endpoints.py
+++ b/tests/unit/api/test_hcg_endpoints.py
@@ -359,3 +359,104 @@ class TestHCGHealthEndpoint:
 
         data = response.json()
         assert data["neo4j_connected"] is False
+
+
+class TestSnapshotEmbeddingProjection:
+    @patch("sophia.api.app._hcg_client")
+    def test_pca2d_ships_coords_not_vectors(self, mock_hcg, client, auth_headers):
+        """embedding_projection=pca2d projects server-side: each entity gets a
+        2-float embedding_2d and NO raw vector (sophia#197 — raw 3072-dim
+        vectors as JSON hit 343MB/28s on a 5.5k-node graph and killed the
+        explorer's fetch)."""
+        import re
+
+        mock_hcg.list_all_nodes.return_value = [
+            {"uuid": "e1", "type": "entity", "name": "e1", "properties": {}},
+            {"uuid": "e2", "type": "entity", "name": "e2", "properties": {}},
+            {"uuid": "e3", "type": "entity", "name": "e3", "properties": {}},
+        ]
+        mock_hcg.list_all_edges.return_value = []
+
+        store = {
+            "hcg_entity_embeddings": {
+                "e1": [1.0, 0.0, 0.0, 0.0],
+                "e2": [0.0, 1.0, 0.0, 0.0],
+                "e3": [0.0, 0.0, 1.0, 0.0],
+            },
+        }
+
+        class FakeCollection:
+            def __init__(self, name):
+                self.name = name
+
+            def load(self):
+                pass
+
+            def query(self, expr, output_fields, limit):
+                uuids = re.findall(r'"([^"]+)"', expr)
+                col = store.get(self.name, {})
+                return [{"uuid": u, "embedding": col[u]} for u in uuids if u in col]
+
+        with patch("pymilvus.Collection", FakeCollection):
+            response = client.get(
+                "/hcg/snapshot",
+                params={"embedding_projection": "pca2d"},
+                headers=auth_headers,
+            )
+
+        assert response.status_code == 200
+        ents = response.json()["entities"]
+        assert len(ents) == 3
+        for e in ents:
+            assert e["embedding"] is None  # raw vectors never serialized
+            assert e["embedding_2d"] is not None
+            assert len(e["embedding_2d"]) == 2
+
+    @patch("sophia.api.app._hcg_client")
+    def test_pca2d_overrides_include_embeddings(self, mock_hcg, client, auth_headers):
+        """Even with include_embeddings=true, projection mode must not ship
+        raw vectors — shipping both would defeat the point."""
+        import re
+
+        mock_hcg.list_all_nodes.return_value = [
+            {"uuid": "e1", "type": "entity", "name": "e1", "properties": {}},
+            {"uuid": "e2", "type": "entity", "name": "e2", "properties": {}},
+        ]
+        mock_hcg.list_all_edges.return_value = []
+        store = {"hcg_entity_embeddings": {"e1": [1.0, 0.0], "e2": [0.0, 1.0]}}
+
+        class FakeCollection:
+            def __init__(self, name):
+                self.name = name
+
+            def load(self):
+                pass
+
+            def query(self, expr, output_fields, limit):
+                uuids = re.findall(r'"([^"]+)"', expr)
+                col = store.get(self.name, {})
+                return [{"uuid": u, "embedding": col[u]} for u in uuids if u in col]
+
+        with patch("pymilvus.Collection", FakeCollection):
+            response = client.get(
+                "/hcg/snapshot",
+                params={
+                    "include_embeddings": "true",
+                    "embedding_projection": "pca2d",
+                },
+                headers=auth_headers,
+            )
+
+        assert response.status_code == 200
+        for e in response.json()["entities"]:
+            assert e["embedding"] is None
+            assert len(e["embedding_2d"]) == 2
+
+    @patch("sophia.api.app._hcg_client")
+    def test_unknown_projection_rejected(self, mock_hcg, client, auth_headers):
+        response = client.get(
+            "/hcg/snapshot",
+            params={"embedding_projection": "umap9000"},
+            headers=auth_headers,
+        )
+        assert response.status_code == 422


### PR DESCRIPTION
`include_embeddings=true` ships raw 3072-dim vectors as JSON — **measured 343MB / 27.6s** on the 5.5k-node reference graph (server logs 200; the explorer's fetch dies client-side on timeout/parse). Small graphs masked it; the first production-scale graph broke the explorer.

**Change:** `embedding_projection=pca2d` fetches vectors exactly as before (same single-collection, batched-uuid path), projects server-side (centered thin SVD = PCA, numpy-only, no new deps), and attaches `embedding_2d=[x, y]` per node — **two floats instead of 3072, ~1500× smaller embedding payload** (a 5.5k-node response drops from ~343MB to single-digit MB). Projection mode never serializes raw vectors, even when `include_embeddings=true` is also passed (shipping both would defeat the point). Unknown modes are rejected 422 via the Query pattern. `include_embeddings` behavior is byte-for-byte unchanged for back-compat.

**Validation:** TDD red→green — 3 new endpoint tests (coords-not-vectors, projection-overrides-include, 422 on unknown mode); full unit suite 322 passed / 6 skipped; ruff/black clean.

**Companion change (separate, apollo):** the explorer should request `embedding_projection=pca2d` and use `embedding_2d` for the semantic layout — until then the workaround is the non-embedding layout. A consistent server-side projection also fixes the per-fetch layout jitter that client-side projection of partial node sets produces.

Fixes #197