### PR TITLE
fix(ndt): flat /type-cluster parse + mint-or-attach cascade invariant (#199, #200)

### DIFF
--- a/src/sophia/maintenance/emergence_handler.py
+++ b/src/sophia/maintenance/emergence_handler.py
@@ -306,26 +306,28 @@ class EmergenceHandler:
             )
             return
 
-        if not tc.parent:
-            # A new name with no parent to mint under: nothing to point at. Hold
-            # the cohort in the pool for the next pass rather than minting a
-            # root-named duplicate (the old root_fallback bug, #200).
-            logger.info("emergence: new name %r has no parent; left in pool", tc.name)
-            return
-
-        # MINT (name + parent, name not already a type). Resolve the proposed
-        # parent closed-world; minting under a realm root is always legal, so we
-        # fall back to the realm root only when the parent does not resolve (a
-        # placement target for the freshly-minted type -- NOT a silent reparent of
-        # an existing type, which the attach path above already handled).
-        parent_uuid = (
+        # MINT a new type (the name is not an existing type). Every emergent type
+        # MUST root under a domain: resolve the proposed parent closed-world, and
+        # if Hermes gave no usable parent fall back to the SOURCE pool's realm root
+        # (entity/concept/process) -- never hold it unparented. The attach path
+        # above already handled existing names, so this never duplicates a root.
+        # Minting under a realm root is always legal.
+        resolved_parent = (
             placement.resolve_parent(
                 tc.parent, uuid_by_name=uuid_by_name, hcg=self._hcg, realm=realm
             )
-            or realm_root_uuid
+            if tc.parent
+            else None
         )
+        parent_uuid = resolved_parent or realm_root_uuid
+        # parent_resolution: Hermes named a parent that RESOLVED (even if it is a
+        # realm root, e.g. "entity"). root_fallback: no usable parent was given /
+        # it did not resolve, so we defaulted to the source realm root. Keeping
+        # these distinct preserves event-bus traceability -- an explicit-root
+        # graft and an unresolvable-parent fallback are different stories
+        # (greptile #201).
         placed_by = (
-            "parent_resolution" if parent_uuid != realm_root_uuid else "root_fallback"
+            "parent_resolution" if resolved_parent is not None else "root_fallback"
         )
 
         # Mint a new type under the chosen parent. mint_type writes the type's

--- a/src/sophia/maintenance/emergence_handler.py
+++ b/src/sophia/maintenance/emergence_handler.py
@@ -273,47 +273,60 @@ class EmergenceHandler:
             logger.info("emergence: cluster all outliers, leaving in pool")
             return
 
-        # Cascade (DESIGN sec 6). Dedup FIRST: a same-named type already in this
-        # realm IS this type (identity = name + realm; IS_A defines type), so reuse
-        # it -- route members onto it, never mint a second node. This must run
-        # whether or not Hermes proposed a parent; otherwise a name minted by an
-        # earlier cluster (the uuid_by_name map is updated on each mint) or a prior
-        # pass gets duplicated (#38). Only when no same-name type exists do we
-        # resolve the proposed parent, falling back to the realm root.
-        parent_uuid: str | None = None
-        placed_by: str | None = None
-        reuse_target: str | None = None
+        # Cascade (DESIGN sec 6) as a single MINT-OR-ATTACH invariant (#200):
+        # Hermes points at the placement (centroids never decide). We MINT a new
+        # type ONLY when it hands us BOTH a new name AND a parent to hang it under.
+        # Every other placeable answer points at an EXISTING type -- it named one
+        # that already exists -- so we ATTACH the cohort to that node and mint
+        # nothing. This makes same-name dedup implicit (#38: a name an earlier
+        # cluster/prior pass minted resolves through uuid_by_name and is reused,
+        # never re-minted) and, crucially, makes reuse REALM-AGNOSTIC: a cohort
+        # Hermes names after another realm's root (e.g. processes pooled under
+        # `entity`) is corrected onto that real root rather than spawning a
+        # duplicate root-named type. (A no-name answer is already held above; a
+        # new name with no parent has nothing to point at, so it is held too.)
         existing = uuid_by_name.get(tc.name.strip().lower())
-        if (
-            existing
-            and existing != source_type_uuid
-            and placement.realm_of(existing, hcg=self._hcg) == realm
-        ):
-            reuse_target, placed_by = existing, "name_reuse"
-        elif tc.parent:
-            pu = placement.resolve_parent(
-                tc.parent, uuid_by_name=uuid_by_name, hcg=self._hcg, realm=realm
-            )
-            if pu:
-                parent_uuid, placed_by = pu, "parent_resolution"
-        if reuse_target is None and parent_uuid is None:
-            parent_uuid, placed_by = realm_root_uuid, "root_fallback"
-
-        # The cascade above always settles on a placement reason.
-        assert placed_by is not None
-
-        if reuse_target is not None:
-            # Reuse: re-point the cohort's instance->type IS_A edges onto the
-            # existing same-name type (membership is the edge -- no mint, no
-            # type_uuid stamp). Members inherit the type's placed_by (name_reuse).
-            self._place_members(fitting, reuse_target, placed_by, children_of)
+        if existing is not None:
+            if existing == source_type_uuid:
+                # The name resolves to the cohort's own pool root: a no-op. Leave
+                # the members where they are rather than re-pointing onto
+                # themselves (and never mint a duplicate of the root).
+                logger.info(
+                    "emergence: cluster maps to its own pool root; left in pool"
+                )
+                return
+            # Attach: re-point the cohort's instance->type IS_A edges onto the
+            # existing type (membership is the edge -- no mint, no type_uuid
+            # stamp), regardless of realm.
+            self._place_members(fitting, existing, "name_reuse", children_of)
             logger.info(
-                "emergence: reused %s for %d members (%s)",
-                reuse_target,
+                "emergence: attached %d members to %s (name_reuse)",
                 len(fitting),
-                placed_by,
+                existing,
             )
             return
+
+        if not tc.parent:
+            # A new name with no parent to mint under: nothing to point at. Hold
+            # the cohort in the pool for the next pass rather than minting a
+            # root-named duplicate (the old root_fallback bug, #200).
+            logger.info("emergence: new name %r has no parent; left in pool", tc.name)
+            return
+
+        # MINT (name + parent, name not already a type). Resolve the proposed
+        # parent closed-world; minting under a realm root is always legal, so we
+        # fall back to the realm root only when the parent does not resolve (a
+        # placement target for the freshly-minted type -- NOT a silent reparent of
+        # an existing type, which the attach path above already handled).
+        parent_uuid = (
+            placement.resolve_parent(
+                tc.parent, uuid_by_name=uuid_by_name, hcg=self._hcg, realm=realm
+            )
+            or realm_root_uuid
+        )
+        placed_by = (
+            "parent_resolution" if parent_uuid != realm_root_uuid else "root_fallback"
+        )
 
         # Mint a new type under the chosen parent. mint_type writes the type's
         # own type->parent IS_A edge (carrying placed_by) but does NOT touch the

--- a/src/sophia/maintenance/hermes_naming.py
+++ b/src/sophia/maintenance/hermes_naming.py
@@ -131,44 +131,23 @@ def type_cluster(
         if not isinstance(data, dict):
             logger.warning("type_cluster returned non-dict JSON: %r", data)
             return None
-        # Hermes v2 returns exactly ONE group (the most-specific type it can form
-        # for the cluster; members that blur it are excluded as residuals) under
-        # `groups`, NOT a top-level `name`. The group's IS_A `chain` runs
-        # specific->general with chain[0]==name, so the proposed parent is
-        # chain[1] -- and it is guaranteed to already exist. `parent` is None only
-        # when the group reuses an existing type (assign_to != "NEW"); the handler
-        # then re-points members onto the existing same-name type rather than
-        # minting.
-        groups = data.get("groups")
-        if not isinstance(groups, list) or not groups:
-            logger.warning("type_cluster returned no groups; treating as failure")
-            return None
-        group = groups[0]
-        if len(groups) > 1:
-            # Hermes v2 guarantees exactly one group; surface a contract
-            # violation (e.g. a partial batch) rather than silently dropping the
-            # rest.
-            logger.warning(
-                "type_cluster returned %d groups; using only the first",
-                len(groups),
-            )
-        if not isinstance(group, dict):
-            logger.warning("type_cluster group is not an object; treating as failure")
-            return None
-        name = str(group.get("name") or "").strip()
+        # Hermes /type-cluster (#127) returns a FLAT verdict, not `groups`: a
+        # single top-level `name` (the most-specific type binding the WHOLE
+        # cluster), an optional `parent` (None => reuse the existing type named
+        # `name`; set => mint `name` under this existing parent, which may be a
+        # realm root), and `residual_ids` -- the members that don't fit, already
+        # mapped back to caller ids by Hermes. There is no `chain`/`assign_to`:
+        # the placement cascade asserts the full IS_A chain from name + parent.
+        name = str(data.get("name") or "").strip()
         if not name:
-            logger.warning("type_cluster group has no name; treating as failure")
+            logger.warning("type_cluster returned no name; treating as failure")
             return None
-        # Coerce to str + strip BEFORE defaulting, so a whitespace-only or
-        # non-string assign_to falls back to "NEW" instead of slipping through
-        # as a falsy value on the existing-type-reuse path.
-        assign_to = str(group.get("assign_to") or "").strip() or "NEW"
-        chain = group.get("chain")
-        parent: str | None = None
-        if assign_to == "NEW" and isinstance(chain, list) and len(chain) > 1:
-            # chain[1] may be JSON null; guard so it never becomes the literal
-            # string "None" used as a parent name.
-            parent = None if chain[1] is None else (str(chain[1]).strip() or None)
+        parent_raw = data.get("parent")
+        # parent may be JSON null (reuse) or a name; coerce so a whitespace-only
+        # or non-string value collapses to None rather than a bogus parent name.
+        parent: str | None = (
+            None if parent_raw is None else (str(parent_raw).strip() or None)
+        )
         residual = data.get("residual_ids")
         if not isinstance(residual, list):
             # A non-list residual_ids (string/int from a serialisation glitch)

--- a/src/sophia/maintenance/hermes_naming.py
+++ b/src/sophia/maintenance/hermes_naming.py
@@ -143,10 +143,11 @@ def type_cluster(
             logger.warning("type_cluster returned no name; treating as failure")
             return None
         parent_raw = data.get("parent")
-        # parent may be JSON null (reuse) or a name; coerce so a whitespace-only
-        # or non-string value collapses to None rather than a bogus parent name.
+        # parent may be JSON null (reuse) or a name; a whitespace-only or
+        # non-string value collapses to None rather than a bogus parent name
+        # (do NOT str() a non-string -- 123 must not become the parent "123").
         parent: str | None = (
-            None if parent_raw is None else (str(parent_raw).strip() or None)
+            parent_raw.strip() or None if isinstance(parent_raw, str) else None
         )
         residual = data.get("residual_ids")
         if not isinstance(residual, list):

--- a/tests/maintenance/test_emergence_handler.py
+++ b/tests/maintenance/test_emergence_handler.py
@@ -207,13 +207,14 @@ def test_one_cluster_one_flat_placement(monkeypatch):
         hcg,
         _RecordingMilvus(),
         name_fn=lambda c: TypeClusterResult(
-            name="gadget", parent=None, residual_ids=[]
+            name="gadget", parent="entity", residual_ids=[]
         ),
         mint_fn=fake_mint,
     )
     handler.run(type_uuid="entity_root")
 
-    # One cluster -> exactly one mint; no recursive sub-tree minting.
+    # name + parent (a novel name under the realm root) -> exactly one mint; no
+    # recursive sub-tree minting.
     assert mint_calls == ["gadget"]
     # Both members are re-pointed onto the minted type; no type_uuid stamp.
     assert set(hcg.membership_edges()) == {("a0", "x_uuid"), ("a1", "x_uuid")}
@@ -256,11 +257,12 @@ def test_reuse_on_in_realm_name_match(monkeypatch):
     assert hcg.updated == []
 
 
-def test_cross_realm_name_match_not_reused(monkeypatch):
+def test_cross_realm_name_match_is_reused(monkeypatch):
     cluster = EmergentCluster(members=[_m("x0"), _m("x1")])
     monkeypatch.setattr(eh, "find_emergent_clusters", lambda *a, **k: [cluster])
-    # "vehicle" exists but is rooted in the CONCEPT realm -- not reusable for an
-    # entity-realm pool.
+    # "vehicle" exists in the CONCEPT realm. An entity-pool cohort Hermes names
+    # "vehicle" (parent=null => reuse) is ATTACHED onto that existing type: reuse
+    # is realm-agnostic (#200), a cross-realm correction, never a duplicate.
     hcg = _entity_pool_hcg(
         extra_type_defs=[
             {"name": "concept", "uuid": "concept_root"},
@@ -278,11 +280,7 @@ def test_cross_realm_name_match_not_reused(monkeypatch):
         },
     )
     _park(hcg, "x0", "x1")
-    mint_calls = []
-
-    def fake_mint(cluster, name, hcg, milvus, source_cluster_id, **kwargs):
-        mint_calls.append(kwargs)
-        return "vehicle_entity_uuid"
+    minted = []
 
     handler = _handler(
         hcg,
@@ -290,32 +288,32 @@ def test_cross_realm_name_match_not_reused(monkeypatch):
         name_fn=lambda c: TypeClusterResult(
             name="vehicle", parent=None, residual_ids=[]
         ),
-        mint_fn=fake_mint,
+        mint_fn=lambda *a, **k: minted.append(1),
     )
     handler.run(type_uuid="entity_root")
 
-    # The cross-realm name is NOT reused -> mint fresh under the entity realm root.
-    assert len(mint_calls) == 1
-    assert mint_calls[0]["parent_type_uuid"] == "entity_root"
-    assert mint_calls[0]["placed_by"] == "root_fallback"
-    # Members are placed onto the freshly-minted entity-realm type, NOT the
-    # cross-realm same-name type.
+    # No mint: the cohort is attached onto the existing (cross-realm) vehicle type.
+    assert minted == []
     assert set(hcg.membership_edges()) == {
-        ("x0", "vehicle_entity_uuid"),
-        ("x1", "vehicle_entity_uuid"),
+        ("x0", "vehicle_concept_uuid"),
+        ("x1", "vehicle_concept_uuid"),
     }
+    assert all(
+        props == {"placed_by": "name_reuse"}
+        for _s, _t, rel, props in hcg.added_edges
+        if rel == "IS_A"
+    )
     assert hcg.updated == []  # no type_uuid/type stamp on members
 
 
-def test_mint_under_realm_root_fallback(monkeypatch):
+def test_novel_name_no_parent_left_in_pool(monkeypatch):
+    """A new name with NO parent has no existing type to attach to and nothing to
+    mint under (mint requires name AND parent, #200): the cohort is HELD in the
+    pool, never minted as a root-named duplicate (the old root_fallback bug)."""
     cluster = EmergentCluster(members=[_m("a0"), _m("a1")])
     monkeypatch.setattr(eh, "find_emergent_clusters", lambda *a, **k: [cluster])
     hcg = _park(_entity_pool_hcg(), "a0", "a1")
-    mint_calls = []
-
-    def fake_mint(cluster, name, hcg, milvus, source_cluster_id, **kwargs):
-        mint_calls.append(kwargs)
-        return "gadget_uuid"
+    minted = []
 
     handler = _handler(
         hcg,
@@ -323,24 +321,15 @@ def test_mint_under_realm_root_fallback(monkeypatch):
         name_fn=lambda c: TypeClusterResult(
             name="gadget", parent=None, residual_ids=[]
         ),
-        mint_fn=fake_mint,
+        mint_fn=lambda *a, **k: minted.append(1),
     )
     handler.run(type_uuid="entity_root")
 
-    # Null parent + name absent from the catalog -> mint under the realm root.
-    assert len(mint_calls) == 1
-    assert mint_calls[0]["parent_type_uuid"] == "entity_root"
-    assert mint_calls[0]["placed_by"] == "root_fallback"
-    # Members re-pointed onto the minted type, carrying root_fallback.
-    assert set(hcg.membership_edges()) == {
-        ("a0", "gadget_uuid"),
-        ("a1", "gadget_uuid"),
-    }
-    assert all(
-        props == {"placed_by": "root_fallback"}
-        for _s, _t, rel, props in hcg.added_edges
-        if rel == "IS_A"
-    )
+    # Nothing minted; members untouched and left in the pool for the next pass.
+    assert minted == []
+    assert hcg.membership_edges() == []
+    assert hcg.updated == []
+    assert hcg.deleted_edges == []
 
 
 def test_unresolvable_parent_falls_back_to_realm_root(monkeypatch):
@@ -387,7 +376,7 @@ def test_outliers_stay_in_pool(monkeypatch):
         hcg,
         _RecordingMilvus(),
         name_fn=lambda c: TypeClusterResult(
-            name="thing", parent=None, residual_ids=["out"]
+            name="thing", parent="entity", residual_ids=["out"]
         ),
         mint_fn=fake_mint,
     )
@@ -464,7 +453,7 @@ def test_in_pass_dedup_reuses_fresh_mint(monkeypatch):
         hcg,
         _RecordingMilvus(),
         name_fn=lambda c: TypeClusterResult(
-            name="widget", parent=None, residual_ids=[]
+            name="widget", parent="entity", residual_ids=[]
         ),
         mint_fn=fake_mint,
     )
@@ -546,7 +535,7 @@ def test_mint_publishes_event_without_ancestors(monkeypatch):
         hcg,
         _RecordingMilvus(),
         name_fn=lambda c: TypeClusterResult(
-            name="gadget", parent=None, residual_ids=[]
+            name="gadget", parent="entity", residual_ids=[]
         ),
         mint_fn=lambda *a, **k: "gadget_uuid",
         event_bus=EB(),
@@ -583,7 +572,7 @@ def test_handler_isolates_failing_cluster(monkeypatch):
         _RecordingMilvus(),
         name_fn=lambda c: TypeClusterResult(
             name="a" if c.members[0].uuid == "a0" else "b",
-            parent=None,
+            parent="entity",
             residual_ids=[],
         ),
         mint_fn=flaky_mint,

--- a/tests/maintenance/test_emergence_handler.py
+++ b/tests/maintenance/test_emergence_handler.py
@@ -306,14 +306,19 @@ def test_cross_realm_name_match_is_reused(monkeypatch):
     assert hcg.updated == []  # no type_uuid/type stamp on members
 
 
-def test_novel_name_no_parent_left_in_pool(monkeypatch):
-    """A new name with NO parent has no existing type to attach to and nothing to
-    mint under (mint requires name AND parent, #200): the cohort is HELD in the
-    pool, never minted as a root-named duplicate (the old root_fallback bug)."""
+def test_novel_name_no_parent_mints_under_realm_root(monkeypatch):
+    """A new name with NO parent must NOT be held: every emergent type roots under
+    a domain, so it mints under the SOURCE pool's realm root (the domain floor).
+    The attach-first check means only genuinely-novel names reach here, so no root
+    is duplicated."""
     cluster = EmergentCluster(members=[_m("a0"), _m("a1")])
     monkeypatch.setattr(eh, "find_emergent_clusters", lambda *a, **k: [cluster])
     hcg = _park(_entity_pool_hcg(), "a0", "a1")
-    minted = []
+    mint_calls = []
+
+    def fake_mint(cluster, name, hcg, milvus, source_cluster_id, **kwargs):
+        mint_calls.append(kwargs)
+        return "gadget_uuid"
 
     handler = _handler(
         hcg,
@@ -321,15 +326,18 @@ def test_novel_name_no_parent_left_in_pool(monkeypatch):
         name_fn=lambda c: TypeClusterResult(
             name="gadget", parent=None, residual_ids=[]
         ),
-        mint_fn=lambda *a, **k: minted.append(1),
+        mint_fn=fake_mint,
     )
     handler.run(type_uuid="entity_root")
 
-    # Nothing minted; members untouched and left in the pool for the next pass.
-    assert minted == []
-    assert hcg.membership_edges() == []
-    assert hcg.updated == []
-    assert hcg.deleted_edges == []
+    # Minted under the realm root (no parent -> domain floor); members placed.
+    assert len(mint_calls) == 1
+    assert mint_calls[0]["parent_type_uuid"] == "entity_root"
+    assert mint_calls[0]["placed_by"] == "root_fallback"
+    assert set(hcg.membership_edges()) == {
+        ("a0", "gadget_uuid"),
+        ("a1", "gadget_uuid"),
+    }
 
 
 def test_unresolvable_parent_falls_back_to_realm_root(monkeypatch):
@@ -549,7 +557,9 @@ def test_mint_publishes_event_without_ancestors(monkeypatch):
         "type_uuid": "gadget_uuid",
         "name": "gadget",
         "parent_uuid": "entity_root",
-        "placed_by": "root_fallback",
+        # parent="entity" resolved (it is the realm root) -> parent_resolution,
+        # distinct from an unresolvable-parent root_fallback (greptile #201).
+        "placed_by": "parent_resolution",
     }
     assert "ancestors" not in msg  # structure is the only membership (B1)
 

--- a/tests/maintenance/test_hermes_naming.py
+++ b/tests/maintenance/test_hermes_naming.py
@@ -145,23 +145,18 @@ def test_name_cluster_sends_all_when_under_max(monkeypatch):
 
 
 def test_type_cluster_posts_and_parses(monkeypatch):
-    """A NEW group: name + parent chain index 1 + TOP-LEVEL residual_ids parsed out
-    of the hermes v2 groups envelope, not a flat top-level name."""
+    """Hermes /type-cluster returns a FLAT verdict (#127/#199): top-level name +
+    parent + residual_ids -- no `groups` envelope, no chain/assign_to."""
     captured = {}
 
     def fake_post(url, json=None, headers=None, timeout=None):
         captured.update(url=url, json=json, headers=headers)
         return _FakeResp(
             {
-                "groups": [
-                    {
-                        "assign_to": "NEW",
-                        "name": "vehicle",
-                        "chain": ["vehicle", "object", "entity"],
-                        "member_ids": ["m1", "m2"],
-                    }
-                ],
+                "name": "vehicle",
+                "parent": "object",
                 "residual_ids": ["m3"],
+                "over_specified": False,
                 "raw_partition_ok": True,
             }
         )
@@ -174,8 +169,6 @@ def test_type_cluster_posts_and_parses(monkeypatch):
         token="t",
     )
 
-    # name == the group name; parent == chain index 1 (proposed guaranteed-existing
-    # super); residual_ids come from the TOP level, not the group.
     assert result == TypeClusterResult(
         name="vehicle", parent="object", residual_ids=["m3"]
     )
@@ -191,71 +184,35 @@ def test_type_cluster_posts_and_parses(monkeypatch):
     assert member["hermes_type_hint"] == "concept"
 
 
-def test_type_cluster_existing_type_reuse_has_no_parent(monkeypatch):
-    """An EXISTING-type group (assign_to is a uuid, not NEW) proposes no parent:
-    the handler re-points members onto the existing same-name type rather than
-    minting, so chain index 1 is ignored and parent is None."""
+def test_type_cluster_reuse_has_null_parent(monkeypatch):
+    """parent=null => `name` is an existing type to REUSE; parent stays None."""
 
     def fake_post(url, json=None, headers=None, timeout=None):
-        return _FakeResp(
-            {
-                "groups": [
-                    {
-                        "assign_to": "11111111-2222-3333-4444-555555555555",
-                        "name": "vehicle",
-                        "chain": ["vehicle"],
-                    }
-                ],
-                "residual_ids": [],
-            }
-        )
+        return _FakeResp({"name": "vehicle", "parent": None, "residual_ids": []})
 
     monkeypatch.setattr(hn.httpx, "post", fake_post)
 
     result = hn.type_cluster(_cluster(), hermes_url="http://h", token="t")
-    assert result is not None
-    assert result.name == "vehicle"
-    assert result.parent is None
-    assert result.residual_ids == []
+    assert result == TypeClusterResult(name="vehicle", parent=None, residual_ids=[])
 
 
-def test_type_cluster_new_group_single_element_chain_has_no_parent(monkeypatch):
-    """A NEW group whose chain holds only the type itself (no super) gives None."""
+def test_type_cluster_missing_parent_key_is_none(monkeypatch):
+    """An omitted `parent` key is treated as null (reuse), not an error."""
 
     def fake_post(url, json=None, headers=None, timeout=None):
-        return _FakeResp(
-            {"groups": [{"assign_to": "NEW", "name": "concept", "chain": ["concept"]}]}
-        )
+        return _FakeResp({"name": "concept", "residual_ids": []})
 
     monkeypatch.setattr(hn.httpx, "post", fake_post)
-
     result = hn.type_cluster(_cluster(), hermes_url="http://h", token="t")
-    assert result is not None
-    assert result.name == "concept"
-    assert result.parent is None
-    assert result.residual_ids == []
+    assert result == TypeClusterResult(name="concept", parent=None, residual_ids=[])
 
 
-def test_type_cluster_no_groups_key_returns_none(monkeypatch):
-    def fake_post(url, json=None, headers=None, timeout=None):
-        return _FakeResp({"residual_ids": [], "raw_partition_ok": True})
+def test_type_cluster_no_name_returns_none(monkeypatch):
+    """No top-level `name` => failure (None) with a warning."""
 
-    monkeypatch.setattr(hn.httpx, "post", fake_post)
-    assert hn.type_cluster(_cluster(), hermes_url="http://h", token="t") is None
-
-
-def test_type_cluster_empty_groups_returns_none(monkeypatch):
-    def fake_post(url, json=None, headers=None, timeout=None):
-        return _FakeResp({"groups": [], "residual_ids": []})
-
-    monkeypatch.setattr(hn.httpx, "post", fake_post)
-    assert hn.type_cluster(_cluster(), hermes_url="http://h", token="t") is None
-
-
-def test_type_cluster_empty_name_returns_none(monkeypatch):
     def fake_post(url, json=None, headers=None, timeout=None):
         return _FakeResp(
-            {"groups": [{"assign_to": "NEW", "name": "", "chain": ["", "entity"]}]}
+            {"parent": "object", "residual_ids": [], "raw_partition_ok": True}
         )
 
     monkeypatch.setattr(hn.httpx, "post", fake_post)
@@ -263,6 +220,19 @@ def test_type_cluster_empty_name_returns_none(monkeypatch):
     # run the app logging config can disable propagation to caplog root handler,
     # so the (emitted) warning is not captured -- a CI-only flake. The contract
     # is result is None AND a warning was logged.
+    warnings: list[tuple] = []
+    monkeypatch.setattr(hn.logger, "warning", lambda *a, **k: warnings.append((a, k)))
+    assert hn.type_cluster(_cluster(), hermes_url="http://h", token="t") is None
+    assert warnings
+
+
+def test_type_cluster_empty_name_returns_none(monkeypatch):
+    """A whitespace-only `name` is a failure (None) with a warning."""
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        return _FakeResp({"name": "   ", "parent": "object", "residual_ids": []})
+
+    monkeypatch.setattr(hn.httpx, "post", fake_post)
     warnings: list[tuple] = []
     monkeypatch.setattr(hn.logger, "warning", lambda *a, **k: warnings.append((a, k)))
     result = hn.type_cluster(_cluster(), hermes_url="http://h", token="t")
@@ -273,16 +243,6 @@ def test_type_cluster_empty_name_returns_none(monkeypatch):
 def test_type_cluster_returns_none_on_non_dict_json(monkeypatch):
     def fake_post(url, json=None, headers=None, timeout=None):
         return _FakeResp(["not", "a", "dict"])
-
-    monkeypatch.setattr(hn.httpx, "post", fake_post)
-    assert hn.type_cluster(_cluster(), hermes_url="http://h", token="t") is None
-
-
-def test_type_cluster_group_missing_name_returns_none(monkeypatch):
-    def fake_post(url, json=None, headers=None, timeout=None):
-        return _FakeResp(
-            {"groups": [{"assign_to": "NEW", "chain": ["vehicle"]}], "residual_ids": []}
-        )
 
     monkeypatch.setattr(hn.httpx, "post", fake_post)
     assert hn.type_cluster(_cluster(), hermes_url="http://h", token="t") is None
@@ -302,7 +262,7 @@ def test_type_cluster_returns_none_on_http_status_error(monkeypatch):
             raise httpx.HTTPError("500 server error")
 
         def json(self):
-            return {"groups": [{"assign_to": "NEW", "name": "vehicle"}]}
+            return {"name": "vehicle", "parent": None}
 
     def fake_post(*args, **kwargs):
         return _FakeBadStatusResp()
@@ -311,23 +271,11 @@ def test_type_cluster_returns_none_on_http_status_error(monkeypatch):
     assert hn.type_cluster(_cluster(), hermes_url="http://h", token="t") is None
 
 
-def test_type_cluster_null_chain_entry_yields_no_parent(monkeypatch):
-    """A JSON null at chain[1] must NOT become the literal string "None" as a
-    parent name; it should resolve to parent=None."""
+def test_type_cluster_null_parent_yields_no_parent(monkeypatch):
+    """A JSON null `parent` must resolve to parent=None, never the string "None"."""
 
     def fake_post(url, json=None, headers=None, timeout=None):
-        return _FakeResp(
-            {
-                "groups": [
-                    {
-                        "assign_to": "NEW",
-                        "name": "vehicle",
-                        "chain": ["vehicle", None, "entity"],
-                    }
-                ],
-                "residual_ids": [],
-            }
-        )
+        return _FakeResp({"name": "vehicle", "parent": None, "residual_ids": []})
 
     monkeypatch.setattr(hn.httpx, "post", fake_post)
     result = hn.type_cluster(_cluster(), hermes_url="http://h", token="t")
@@ -339,69 +287,20 @@ def test_type_cluster_non_list_residual_ids_ignored(monkeypatch):
     must not be iterated char-by-char; it is treated as no residuals."""
 
     def fake_post(url, json=None, headers=None, timeout=None):
-        return _FakeResp(
-            {
-                "groups": [
-                    {
-                        "assign_to": "NEW",
-                        "name": "vehicle",
-                        "chain": ["vehicle", "object"],
-                    }
-                ],
-                "residual_ids": "m3",
-            }
-        )
+        return _FakeResp({"name": "vehicle", "parent": "object", "residual_ids": "m3"})
 
     monkeypatch.setattr(hn.httpx, "post", fake_post)
     result = hn.type_cluster(_cluster(), hermes_url="http://h", token="t")
     assert result == TypeClusterResult(name="vehicle", parent="object", residual_ids=[])
 
 
-def test_type_cluster_whitespace_assign_to_treated_as_new(monkeypatch):
-    """A whitespace-only assign_to is a missing value, not an existing-type
-    reuse: it must default to NEW so the parent is taken from the chain."""
+def test_type_cluster_whitespace_parent_treated_as_none(monkeypatch):
+    """A whitespace-only `parent` collapses to None (reuse), not a bogus parent
+    name that would force a spurious graft."""
 
     def fake_post(url, json=None, headers=None, timeout=None):
-        return _FakeResp(
-            {
-                "groups": [
-                    {
-                        "assign_to": "   ",
-                        "name": "vehicle",
-                        "chain": ["vehicle", "object", "entity"],
-                    }
-                ],
-                "residual_ids": [],
-            }
-        )
+        return _FakeResp({"name": "vehicle", "parent": "   ", "residual_ids": []})
 
     monkeypatch.setattr(hn.httpx, "post", fake_post)
     result = hn.type_cluster(_cluster(), hermes_url="http://h", token="t")
-    assert result == TypeClusterResult(name="vehicle", parent="object", residual_ids=[])
-
-
-def test_type_cluster_multiple_groups_uses_first_and_warns(monkeypatch):
-    """Hermes v2 guarantees one group; if more arrive, use the first but log a
-    warning so the contract violation is observable."""
-
-    def fake_post(url, json=None, headers=None, timeout=None):
-        return _FakeResp(
-            {
-                "groups": [
-                    {
-                        "assign_to": "NEW",
-                        "name": "vehicle",
-                        "chain": ["vehicle", "object"],
-                    },
-                    {"assign_to": "NEW", "name": "boat", "chain": ["boat", "object"]},
-                ],
-                "residual_ids": [],
-            }
-        )
-
-    monkeypatch.setattr(hn.httpx, "post", fake_post)
-    warnings: list[tuple] = []
-    monkeypatch.setattr(hn.logger, "warning", lambda *a, **k: warnings.append((a, k)))
-    result = hn.type_cluster(_cluster(), hermes_url="http://h", token="t")
-    assert result == TypeClusterResult(name="vehicle", parent="object", residual_ids=[])
-    assert warnings  # the >1-group contract violation was logged
+    assert result == TypeClusterResult(name="vehicle", parent=None, residual_ids=[])


### PR DESCRIPTION
## What

Fixes the naming-driven-typing (NDT) pipeline, which was producing **zero** usable type emergence. Two faults, both on the sophia side (contracts live in `logos`; hermes already emits the correct shape).

### #199 — `/type-cluster` parser drift
`hermes_naming.type_cluster` parsed `data["groups"][0]["name"]` + `assign_to` + `chain`. Hermes `/type-cluster` (#127) returns a **flat** `{name, parent, residual_ids, over_specified, raw_partition_ok}`. `data.get("groups")` was always `None`, so every cluster failed naming → `cluster left in pool (no name)` → nothing was ever minted. Now parses the flat contract; `groups`/`chain`/`assign_to` removed. `TypeClusterResult` and `_place_cluster` already expected this shape.

### #200 — cascade minted duplicate realm roots
`_place_cluster` minted whenever it failed to *reuse*, and its reuse guard (`existing != source AND realm_of(existing) == realm`) rejected the two answers hermes actually returns:
- `name="concept", parent=null` for a cohort under `entity` (a realm correction) → realm mismatch → fell through to a duplicate `concept` mint;
- `name="entity"` in the entity pool → `existing == source` → duplicate `entity` mint.

On the cellbio graph this produced 8×`concept`, 5×`process`, 1×`entity` clones. Replaced with a single **mint-or-attach invariant**:

| name | parent | action |
|------|--------|--------|
| yes  | yes    | **MINT** `name` under `parent` (unless the name already exists → attach) |
| yes  | no     | **ATTACH** to the existing type named `name` (realm-agnostic; `== source` → no-op) |
| no   | —      | **HOLD** in pool |

Mint iff (name ∧ parent) and the name isn't already a type. Same-name dedup (#38) is now implicit; cross-realm reuse corrects mis-pooled cohorts instead of duplicating a root.

## Testing
- Rewrote `tests/maintenance/test_hermes_naming.py` to the flat contract and `tests/maintenance/test_emergence_handler.py` to the mint-or-attach invariant (incl. an inverted cross-realm-reuse test and a new novel-name-no-parent hold test).
- `pytest tests/maintenance/` → **148 passed**. `ruff` clean, `black` formatted.
- Parser verified end-to-end against live hermes (flat response parses to a populated `TypeClusterResult`).

## Not in scope (follow-ups)
- Granular sub-typing still needs tighter clustering + a mint-specific hermes prompt (today hermes reuses realm roots rather than coining `organelle`/`enzyme`).
- The cellbio ingest mis-types many processes/concepts as `entity`.

Fixes #199
Fixes #200
