### PR TITLE
Positional type layer + evolving centroids + logos v0.7.4 pin

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -886,8 +886,8 @@ uvicorn = {version = "^0.32.0", extras = ["standard"]}
 [package.source]
 type = "git"
 url = "https://github.com/c-daly/logos.git"
-reference = "v0.7.3"
-resolved_reference = "df52348fc1c393c3401ecbdd98198aaaff560147"
+reference = "v0.7.4"
+resolved_reference = "0931309ee1c47ebb4c6a4d29ef81ba1775b00daf"
 
 [[package]]
 name = "markupsafe"
@@ -3516,4 +3516,4 @@ otel = ["opentelemetry-api", "opentelemetry-exporter-otlp", "opentelemetry-instr
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "a1f30de884e433d242ebf124fbd8764dffa4a73c1b1a09cdaf1934f4190a2651"
+content-hash = "748a68b7551e516645fbe217fb552b5cf05f1ab4e99245d52bcf1896a4f09faa"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ urllib3 = "^2.5.0"
 redis = ">=5.0.0"
 pydantic-settings = ">=2.0.0"
 # Also provides: logos_config, logos_test_utils, logos_tools, logos_hcg
-logos-foundry = { git = "https://github.com/c-daly/logos.git", tag = "v0.7.3" }
+logos-foundry = { git = "https://github.com/c-daly/logos.git", tag = "v0.7.4" }
 # OpenTelemetry (optional, see [tool.poetry.extras])
 opentelemetry-api = {version = "^1.20.0", optional = true}
 opentelemetry-sdk = {version = "^1.20.0", optional = true}

--- a/src/sophia/api/app.py
+++ b/src/sophia/api/app.py
@@ -621,6 +621,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
                 config=_maintenance_config,
                 handlers=_handlers,
                 hcg_client=_hcg_client,
+                redis_client=_maint_redis,
             )
             _maintenance_task = asyncio.create_task(_maintenance_scheduler.start())
             logger.info("Maintenance scheduler started")

--- a/src/sophia/ingestion/proposal_processor.py
+++ b/src/sophia/ingestion/proposal_processor.py
@@ -290,11 +290,21 @@ class ProposalProcessor:
             # the type-definition catalog so each new instance can be parked under
             # its realm via an IS_A edge (#505). Mirrors the maintenance tier's
             # name->uuid resolution (emergence_handler); built once per batch.
-            uuid_by_name = {
-                n["name"].strip().lower(): n["uuid"]
-                for n in self._hcg.get_all_type_definitions()
-                if n.get("name") and n.get("uuid")
-            }
+            # Fail-soft: if the catalog query fails (e.g. Neo4j transient error),
+            # proceed with an empty map -- nodes are created but left unparked
+            # (the maintenance reconcile loop re-parks them later).
+            try:
+                uuid_by_name = {
+                    n["name"].strip().lower(): n["uuid"]
+                    for n in self._hcg.get_all_type_definitions()
+                    if n.get("name") and n.get("uuid")
+                }
+            except Exception:
+                logger.exception(
+                    "ingest: failed to fetch realm-root catalog; nodes will be "
+                    "created unparked and re-parked by the reconcile loop"
+                )
+                uuid_by_name = {}
 
             with tracer.start_as_current_span("proposal_processor.ingest_nodes"):
                 for proposed in proposal.get("proposed_nodes", []):

--- a/src/sophia/ingestion/proposal_processor.py
+++ b/src/sophia/ingestion/proposal_processor.py
@@ -8,12 +8,12 @@ Sophia operates on embeddings, not text. Text properties exist on nodes
 for Hermes's benefit when context is returned.
 """
 
-import json
 import logging
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Literal, Tuple
 
 from sophia.maintenance import placement
+from sophia.maintenance.type_snapshot import publish_type_snapshot
 
 logger = logging.getLogger(__name__)
 
@@ -199,28 +199,13 @@ class ProposalProcessor:
             logger.exception("Failed to publish proposal_processed event")
 
     def _write_type_snapshot(self) -> None:
-        """Write full type list to Redis for Hermes initial sync."""
-        if self._redis is None:
-            return
-        try:
-            records = self._hcg.get_all_type_definitions()
-            snapshot: dict[str, dict[str, Any]] = {}
-            for record in records:
-                name = record.get("name", "")
-                if not name:
-                    continue
-                props = record.get("properties")
-                if isinstance(props, dict):
-                    member_count = props.get("member_count", 0)
-                else:
-                    member_count = 0
-                snapshot[name] = {
-                    "uuid": record.get("uuid", ""),
-                    "member_count": member_count,
-                }
-            self._redis.set("logos:ontology:types", json.dumps(snapshot))
-        except Exception:
-            logger.exception("Failed to write type snapshot to Redis")
+        """Write full type list to Redis for Hermes initial sync.
+
+        Delegates to the shared positional snapshot writer so ingest, the
+        scheduler reconcile loop, and the emergence event all produce an
+        identical snapshot of the real (incoming-IS_A) type layer.
+        """
+        publish_type_snapshot(self._hcg, self._redis)
 
     def process(self, proposal: dict) -> dict:
         """Process a proposal: search for context, decide what to ingest."""
@@ -307,7 +292,7 @@ class ProposalProcessor:
             # name->uuid resolution (emergence_handler); built once per batch.
             uuid_by_name = {
                 n["name"].strip().lower(): n["uuid"]
-                for n in self._hcg.list_all_nodes(node_type="type_definition")
+                for n in self._hcg.get_all_type_definitions()
                 if n.get("name") and n.get("uuid")
             }
 

--- a/src/sophia/maintenance/centroid.py
+++ b/src/sophia/maintenance/centroid.py
@@ -18,6 +18,7 @@ centroid is their mean, and the ``embedding_model`` label is read off the
 existing vectors (the vector's dimension is the real invariant -- sophia rejects
 a dim mismatch at write time -- so the label is metadata, never fabricated).
 """
+
 from __future__ import annotations
 
 import logging
@@ -108,8 +109,13 @@ def reconcile_centroids(hcg: Any, milvus: Any) -> dict[str, int]:
     protected/reserved roots and any type whose members lack embeddings or carry
     more than one model (no fabrication). Returns a small stats dict; fail-soft.
     """
-    stats = {"written": 0, "skipped_protected": 0, "skipped_no_embeddings": 0,
-             "skipped_mixed_model": 0, "errors": 0}
+    stats = {
+        "written": 0,
+        "skipped_protected": 0,
+        "skipped_no_embeddings": 0,
+        "skipped_mixed_model": 0,
+        "errors": 0,
+    }
     if hcg is None or milvus is None:
         return stats
     try:
@@ -123,8 +129,10 @@ def reconcile_centroids(hcg: Any, milvus: Any) -> dict[str, int]:
         name = (t.get("name") or "").strip().lower()
         if not tu:
             continue
-        if name in _PROTECTED_ROOT_NAMES or name.startswith("_") or name.startswith(
-            "reserved_"
+        if (
+            name in _PROTECTED_ROOT_NAMES
+            or name.startswith("_")
+            or name.startswith("reserved_")
         ):
             stats["skipped_protected"] += 1
             continue

--- a/src/sophia/maintenance/centroid.py
+++ b/src/sophia/maintenance/centroid.py
@@ -1,0 +1,161 @@
+"""Type-centroid maintenance: incremental online-mean on graft + full reconcile.
+
+A type's centroid is the mean of its DIRECT members' embeddings -- the same thing
+``mint_type`` writes once from the founding cluster. It must stay current as
+members are grafted, because the mint/reuse decision
+(``type_rollup_handler._match_existing_type``) matches a candidate cluster's
+centroid against EXISTING type centroids: stale centroids there mean minting a
+duplicate or reusing the wrong type.
+
+Full recompute per graft is O(members) and prohibitively expensive at scale, so:
+  - on graft we fold the new member(s) into the running mean in O(dim)
+    (:func:`online_mean_add` / :func:`bump_centroid`);
+  - a periodic job recomputes everything from scratch (:func:`reconcile_centroids`)
+    to repair float drift, removals, and anything the incremental path missed.
+
+Nothing here invokes an embedding model: the member vectors already exist; a
+centroid is their mean, and the ``embedding_model`` label is read off the
+existing vectors (the vector's dimension is the real invariant -- sophia rejects
+a dim mismatch at write time -- so the label is metadata, never fabricated).
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Member content embeddings physically live in the base "Entity" collection
+# (_CONTENT_COLLECTION); type centroids in "TypeCentroid". Both are realm-agnostic.
+_CONTENT_COLLECTION = "Entity"
+_TYPE_CENTROID = "TypeCentroid"
+# Seeded structural/realm roots: never carry a content centroid (not rollup
+# candidates; some have no member embeddings to average).
+_PROTECTED_ROOT_NAMES = frozenset(
+    {"root", "node", "entity", "concept", "cognition", "process"}
+)
+
+
+def online_mean_add(
+    centroid: list[float] | None, n: int, embeddings: list[list[float]]
+) -> list[float] | None:
+    """Mean of ``n`` vectors (whose mean is ``centroid``) after adding ``embeddings``.
+
+    Pure, O(dim * k). When ``centroid`` is falsy or ``n`` <= 0 this initialises:
+    it returns the plain mean of ``embeddings`` (the founding case). Returns the
+    unchanged ``centroid`` if there is nothing to add.
+    """
+    vecs = [e for e in embeddings if e]
+    if not vecs:
+        return centroid
+    k = len(vecs)
+    dim = len(vecs[0])
+    sums = [sum(e[i] for e in vecs) for i in range(dim)]
+    if not centroid or n <= 0:
+        return [s / k for s in sums]
+    return [(centroid[i] * n + sums[i]) / (n + k) for i in range(dim)]
+
+
+def bump_centroid(
+    milvus: Any,
+    type_uuid: str,
+    embeddings: list[list[float]],
+    n: int,
+    *,
+    model: str | None = None,
+) -> None:
+    """Fold ``embeddings`` into ``type_uuid``'s centroid incrementally (fail-soft).
+
+    ``n`` is the type's direct-member count BEFORE this add (the cheap
+    ``member_count`` already tracked in the type snapshot / a direct in-degree
+    count). The model label is read off the existing centroid when present,
+    otherwise taken from ``model`` (the members' recorded embedding_model) --
+    never invented. A failure just leaves the centroid for the periodic reconcile
+    to repair rather than breaking the graft.
+    """
+    if milvus is None or not type_uuid:
+        return
+    vecs = [e for e in embeddings if e]
+    if not vecs:
+        return
+    try:
+        cur = milvus.get_embedding(node_type=_TYPE_CENTROID, uuid=type_uuid) or {}
+        old = cur.get("embedding")
+        # A centroid exists but we don't have its prior count (n<=0): folding
+        # would re-init it to just the new members' mean and lose the existing
+        # population. Don't corrupt -- leave it for the periodic reconcile.
+        if old and n <= 0:
+            return
+        mdl = cur.get("embedding_model") or model
+        new = online_mean_add(old, n, vecs)
+        if new is None:
+            return
+        milvus.update_centroid(type_uuid=type_uuid, centroid=new, model=mdl)
+    except Exception:
+        logger.exception("centroid bump failed for %s", type_uuid)
+
+
+def reconcile_centroids(hcg: Any, milvus: Any) -> dict[str, int]:
+    """Recompute every type's centroid from its direct members' current embeddings.
+
+    The periodic backstop + initialiser: corrects drift/removals the incremental
+    path can't, and seeds a centroid for any type that never had one (e.g. an
+    accreted content type that became a type by graft, not by mint). Skips the
+    protected/reserved roots and any type whose members lack embeddings or carry
+    more than one model (no fabrication). Returns a small stats dict; fail-soft.
+    """
+    stats = {"written": 0, "skipped_protected": 0, "skipped_no_embeddings": 0,
+             "skipped_mixed_model": 0, "errors": 0}
+    if hcg is None or milvus is None:
+        return stats
+    try:
+        types = hcg.get_all_type_definitions()
+    except Exception:
+        logger.exception("centroid reconcile: failed to list types")
+        stats["errors"] += 1
+        return stats
+    for t in types or []:
+        tu = t.get("uuid")
+        name = (t.get("name") or "").strip().lower()
+        if not tu:
+            continue
+        if name in _PROTECTED_ROOT_NAMES or name.startswith("_") or name.startswith(
+            "reserved_"
+        ):
+            stats["skipped_protected"] += 1
+            continue
+        try:
+            member_uuids = _member_uuids(hcg, tu)
+            embs: list[list[float]] = []
+            models: set[str] = set()
+            for m in member_uuids:
+                e = milvus.get_embedding(node_type=_CONTENT_COLLECTION, uuid=m)
+                if e and e.get("embedding"):
+                    embs.append(e["embedding"])
+                    if e.get("embedding_model"):
+                        models.add(e["embedding_model"])
+            if not embs:
+                stats["skipped_no_embeddings"] += 1
+                continue
+            if len(models) > 1:
+                stats["skipped_mixed_model"] += 1
+                continue
+            centroid = online_mean_add(None, 0, embs)
+            milvus.update_centroid(
+                type_uuid=tu, centroid=centroid, model=next(iter(models), None)
+            )
+            stats["written"] += 1
+        except Exception:
+            logger.exception("centroid reconcile failed for %s", tu)
+            stats["errors"] += 1
+    logger.info("centroid reconcile: %s", stats)
+    return stats
+
+
+def _member_uuids(hcg: Any, type_uuid: str) -> list[str]:
+    """Direct members of a type: nodes whose reified IS_A edge points :TO it."""
+    query = """
+    MATCH (m:Node)<-[:FROM]-(:Node {relation: "IS_A"})-[:TO]->(t:Node {uuid: $u})
+    RETURN m.uuid AS uuid
+    """
+    return [r["uuid"] for r in hcg._execute_read(query, {"u": type_uuid})]

--- a/src/sophia/maintenance/centroid.py
+++ b/src/sophia/maintenance/centroid.py
@@ -53,6 +53,10 @@ def online_mean_add(
     sums = [sum(e[i] for e in vecs) for i in range(dim)]
     if not centroid or n <= 0:
         return [s / k for s in sums]
+    assert len(centroid) == dim, (
+        f"online_mean_add: centroid dim {len(centroid)} != new-vec dim {dim}; "
+        "dimension mismatch should be caught at Milvus write time"
+    )
     return [(centroid[i] * n + sums[i]) / (n + k) for i in range(dim)]
 
 

--- a/src/sophia/maintenance/config.py
+++ b/src/sophia/maintenance/config.py
@@ -57,16 +57,17 @@ class MaintenanceConfig(BaseSettings):
         description="Discard Hermes cluster names below this confidence.",
     )
     rollup_enabled: bool = Field(
-        # The rollup (revision) tier's WRITE side is now on placement.py -- it
-        # re-points IS_A edges and writes no `ancestors` property (#24). It stays
-        # gated OFF because it still (a) resolves `type_<name>` slugs for realm
-        # roots, which dangle against the uuid5 seeder, and (b) infers membership
-        # by reading the `type`/`type_uuid` properties (#35). Both must go
-        # edge-based before it can run correctly on a reseeded graph.
-        default=False,
+        # The rollup is now fully edge-based (#209):
+        #   (a) realm roots are resolved by uuid positionally via _root_uuid_by_name
+        #       (landed in commit 5e8825b; no `type_<name>` slugs remain), and
+        #   (b) membership is derived from the IS_A edge target in _type_uuid_map,
+        #       not from the `type_uuid` / `type` property (which doesn't exist on
+        #       a reseeded graph).
+        # Both blockers are gone; the rollup can run on positional/reseeded graphs.
+        default=True,
         description="Run the periodic type-level rollup that groups the flat "
-        "layer of emergent types into super-types (#160). Disabled pending "
-        "realm-root uuid + read-path edge conversion (#35).",
+        "layer of emergent types into super-types (#160). Enabled after "
+        "edge-based realm-root resolution and IS_A-edge read-path (#209).",
     )
     rollup_interval_seconds: int = Field(
         default=600,

--- a/src/sophia/maintenance/emergence_handler.py
+++ b/src/sophia/maintenance/emergence_handler.py
@@ -54,19 +54,22 @@ def _cosine(a: list[float], b: list[float]) -> float:
 
 
 def _type_name(type_uuid: str) -> str:
-    """Best-effort label from a type-definition uuid.
+    """Best-effort display handle for a type uuid.
 
-    Minted uuids are ``type_<label>_<hex8>`` and base/legacy ones ``type_<name>``.
-    Used only as the ``current_type`` display fallback in :func:`_build_member`;
-    membership itself is the IS_A edge, never this slug (B2/B3, DESIGN §3).
+    Type uuids are now opaque (``uuid4``) and carry no embedded name -- the name
+    lives on the node, and membership is the IS_A edge, never the uuid (B2/B3,
+    DESIGN §3). Used only as the ``current_type`` display fallback in
+    :func:`_build_member`, so returning the uuid verbatim is sufficient; the
+    legacy ``type_<name>`` prefix is no longer parsed.
     """
-    return type_uuid[len("type_") :] if type_uuid.startswith("type_") else type_uuid
+    return type_uuid
 
 
 def current_categories(hcg: Any) -> list[str]:
-    """Existing type-definition labels, excluding `entity` and reserved_* types."""
+    """Existing type names (positional: nodes with incoming IS_A), excluding
+    `entity` and reserved_* types."""
     out: list[str] = []
-    for node in hcg.list_all_nodes(node_type="type_definition"):
+    for node in hcg.get_all_type_definitions():
         name = node.get("name")
         if not name or name == "entity" or name.startswith("reserved_"):
             continue
@@ -200,7 +203,7 @@ class EmergenceHandler:
         # `type_<name>` slug (DESIGN sec 3).
         uuid_by_name = {
             n["name"].strip().lower(): n["uuid"]
-            for n in self._hcg.list_all_nodes(node_type="type_definition")
+            for n in self._hcg.get_all_type_definitions()
             if n.get("name") and n.get("uuid")
         }
 
@@ -343,6 +346,7 @@ class EmergenceHandler:
             milvus=self._milvus,
             source_cluster_id=uuid_lib.uuid4().hex[:8],
             parent_type_uuid=parent_uuid,
+            realm=realm,
             placed_by=placed_by,
         )
         # Re-point each fitting member's instance->type IS_A edge onto the

--- a/src/sophia/maintenance/emergence_handler.py
+++ b/src/sophia/maintenance/emergence_handler.py
@@ -415,10 +415,16 @@ class EmergenceHandler:
                 bump_centroid(self._milvus, type_uuid, embs, n_before, model=model)
 
     def _member_count(self, type_uuid: str) -> int:
-        """Direct-member in-degree of a type (cheap); 0 on any failure."""
+        """Direct content-member in-degree of a type (cheap); 0 on any failure.
+
+        Uses the :FROM leg to reach the source node, matching only content-node
+        members (the same pattern as ``_member_uuids`` in centroid.py). Without
+        the :FROM leg, child-type taxonomy edges (child_type IS_A parent_type)
+        would also be counted, inflating n_before for ``online_mean_add``.
+        """
         try:
             rows = self._hcg._execute_read(
-                'MATCH (:Node {relation: "IS_A"})-[:TO]->(t:Node {uuid: $u}) '
+                'MATCH (:Node)<-[:FROM]-(:Node {relation: "IS_A"})-[:TO]->(t:Node {uuid: $u}) '
                 "RETURN count(*) AS n",
                 {"u": type_uuid},
             )

--- a/src/sophia/maintenance/emergence_handler.py
+++ b/src/sophia/maintenance/emergence_handler.py
@@ -20,6 +20,7 @@ from collections.abc import Callable
 from typing import Any
 
 from sophia.maintenance import placement
+from sophia.maintenance.centroid import bump_centroid
 from sophia.maintenance.config import MaintenanceConfig
 from sophia.maintenance.emergence_clustering import find_emergent_clusters
 from sophia.maintenance.emergence_types import EmergentCluster, Member, NameResult
@@ -389,6 +390,14 @@ class EmergenceHandler:
         is stamped. Members are leaves, so the cycle guard is trivially false and
         the type-layer hierarchy in ``children_of`` is unaffected.
         """
+        # Incremental centroid maintenance fires ONLY on the attach path
+        # (placed_by == "name_reuse"): we add members to a PRE-EXISTING type, so
+        # its centroid must fold them in. On the mint path mint_type already
+        # built the centroid from these same founding members -> bumping would
+        # double-count. Members are leaves, so a member's embedding IS its
+        # representation (no subtree walk). n = direct-member count BEFORE attach.
+        attach = placed_by == "name_reuse"
+        n_before = self._member_count(type_uuid) if attach else 0
         for member in members:
             placement.reparent(
                 member.uuid,
@@ -397,6 +406,26 @@ class EmergenceHandler:
                 children_of=children_of,
                 placed_by=placed_by,
             )
+        if attach:
+            embs = [m.embedding for m in members if getattr(m, "embedding", None)]
+            if embs:
+                model = next(
+                    (m.model for m in members if getattr(m, "model", None)), None
+                )
+                bump_centroid(self._milvus, type_uuid, embs, n_before, model=model)
+
+    def _member_count(self, type_uuid: str) -> int:
+        """Direct-member in-degree of a type (cheap); 0 on any failure."""
+        try:
+            rows = self._hcg._execute_read(
+                'MATCH (:Node {relation: "IS_A"})-[:TO]->(t:Node {uuid: $u}) '
+                "RETURN count(*) AS n",
+                {"u": type_uuid},
+            )
+            return int(rows[0]["n"]) if rows else 0
+        except Exception:
+            logger.exception("emergence: member count failed for %s", type_uuid)
+            return 0
 
 
 def build_emergence_handler(

--- a/src/sophia/maintenance/scheduler.py
+++ b/src/sophia/maintenance/scheduler.py
@@ -9,7 +9,9 @@ import threading
 from typing import Any, Callable
 
 from sophia.maintenance.config import MaintenanceConfig
+from sophia.maintenance.emergence_handler import ONTOLOGY_CHANGED_CHANNEL
 from sophia.maintenance.job_queue import MaintenanceJob, MaintenanceQueue
+from sophia.maintenance.type_snapshot import publish_type_snapshot
 
 logger = logging.getLogger(__name__)
 
@@ -34,6 +36,7 @@ class MaintenanceScheduler:
         config: MaintenanceConfig,
         handlers: dict[str, Callable],
         hcg_client: Any | None = None,
+        redis_client: Any | None = None,
     ) -> None:
         """Initialize the scheduler.
 
@@ -43,12 +46,16 @@ class MaintenanceScheduler:
             config: Maintenance scheduler configuration.
             handlers: Mapping of job_type -> callable handler.
             hcg_client: Optional HCG client for graph operations.
+            redis_client: Optional Redis client for keeping the
+                ``logos:ontology:types`` snapshot in sync (incremental on
+                ``ontology.type_created``, reconcile in the periodic loop).
         """
         self._queue = queue
         self._event_bus = event_bus
         self._config = config
         self._handlers = handlers
         self._hcg = hcg_client
+        self._redis = redis_client
         self._running = False
         self._semaphore: asyncio.Semaphore | None = None
         self._listener_thread: threading.Thread | None = None
@@ -72,6 +79,17 @@ class MaintenanceScheduler:
                 self._on_threshold_crossed,
             )
             logger.info("Subscribed to logos:sophia:threshold_crossed")
+
+        # Keep the Redis type snapshot in sync incrementally: emergence
+        # publishes ONTOLOGY_CHANGED_CHANNEL on every mint, and we re-publish
+        # the full positional snapshot in response. The periodic loop reconciles
+        # against drift. Only worth subscribing if we have a Redis handle.
+        if self._redis is not None:
+            self._event_bus.subscribe(
+                ONTOLOGY_CHANGED_CHANNEL,
+                self._on_ontology_type_created,
+            )
+            logger.info("Subscribed to %s", ONTOLOGY_CHANGED_CHANNEL)
 
     def _on_proposal_processed(self, event: dict) -> None:
         """Handle proposal_processed events by enqueuing discovery jobs.
@@ -144,6 +162,28 @@ class MaintenanceScheduler:
                 )
         except Exception:
             logger.exception("Error handling threshold_crossed event")
+
+    def _on_ontology_type_created(self, event: dict) -> None:
+        """Re-publish the Redis type snapshot when emergence mints a type.
+
+        Incremental sync (the user's ask): the snapshot stays current as Sophia
+        adds types, without waiting for the next ingest batch or periodic
+        reconcile. We re-gather the full positional type layer rather than
+        patching the single new entry, because grafting one node shifts the
+        member_count of its ancestor types too -- a full re-publish is the only
+        drift-free option, and the positional query is cheap.
+
+        Note: Called from the EventBus listener thread. Must remain synchronous.
+        ``publish_type_snapshot`` is itself fail-soft; the extra guard keeps a
+        bad event from killing the listener thread.
+
+        Args:
+            event: The ``ontology.type_created`` payload (unused -- we re-gather).
+        """
+        try:
+            publish_type_snapshot(self._hcg, self._redis)
+        except Exception:
+            logger.exception("Error handling ontology.type_created event")
 
     def _check_thresholds(self, type_uuids: list[str]) -> None:
         """Check if any types cross the member count threshold."""
@@ -265,6 +305,15 @@ class MaintenanceScheduler:
                                 priority="low",
                                 params={"type_uuid": type_uuid},
                             )
+
+                # Reconcile the Redis type snapshot against the graph. The
+                # incremental ontology.type_created path keeps it current in the
+                # common case; this is the periodic safety net that repairs any
+                # drift (missed events, out-of-band graph edits).
+                if self._redis is not None and self._hcg is not None:
+                    await asyncio.to_thread(
+                        publish_type_snapshot, self._hcg, self._redis
+                    )
             except Exception:
                 if self._running:
                     logger.exception("Error in periodic loop")

--- a/src/sophia/maintenance/type_correction_handler.py
+++ b/src/sophia/maintenance/type_correction_handler.py
@@ -135,7 +135,7 @@ class TypeCorrectionHandler:
         """
         if self._entity_uuid is None:
             try:
-                for n in self._hcg.list_all_nodes(node_type="type_definition"):
+                for n in self._hcg.get_all_type_definitions():
                     if n.get("name") == "entity":
                         self._entity_uuid = n.get("uuid")
                         break

--- a/src/sophia/maintenance/type_minting.py
+++ b/src/sophia/maintenance/type_minting.py
@@ -21,7 +21,6 @@ existing same-name type is the caller's job -- see
 from __future__ import annotations
 
 import logging
-import re
 from datetime import datetime, timezone
 from typing import Any
 from uuid import uuid4
@@ -31,21 +30,6 @@ from sophia.maintenance.emergence_types import EmergentCluster, NameResult
 logger = logging.getLogger(__name__)
 
 _DEFAULT_MODEL = "all-MiniLM-L6-v2"
-
-
-def _slugify(label: str) -> str:
-    """Normalize a free-text Hermes label into a slug-safe identifier component.
-
-    ``name.label`` comes verbatim from Hermes' JSON response and flows into the
-    ``type_uuid``, the node ``type`` property, and event payloads. A multi-word
-    or punctuated label (e.g. ``"living thing"``, ``"sub-class"``) would inject
-    spaces/punctuation into the graph's type namespace and corrupt subsequent
-    lookups (greptile review #149). Lowercase and collapse any run of
-    non-alphanumeric characters to a single underscore; fall back to ``unnamed``
-    so the identifier is never empty (uniqueness still comes from the uuid suffix).
-    """
-    slug = re.sub(r"[^a-z0-9]+", "_", label.strip().lower()).strip("_")
-    return slug or "unnamed"
 
 
 def _mean_vector(vectors: list[list[float]]) -> list[float]:
@@ -61,21 +45,29 @@ def mint_type(
     hcg: Any,
     milvus: Any,
     source_cluster_id: str,
-    # Last-resort default only -- drainage callers always pass a real parent uuid.
-    parent_type_uuid: str = "type_entity",
+    # Required: drainage callers always resolve and pass a real parent uuid
+    # (a resolved parent or the source realm root). No `type_<name>` slug
+    # default -- type identity is an opaque uuid, never name-encoded.
+    parent_type_uuid: str,
+    # The realm this type roots into (entity/concept/process), stamped as the
+    # node `.type`. Type-ness itself is NOT stamped -- it is positional (the
+    # incoming IS_A edge); `.type` carries the realm, uniform with content nodes.
+    realm: str,
     placed_by: str | None = None,
 ) -> str:
-    """Create the type-definition node, seed its centroid, and wire its IS_A edge.
+    """Create the type node, seed its centroid, and wire its IS_A edge.
 
-    The type uuid carries a random suffix so that two clusters that Hermes
-    happens to name identically mint *distinct* type-definition nodes (and
-    distinct centroids) instead of overwriting each other. Members are NOT
-    touched here -- membership is the instance->type IS_A edge, re-pointed onto
-    this type by the draining caller through ``placement.reparent`` (B2/B3,
-    DESIGN §3).
+    The type uuid is an opaque ``uuid4`` -- type identity is positional (the
+    incoming IS_A edges), NOT encoded in the uuid. The node ``.type`` holds the
+    REALM (entity/concept/process), the same field content nodes use; "is this a
+    type?" is answered positionally (does anything IS_A it?), never by a stored
+    ``type_definition`` label. Two clusters Hermes happens to name identically
+    still mint *distinct* type nodes (distinct uuids, distinct centroids).
+    Members are NOT touched here -- membership is the instance->type IS_A edge,
+    re-pointed onto this type by the draining caller through
+    ``placement.reparent`` (B2/B3, DESIGN §3).
     """
-    slug = _slugify(name.label)
-    type_uuid = f"type_{slug}_{uuid4().hex[:8]}"
+    type_uuid = str(uuid4())
     now = datetime.now(timezone.utc).isoformat()
     name_history = [
         {
@@ -88,12 +80,13 @@ def mint_type(
     ]
     hcg.add_node(
         name=name.label,
-        node_type="type_definition",
+        node_type=realm,
         uuid=type_uuid,
         properties={
-            # No `is_type_definition` flag (#171): the type layer is detected
-            # structurally via node_type="type_definition" + the type_ uuid.
-            # No `ancestors` snapshot either: the IS_A edge below IS the
+            # No `is_type_definition` flag and no `type_`-encoded uuid: the type
+            # layer is detected POSITIONALLY (a node is a type iff it has an
+            # incoming IS_A edge), not from the uuid or a stored flag. No
+            # `ancestors` snapshot either: the IS_A edge below IS the
             # membership/typing structure, walked on demand (DESIGN §3).
             "name_history": name_history,
         },

--- a/src/sophia/maintenance/type_rollup_handler.py
+++ b/src/sophia/maintenance/type_rollup_handler.py
@@ -314,23 +314,42 @@ class TypeRollupHandler:
         return explicit_children
 
     def _type_uuid_map(self, node_uuids: list[str]) -> dict[str, str]:
-        # TODO #35: read still infers membership from property; convert to IS_A walk
-        # Resolve in chunks: a single get_nodes_batch over every member uuid can
-        # exceed query-size/timeout limits on a large graph (gemini #161).
+        # Derive each node's type-uuid from the TARGET of its outgoing IS_A edge
+        # (#209). On a positional/reseeded graph there is no `type_uuid` property;
+        # the IS_A edge is the sole membership fact (placement.py L198). This aligns
+        # the rollup READ path with the placement WRITE path.
+        #
+        # Chunk the loop to stay within query-size/timeout limits on a large graph
+        # (same 500-chunk guard retained from the old get_nodes_batch path, gemini
+        # #161). Each uuid gets at most one IS_A edge under the single-upward-pointer
+        # invariant; if multiple edges exist we prefer a non-protected-root target
+        # (avoiding realm roots as the type identity of members), then take the first
+        # deterministically.
         out: dict[str, str] = {}
         chunk = 500
         for i in range(0, len(node_uuids), chunk):
-            try:
-                nodes = self._hcg.get_nodes_batch(node_uuids[i : i + chunk]) or []
-            except Exception:
-                logger.exception("type_rollup: get_nodes_batch failed")
-                continue
-            for n in nodes:
-                if not n or "uuid" not in n:
+            for uuid in node_uuids[i : i + chunk]:
+                try:
+                    edges = self._hcg.query_edges_from(uuid) or []
+                except Exception:
+                    logger.exception(
+                        "type_rollup: query_edges_from failed for %s", uuid
+                    )
                     continue
-                tu = n.get("type_uuid") or (n.get("properties") or {}).get("type_uuid")
-                if tu:
-                    out[n["uuid"]] = tu
+                is_a_targets = [
+                    e["target"]
+                    for e in edges
+                    if e.get("relation") == "IS_A" and e.get("target")
+                ]
+                if not is_a_targets:
+                    continue
+                # Prefer a non-realm-root target so realm-root membership doesn't
+                # mask the type identity of a leaf instance; fall back to first.
+                chosen = next(
+                    (t for t in is_a_targets if t not in self._protected_root_uuids),
+                    is_a_targets[0],
+                )
+                out[uuid] = chosen
         return out
 
     # ------------------------------------------------------------ tier 2

--- a/src/sophia/maintenance/type_rollup_handler.py
+++ b/src/sophia/maintenance/type_rollup_handler.py
@@ -221,9 +221,7 @@ class TypeRollupHandler:
         }
         # Every node returned here is a type positionally; keep the uuid set so
         # `_build_is_a_adjacency` can keep to type-level IS_A edges.
-        self._type_uuids = {
-            td["uuid"] for td in (type_defs or []) if td.get("uuid")
-        }
+        self._type_uuids = {td["uuid"] for td in (type_defs or []) if td.get("uuid")}
         rows: list[dict] = []
         for td in type_defs or []:
             if not _is_rollup_candidate(td):

--- a/src/sophia/maintenance/type_rollup_handler.py
+++ b/src/sophia/maintenance/type_rollup_handler.py
@@ -189,10 +189,35 @@ class TypeRollupHandler:
         # Full positional name -> uuid (incl. the seeded realm/protected roots,
         # which are NOT rollup candidates). This is how root parents resolve to
         # their REAL uuids by name, replacing the old `type_<name>` slug.
+        #
+        # Protected-root precedence: an accreted content node that happens to
+        # share a protected realm-root name (e.g. a minted "entity" or "concept"
+        # type-def) must NEVER overwrite the seeded realm-root uuid in this map.
+        # If it did, _entity_root_uuid / _protected_root_uuids would point at the
+        # accreted node and every subsequent graft would land under the wrong
+        # parent, silently corrupting the ontology hierarchy.
+        #
+        # The seeded structural root sits structurally higher than any accreted
+        # node of the same name: it has a shorter ancestors chain (["root","node"]
+        # vs. ["root","node","entity",...]).  We therefore resolve protected names
+        # by picking the candidate with the FEWEST ancestors -- ties go to the
+        # first entry (stable under repeated graph scans).  Non-protected names
+        # keep last-wins behaviour as before.
+        _all: dict[str, str] = {}
+        _protected_best: dict[str, tuple[int, str]] = {}  # name -> (depth, uuid)
+        for td in type_defs or []:
+            if not td.get("name") or not td.get("uuid"):
+                continue
+            key = td["name"].strip().lower()
+            _all[key] = td["uuid"]
+            if key in _PROTECTED_ROOT_NAMES:
+                depth = len((td.get("properties") or {}).get("ancestors") or [])
+                prev = _protected_best.get(key)
+                if prev is None or depth < prev[0]:
+                    _protected_best[key] = (depth, td["uuid"])
         self._root_uuid_by_name = {
-            (td.get("name") or "").strip().lower(): td["uuid"]
-            for td in (type_defs or [])
-            if td.get("name") and td.get("uuid")
+            **_all,
+            **{k: v for k, (_, v) in _protected_best.items()},
         }
         # Every node returned here is a type positionally; keep the uuid set so
         # `_build_is_a_adjacency` can keep to type-level IS_A edges.

--- a/src/sophia/maintenance/type_rollup_handler.py
+++ b/src/sophia/maintenance/type_rollup_handler.py
@@ -60,7 +60,9 @@ _GRAFTABLE_REALMS = frozenset({"entity", "concept", "process"})
 _PROTECTED_ROOT_NAMES = frozenset(
     {"root", "node", "entity", "concept", "cognition", "process"}
 )
-_PROTECTED_ROOT_UUIDS = frozenset(f"type_{n}" for n in _PROTECTED_ROOT_NAMES)
+# Their real uuids are resolved POSITIONALLY at run() time (name -> uuid from the
+# type layer), never assumed to be a `type_<name>` slug -- the seeder mints roots
+# with uuid5 ids and emergence mints opaque uuid4s, so a `type_` prefix is gone.
 
 # Member-relation labels that imply a type-level relationship.
 _PARENT_REL = {"HAS_PART", "INCLUDES", "COMPOSED_OF"}  # source-type is the PARENT
@@ -74,19 +76,17 @@ def _is_rollup_candidate(td: dict) -> bool:
     """A non-reserved entity-side type-def (seeded or minted) eligible for rollup."""
     name = (td.get("name") or "").strip()
     uuid = td.get("uuid") or ""
-    if not name or not uuid.startswith("type_"):
+    if not name or not uuid:
         return False
     if name in _PROTECTED_ROOT_NAMES or name.startswith("reserved_"):
         return False
-    props = td.get("properties") or {}
-    # Structural type-layer detection (#171). The foundry is structure-not-
-    # flags: add_node/the seeder never write an `is_type_definition` flag, so
-    # filtering on it dropped every seeded root. The node `type` is set to
-    # "type_definition" by BOTH the seeder and type_minting, and every record
-    # reaching this predicate comes through get_all_type_definitions(), which
-    # returns the full node map nested under `properties` -- that is the ONE
-    # canonical shape, so no flattened-record tolerance (PR #173 review).
-    return props.get("type") == "type_definition"
+    # Every record reaching here came from get_all_type_definitions(), i.e. it is
+    # already a type POSITIONALLY (a node with an incoming IS_A edge). Neither the
+    # `type_definition` label nor a `type_`-prefixed uuid is consulted -- the IS_A
+    # subgraph is the sole definition of "is a type". Non-reserved, non-protected
+    # types (whatever their uuid scheme: uuid5 seed roots, opaque uuid4 mints, or
+    # accreted content nodes like `engine`) are all eligible to roll up.
+    return True
 
 
 class TypeRollupHandler:
@@ -116,6 +116,14 @@ class TypeRollupHandler:
         self._children_of: dict[str, list[str]] = {}
         self._name_of: dict[str, str] = {}
         self._uuid_by_name: dict[str, str] = {}
+        # Positional root resolution (name -> real uuid for the seeded roots),
+        # built from the full type layer so we never assume a `type_<name>` slug.
+        self._root_uuid_by_name: dict[str, str] = {}
+        self._entity_root_uuid: str | None = None
+        self._protected_root_uuids: frozenset[str] = frozenset()
+        # All positional type uuids (nodes with an incoming IS_A), for telling
+        # type-level IS_A edges (type IS_A type) from instance-level ones.
+        self._type_uuids: set[str] = set()
 
     # ------------------------------------------------------------------ pass
     def run(self) -> None:
@@ -133,14 +141,21 @@ class TypeRollupHandler:
         # match a coined label and never bypass the reuse / protected-root guards
         # (review #165: case-insensitive lookup on the name->uuid map).
         self._uuid_by_name = {r["name"].strip().lower(): r["uuid"] for r in rows}
-        # Tier-2 fallback parent for residual types. Realm roots are NOT in
-        # `_uuid_by_name` (it holds rollup candidates only), so this resolves to
-        # the `type_entity` SLUG today -- which is exactly what the tier-2
-        # top-level check (`parent_type_uuid == f"type_{_BASE_TYPE}"`) keys on.
-        # Against the uuid5 seeder that slug is dangling; reconciling realm roots
-        # to their real uuids is part of un-gating this tier (#35) -- which is
-        # why the tier stays gated OFF (config.rollup_enabled).
-        entity_root_uuid = self._uuid_by_name.get("entity") or "type_entity"
+        # Resolve the seeded roots to their REAL uuids positionally (by name from
+        # the full type layer), not the dangling `type_<name>` slug. Roots are not
+        # rollup candidates, so they live in `_root_uuid_by_name`, not `_uuid_by_name`.
+        self._entity_root_uuid = self._root_uuid_by_name.get(_BASE_TYPE)
+        self._protected_root_uuids = frozenset(
+            self._root_uuid_by_name[n]
+            for n in _PROTECTED_ROOT_NAMES
+            if n in self._root_uuid_by_name
+        )
+        if not self._entity_root_uuid:
+            logger.warning(
+                "type_rollup: entity root not found positionally; skipping pass"
+            )
+            return
+        entity_root_uuid = self._entity_root_uuid
 
         # Include the realm roots so Hermes can name one as a super-type's
         # parent: the rollup is the single authority that roots types under
@@ -171,6 +186,19 @@ class TypeRollupHandler:
         except Exception:
             logger.exception("type_rollup: failed to list type definitions")
             return []
+        # Full positional name -> uuid (incl. the seeded realm/protected roots,
+        # which are NOT rollup candidates). This is how root parents resolve to
+        # their REAL uuids by name, replacing the old `type_<name>` slug.
+        self._root_uuid_by_name = {
+            (td.get("name") or "").strip().lower(): td["uuid"]
+            for td in (type_defs or [])
+            if td.get("name") and td.get("uuid")
+        }
+        # Every node returned here is a type positionally; keep the uuid set so
+        # `_build_is_a_adjacency` can keep to type-level IS_A edges.
+        self._type_uuids = {
+            td["uuid"] for td in (type_defs or []) if td.get("uuid")
+        }
         rows: list[dict] = []
         for td in type_defs or []:
             if not _is_rollup_candidate(td):
@@ -298,7 +326,10 @@ class TypeRollupHandler:
                 name=r["name"],
                 embedding=r["centroid"],
                 signature=Counter(),
-                current_type="type_definition",
+                # These synthetic members ARE types (positionally); the naming
+                # context just marks them as such, matching emergence_clustering's
+                # generic "type" marker (no `type_definition` label anywhere).
+                current_type="type",
                 hermes_type_hint=None,
                 neighbors=[],
                 model=r["model"],
@@ -356,7 +387,7 @@ class TypeRollupHandler:
             # would duplicate the root, and reusing it would reparent it. If
             # Hermes labelled the cluster after a root, skip this super level and
             # attach the children directly under the current parent.
-            if f"type_{clean_label}" in _PROTECTED_ROOT_UUIDS:
+            if clean_label in _PROTECTED_ROOT_NAMES:
                 logger.info(
                     "type_rollup: cluster named after root %r -- skipping super level",
                     name.label,
@@ -373,7 +404,7 @@ class TypeRollupHandler:
             # the cluster's own members or the coined label itself. Degrades to
             # the default `entity` parent when nothing valid resolves.
             if (
-                parent_type_uuid == f"type_{_BASE_TYPE}"
+                parent_type_uuid == self._entity_root_uuid
                 and name.parent
                 and name.parent.strip().lower() != name.label.strip().lower()
             ):
@@ -398,7 +429,7 @@ class TypeRollupHandler:
             # the reuse branch's _reparent_one would then move the root into the
             # domain tree (no cycle, so the cycle guard cannot stop it). Treat a
             # realm-root hit as no-match -> mint a fresh super instead (blocker).
-            if super_uuid in _PROTECTED_ROOT_UUIDS:
+            if super_uuid in self._protected_root_uuids:
                 super_uuid = None
             if super_uuid is None:
                 # Name-based reconcile before minting: never create a second
@@ -429,6 +460,9 @@ class TypeRollupHandler:
                     milvus=self._milvus,
                     source_cluster_id=cid,
                     parent_type_uuid=parent_type_uuid,
+                    # The super roots into the realm of its graft parent.
+                    realm=placement.realm_of(parent_type_uuid, hcg=self._hcg)
+                    or _BASE_TYPE,
                 )
                 if name.label not in candidates:
                     candidates.append(name.label)
@@ -493,8 +527,10 @@ class TypeRollupHandler:
                 # Type-level hierarchy only. IS_A also carries instance taxonomy
                 # (e.g. `fish IS_A natural_resource`); walking those would let the
                 # cascade and cycle-check wander out of the type layer and report
-                # spurious cycles between unrelated types.
-                if src and tgt and src.startswith("type_") and tgt.startswith("type_"):
+                # spurious cycles between unrelated types. A type-level edge is one
+                # whose BOTH endpoints are positional types (in `_type_uuids`) --
+                # the child must itself be a type, not a leaf instance.
+                if src in self._type_uuids and tgt in self._type_uuids:
                     self._children_of[tgt].append(src)
         except Exception:
             logger.exception("type_rollup: build IS_A adjacency failed")
@@ -519,11 +555,13 @@ class TypeRollupHandler:
         if target in _PROTECTED_ROOT_NAMES:
             # A seeded root: only the graftable realms (entity / concept /
             # process) are valid; `cognition` and the structural roots are not.
-            # Resolve to the CANONICAL `type_<name>` uuid so a case-variant domain
-            # type-def cannot shadow the realm key (the run map is lowercased).
+            # Resolve to the root's REAL uuid positionally by name (the run map
+            # is lowercased, so a case-variant domain type-def cannot shadow it).
             if target not in _GRAFTABLE_REALMS:
                 return None
-            uuid = f"type_{target}"
+            uuid = self._root_uuid_by_name.get(target)
+            if not uuid:
+                return None
         else:
             # A deeper domain type Hermes named as the closest cover. Resolve it
             # via the run's name->uuid map (reserved/edge/protected types are

--- a/src/sophia/maintenance/type_snapshot.py
+++ b/src/sophia/maintenance/type_snapshot.py
@@ -41,6 +41,14 @@ def publish_type_snapshot(hcg: Any, redis: Any) -> int:
             member_count = (
                 props.get("member_count", 0) if isinstance(props, dict) else 0
             )
+            if name in snapshot:
+                logger.warning(
+                    "publish_type_snapshot: name collision %r (uuid %s clobbers %s); "
+                    "only the last will be visible to TypeRegistry",
+                    name,
+                    record.get("uuid", ""),
+                    snapshot[name].get("uuid", ""),
+                )
             snapshot[name] = {
                 "uuid": record.get("uuid", ""),
                 "member_count": member_count,

--- a/src/sophia/maintenance/type_snapshot.py
+++ b/src/sophia/maintenance/type_snapshot.py
@@ -1,0 +1,52 @@
+"""Publish the positional type snapshot to Redis (`logos:ontology:types`).
+
+Single source for the type-catalog snapshot Hermes' TypeRegistry boots from.
+Types are gathered positionally via ``get_all_type_definitions()`` (incoming-IS_A
+over the IS_A subgraph), so the snapshot reflects the *real* type layer -- every
+node something IS_A's, including content-node types (``engine``) and anything that
+became a type after a graft -- not just label-stamped/minted nodes.
+
+Driven from three places so it stays in sync:
+  - ingest, after each proposal batch (proposal_processor);
+  - the maintenance scheduler's periodic loop (reconcile / safety net);
+  - the ``ontology.type_created`` event (incremental, on emergence mint).
+"""
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+REDIS_KEY = "logos:ontology:types"
+
+
+def publish_type_snapshot(hcg: Any, redis: Any) -> int:
+    """Gather the positional type layer and write it to Redis; return the count.
+
+    Fail-soft (sophia#195): a missing/failed snapshot just makes Hermes'
+    TypeRegistry boot empty rather than crashing the caller.
+    """
+    if redis is None or hcg is None:
+        return 0
+    try:
+        records = hcg.get_all_type_definitions()
+        snapshot: dict[str, dict[str, Any]] = {}
+        for record in records:
+            name = record.get("name", "")
+            if not name:
+                continue
+            props = record.get("properties")
+            member_count = (
+                props.get("member_count", 0) if isinstance(props, dict) else 0
+            )
+            snapshot[name] = {
+                "uuid": record.get("uuid", ""),
+                "member_count": member_count,
+            }
+        redis.set(REDIS_KEY, json.dumps(snapshot))
+        return len(snapshot)
+    except Exception:
+        logger.exception("Failed to publish type snapshot to Redis")
+        return 0

--- a/src/sophia/maintenance/type_snapshot.py
+++ b/src/sophia/maintenance/type_snapshot.py
@@ -11,6 +11,7 @@ Driven from three places so it stays in sync:
   - the maintenance scheduler's periodic loop (reconcile / safety net);
   - the ``ontology.type_created`` event (incremental, on emergence mint).
 """
+
 from __future__ import annotations
 
 import json

--- a/tests/maintenance/test_centroid.py
+++ b/tests/maintenance/test_centroid.py
@@ -1,0 +1,143 @@
+"""Tests for incremental + reconcile type-centroid maintenance."""
+
+from __future__ import annotations
+
+from sophia.maintenance.centroid import (
+    bump_centroid,
+    online_mean_add,
+    reconcile_centroids,
+)
+
+
+# --------------------------------------------------------------- online_mean_add
+def test_online_mean_init_when_no_centroid():
+    """No prior centroid (or n<=0) -> plain mean of the added vectors."""
+    assert online_mean_add(None, 0, [[2.0, 4.0], [4.0, 8.0]]) == [3.0, 6.0]
+    assert online_mean_add([], 5, [[1.0, 1.0]]) == [1.0, 1.0]
+
+
+def test_online_mean_add_folds_into_running_mean():
+    """centroid of n vectors + one more == correct new mean."""
+    # mean of 2 vectors is [2,2]; add [8,8] -> (([2,2]*2)+[8,8])/3 = [4,4]
+    assert online_mean_add([2.0, 2.0], 2, [[8.0, 8.0]]) == [4.0, 4.0]
+
+
+def test_online_mean_equivalent_to_full_mean():
+    """Incremental folding reproduces the full batch mean exactly."""
+    embs = [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]
+    c = None
+    n = 0
+    for e in embs:
+        c = online_mean_add(c, n, [e])
+        n += 1
+    full = [sum(e[i] for e in embs) / len(embs) for i in range(2)]
+    assert c == full == [3.0, 4.0]
+
+
+def test_online_mean_empty_add_is_noop():
+    assert online_mean_add([1.0, 1.0], 3, []) == [1.0, 1.0]
+    assert online_mean_add([1.0, 1.0], 3, [None]) == [1.0, 1.0]
+
+
+# ------------------------------------------------------------------ FakeMilvus
+class FakeMilvus:
+    def __init__(self, centroids=None, content=None):
+        # centroids: {uuid: (vec, model)} ; content: {uuid: (vec, model)}
+        self.centroids = dict(centroids or {})
+        self.content = dict(content or {})
+        self.writes = []
+
+    def get_embedding(self, node_type, uuid):
+        src = self.centroids if node_type == "TypeCentroid" else self.content
+        if uuid in src:
+            v, m = src[uuid]
+            return {"uuid": uuid, "embedding": v, "embedding_model": m}
+        return None
+
+    def update_centroid(self, type_uuid, centroid, model):
+        self.centroids[type_uuid] = (centroid, model)
+        self.writes.append((type_uuid, centroid, model))
+
+
+# ----------------------------------------------------------------- bump_centroid
+def test_bump_folds_member_into_existing_centroid():
+    mv = FakeMilvus(centroids={"t": ([2.0, 2.0], "text-embedding-3-large")})
+    bump_centroid(mv, "t", [[8.0, 8.0]], n=2)
+    assert mv.centroids["t"] == ([4.0, 4.0], "text-embedding-3-large")
+
+
+def test_bump_initialises_when_no_centroid_using_passed_model():
+    mv = FakeMilvus()
+    bump_centroid(mv, "new", [[4.0, 4.0], [6.0, 6.0]], n=0, model="m2")
+    assert mv.centroids["new"] == ([5.0, 5.0], "m2")
+
+
+def test_bump_skips_rather_than_corrupts_when_count_unknown():
+    """Existing centroid + n<=0 (count unavailable) -> skip, don't re-init to
+    just the new members' mean (that would lose the existing population)."""
+    mv = FakeMilvus(centroids={"t": ([2.0, 2.0], "m")})
+    bump_centroid(mv, "t", [[8.0, 8.0]], n=0)
+    assert mv.centroids["t"] == ([2.0, 2.0], "m")  # unchanged
+    assert mv.writes == []
+
+
+def test_bump_is_fail_soft():
+    # No milvus / no uuid / no embeddings -> no error, no write.
+    bump_centroid(None, "t", [[1.0]], n=1)
+    mv = FakeMilvus()
+    bump_centroid(mv, "", [[1.0]], n=1)
+    bump_centroid(mv, "t", [], n=1)
+    assert mv.writes == []
+
+
+# ------------------------------------------------------------- reconcile_centroids
+class FakeHCG:
+    def __init__(self, types, members):
+        self._types = types          # list of {uuid,name,...}
+        self._members = members      # {type_uuid: [member_uuid,...]}
+
+    def get_all_type_definitions(self):
+        return self._types
+
+    def _execute_read(self, query, params):
+        return [{"uuid": u} for u in self._members.get(params["u"], [])]
+
+
+def test_reconcile_writes_content_types_skips_roots_and_nodata():
+    types = [
+        {"uuid": "engine", "name": "engine"},
+        {"uuid": "type_entity", "name": "entity"},      # protected root
+        {"uuid": "ghost", "name": "ghost"},             # members lack embeddings
+    ]
+    members = {"engine": ["m1", "m2"], "type_entity": ["e1"], "ghost": ["g1"]}
+    content = {
+        "m1": ([0.0, 2.0], "text-embedding-3-large"),
+        "m2": ([2.0, 0.0], "text-embedding-3-large"),
+        # g1 has no embedding -> ghost skipped
+    }
+    hcg = FakeHCG(types, members)
+    mv = FakeMilvus(content=content)
+
+    stats = reconcile_centroids(hcg, mv)
+
+    assert mv.centroids["engine"] == ([1.0, 1.0], "text-embedding-3-large")
+    assert "type_entity" not in mv.centroids  # protected, skipped
+    assert "ghost" not in mv.centroids         # no member embeddings, skipped
+    assert stats["written"] == 1
+    assert stats["skipped_protected"] == 1
+    assert stats["skipped_no_embeddings"] == 1
+
+
+def test_reconcile_skips_mixed_model():
+    types = [{"uuid": "mix", "name": "mix"}]
+    members = {"mix": ["a", "b"]}
+    content = {"a": ([1.0], "model-x"), "b": ([2.0], "model-y")}
+    hcg = FakeHCG(types, members)
+    mv = FakeMilvus(content=content)
+    stats = reconcile_centroids(hcg, mv)
+    assert "mix" not in mv.centroids
+    assert stats["skipped_mixed_model"] == 1
+
+
+def test_reconcile_fail_soft_on_none():
+    assert reconcile_centroids(None, None)["written"] == 0

--- a/tests/maintenance/test_centroid.py
+++ b/tests/maintenance/test_centroid.py
@@ -141,3 +141,9 @@ def test_reconcile_skips_mixed_model():
 
 def test_reconcile_fail_soft_on_none():
     assert reconcile_centroids(None, None)["written"] == 0
+
+def test_online_mean_add_raises_on_dim_mismatch():
+    """online_mean_add raises AssertionError when existing centroid dim != new-vec dim."""
+    import pytest
+    with pytest.raises(AssertionError, match="dimension mismatch"):
+        online_mean_add([1.0, 2.0], 3, [[1.0, 2.0, 3.0]])  # centroid dim=2, vec dim=3

--- a/tests/maintenance/test_centroid.py
+++ b/tests/maintenance/test_centroid.py
@@ -93,8 +93,8 @@ def test_bump_is_fail_soft():
 # ------------------------------------------------------------- reconcile_centroids
 class FakeHCG:
     def __init__(self, types, members):
-        self._types = types          # list of {uuid,name,...}
-        self._members = members      # {type_uuid: [member_uuid,...]}
+        self._types = types  # list of {uuid,name,...}
+        self._members = members  # {type_uuid: [member_uuid,...]}
 
     def get_all_type_definitions(self):
         return self._types
@@ -106,8 +106,8 @@ class FakeHCG:
 def test_reconcile_writes_content_types_skips_roots_and_nodata():
     types = [
         {"uuid": "engine", "name": "engine"},
-        {"uuid": "type_entity", "name": "entity"},      # protected root
-        {"uuid": "ghost", "name": "ghost"},             # members lack embeddings
+        {"uuid": "type_entity", "name": "entity"},  # protected root
+        {"uuid": "ghost", "name": "ghost"},  # members lack embeddings
     ]
     members = {"engine": ["m1", "m2"], "type_entity": ["e1"], "ghost": ["g1"]}
     content = {
@@ -122,7 +122,7 @@ def test_reconcile_writes_content_types_skips_roots_and_nodata():
 
     assert mv.centroids["engine"] == ([1.0, 1.0], "text-embedding-3-large")
     assert "type_entity" not in mv.centroids  # protected, skipped
-    assert "ghost" not in mv.centroids         # no member embeddings, skipped
+    assert "ghost" not in mv.centroids  # no member embeddings, skipped
     assert stats["written"] == 1
     assert stats["skipped_protected"] == 1
     assert stats["skipped_no_embeddings"] == 1
@@ -142,8 +142,10 @@ def test_reconcile_skips_mixed_model():
 def test_reconcile_fail_soft_on_none():
     assert reconcile_centroids(None, None)["written"] == 0
 
+
 def test_online_mean_add_raises_on_dim_mismatch():
     """online_mean_add raises AssertionError when existing centroid dim != new-vec dim."""
     import pytest
+
     with pytest.raises(AssertionError, match="dimension mismatch"):
         online_mean_add([1.0, 2.0], 3, [[1.0, 2.0, 3.0]])  # centroid dim=2, vec dim=3

--- a/tests/maintenance/test_config.py
+++ b/tests/maintenance/test_config.py
@@ -19,9 +19,8 @@ class TestMaintenanceConfig:
         assert config.threshold_enabled is True
         assert config.type_member_count_threshold == 100
         assert config.max_concurrent_jobs == 2
-        # Rollup (revision) tier is deferred for naming-driven-typing B1 and
-        # gated OFF by default until it is converted onto placement.py.
-        assert config.rollup_enabled is False
+        # Rollup is fully edge-based after #209; enabled by default.
+        assert config.rollup_enabled is True
 
     def test_env_override(self):
         with mock.patch.dict(

--- a/tests/maintenance/test_emergence_adapters.py
+++ b/tests/maintenance/test_emergence_adapters.py
@@ -25,6 +25,16 @@ class _FakeHCG:
             return list(self._type_defs)
         return []
 
+    def get_all_type_definitions(self):
+        return [
+            {
+                "uuid": td.get("uuid", ""),
+                "name": td.get("name"),
+                "properties": dict(td.get("properties", {})),
+            }
+            for td in self._type_defs
+        ]
+
     def query_edges_from(self, uuid):
         return self._edges.get(uuid, [])
 

--- a/tests/maintenance/test_emergence_handler.py
+++ b/tests/maintenance/test_emergence_handler.py
@@ -68,6 +68,19 @@ class _FakeHCG:
             return list(self._type_defs)
         return []
 
+    def get_all_type_definitions(self):
+        # Positional type catalog (the rework's canonical gather). The fake's
+        # type layer is `_type_defs`; reshape to the client's
+        # {uuid, name, properties} contract.
+        return [
+            {
+                "uuid": td["uuid"],
+                "name": td["name"],
+                "properties": dict(td.get("properties", {})),
+            }
+            for td in self._type_defs
+        ]
+
     def get_node(self, uuid):
         return self._nodes.get(uuid)
 

--- a/tests/maintenance/test_scheduler.py
+++ b/tests/maintenance/test_scheduler.py
@@ -304,8 +304,7 @@ class TestTypeSnapshotSync:
         self.mock_redis = MagicMock()
         self.mock_hcg = MagicMock()
         self.mock_hcg.get_all_type_definitions.return_value = [
-            {"uuid": "u-engine", "name": "engine",
-             "properties": {"member_count": 5}},
+            {"uuid": "u-engine", "name": "engine", "properties": {"member_count": 5}},
         ]
         config = MaintenanceConfig(enabled=True)
         self.scheduler = MaintenanceScheduler(

--- a/tests/maintenance/test_scheduler.py
+++ b/tests/maintenance/test_scheduler.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from sophia.maintenance.config import MaintenanceConfig
+from sophia.maintenance.emergence_handler import ONTOLOGY_CHANGED_CHANNEL
 from sophia.maintenance.job_queue import MaintenanceJob, MaintenanceQueue
 from sophia.maintenance.scheduler import MaintenanceScheduler
 
@@ -107,6 +108,33 @@ class TestMaintenanceSchedulerInit:
         subscribe_calls = self.mock_event_bus.subscribe.call_args_list
         channels = [c[0][0] for c in subscribe_calls]
         assert "logos:sophia:threshold_crossed" in channels
+
+    def test_subscribes_to_ontology_type_created_when_redis_present(self) -> None:
+        """With a Redis handle, subscribe to ontology.type_created for sync."""
+        config = MaintenanceConfig(enabled=True)
+        MaintenanceScheduler(
+            queue=self.mock_queue,
+            event_bus=self.mock_event_bus,
+            config=config,
+            handlers=self.handlers,
+            redis_client=MagicMock(),
+        )
+        subscribe_calls = self.mock_event_bus.subscribe.call_args_list
+        channels = [c[0][0] for c in subscribe_calls]
+        assert ONTOLOGY_CHANGED_CHANNEL in channels
+
+    def test_no_ontology_subscription_without_redis(self) -> None:
+        """Without a Redis handle, the snapshot-sync subscription is skipped."""
+        config = MaintenanceConfig(enabled=True)
+        MaintenanceScheduler(
+            queue=self.mock_queue,
+            event_bus=self.mock_event_bus,
+            config=config,
+            handlers=self.handlers,
+        )
+        subscribe_calls = self.mock_event_bus.subscribe.call_args_list
+        channels = [c[0][0] for c in subscribe_calls]
+        assert ONTOLOGY_CHANGED_CHANNEL not in channels
 
 
 class TestEventHandlers:
@@ -265,3 +293,47 @@ class TestStartStop:
         await scheduler.stop()
         assert not scheduler._running
         self.mock_event_bus.stop.assert_called_once()
+
+
+class TestTypeSnapshotSync:
+    """The ontology.type_created handler keeps the Redis snapshot in sync."""
+
+    def setup_method(self) -> None:
+        self.mock_queue = MagicMock(spec=MaintenanceQueue)
+        self.mock_event_bus = MagicMock()
+        self.mock_redis = MagicMock()
+        self.mock_hcg = MagicMock()
+        self.mock_hcg.get_all_type_definitions.return_value = [
+            {"uuid": "u-engine", "name": "engine",
+             "properties": {"member_count": 5}},
+        ]
+        config = MaintenanceConfig(enabled=True)
+        self.scheduler = MaintenanceScheduler(
+            queue=self.mock_queue,
+            event_bus=self.mock_event_bus,
+            config=config,
+            handlers={},
+            hcg_client=self.mock_hcg,
+            redis_client=self.mock_redis,
+        )
+
+    def test_event_republishes_positional_snapshot(self) -> None:
+        """On ontology.type_created, re-gather and write the full snapshot."""
+        import json
+
+        self.scheduler._on_ontology_type_created({"type_uuid": "u-engine"})
+
+        self.mock_hcg.get_all_type_definitions.assert_called_once()
+        self.mock_redis.set.assert_called_once()
+        key, payload = self.mock_redis.set.call_args[0]
+        assert key == "logos:ontology:types"
+        assert json.loads(payload) == {
+            "engine": {"uuid": "u-engine", "member_count": 5}
+        }
+
+    def test_event_handler_is_fail_soft(self) -> None:
+        """A graph error in the handler must not propagate (listener thread)."""
+        self.mock_hcg.get_all_type_definitions.side_effect = RuntimeError("boom")
+        # Should not raise.
+        self.scheduler._on_ontology_type_created({})
+        self.mock_redis.set.assert_not_called()

--- a/tests/maintenance/test_type_correction.py
+++ b/tests/maintenance/test_type_correction.py
@@ -38,6 +38,13 @@ class FakeHCG:
             if node_type is None or n.get("type") == node_type
         ]
 
+    def get_all_type_definitions(self):
+        return [
+            {"uuid": n["uuid"], "name": n.get("name"), "properties": dict(n)}
+            for n in self.nodes.values()
+            if n.get("type") == "type_definition"
+        ]
+
     def list_all_edges(self, relation_type=None, limit=1000):
         return [
             e

--- a/tests/maintenance/test_type_minting.py
+++ b/tests/maintenance/test_type_minting.py
@@ -157,12 +157,22 @@ def test_same_label_mints_are_distinct_no_overwrite():
     name = NameResult(label="concept", description="", confidence=0.8)
 
     uuid_a = mint_type(
-        _cluster(), name, hcg=hcg, milvus=milvus,
-        source_cluster_id="a", parent_type_uuid="entity-uuid", realm="entity",
+        _cluster(),
+        name,
+        hcg=hcg,
+        milvus=milvus,
+        source_cluster_id="a",
+        parent_type_uuid="entity-uuid",
+        realm="entity",
     )
     uuid_b = mint_type(
-        _cluster(), name, hcg=hcg, milvus=milvus,
-        source_cluster_id="b", parent_type_uuid="entity-uuid", realm="entity",
+        _cluster(),
+        name,
+        hcg=hcg,
+        milvus=milvus,
+        source_cluster_id="b",
+        parent_type_uuid="entity-uuid",
+        realm="entity",
     )
 
     assert uuid_a != uuid_b
@@ -186,8 +196,13 @@ def test_messy_label_is_not_encoded_in_the_opaque_uuid():
     name = NameResult(label="Living Thing!", description="", confidence=0.7)
 
     type_uuid = mint_type(
-        _cluster(), name, hcg=hcg, milvus=milvus,
-        source_cluster_id="cl1", parent_type_uuid="entity-uuid", realm="entity",
+        _cluster(),
+        name,
+        hcg=hcg,
+        milvus=milvus,
+        source_cluster_id="cl1",
+        parent_type_uuid="entity-uuid",
+        realm="entity",
     )
 
     assert not type_uuid.startswith("type_")
@@ -218,8 +233,13 @@ def test_mint_does_not_touch_member_is_a_edges():
     name = NameResult(label="hammer", description="", confidence=0.8)
 
     new_uuid = mint_type(
-        _cluster(), name, hcg=hcg, milvus=FakeMilvus(),
-        source_cluster_id="cl", parent_type_uuid=parent, realm="entity",
+        _cluster(),
+        name,
+        hcg=hcg,
+        milvus=FakeMilvus(),
+        source_cluster_id="cl",
+        parent_type_uuid=parent,
+        realm="entity",
     )
 
     # mint touches no member: no edge created/deleted, no property stamped.
@@ -291,8 +311,13 @@ def test_mint_omits_placed_by_property_when_absent():
     name = NameResult(label="boat", description="", confidence=0.8)
 
     type_uuid = mint_type(
-        _cluster(), name, hcg=hcg, milvus=milvus,
-        source_cluster_id="cl1", parent_type_uuid="entity-uuid", realm="entity",
+        _cluster(),
+        name,
+        hcg=hcg,
+        milvus=milvus,
+        source_cluster_id="cl1",
+        parent_type_uuid="entity-uuid",
+        realm="entity",
     )
 
     idx = hcg.edges.index((type_uuid, "entity-uuid", "IS_A"))

--- a/tests/maintenance/test_type_minting.py
+++ b/tests/maintenance/test_type_minting.py
@@ -92,14 +92,21 @@ def test_mint_creates_type_node_and_centroid_without_touching_members():
     name = NameResult(label="concept", description="ideas", confidence=0.8)
 
     type_uuid = mint_type(
-        _cluster(), name, hcg=hcg, milvus=milvus, source_cluster_id="cl1"
+        _cluster(),
+        name,
+        hcg=hcg,
+        milvus=milvus,
+        source_cluster_id="cl1",
+        parent_type_uuid="entity-uuid",
+        realm="entity",
     )
 
-    # Unique suffix avoids same-label mints overwriting each other.
-    assert type_uuid.startswith("type_concept_")
-    assert type_uuid != "type_concept"
+    # Opaque uuid -- type identity is positional (incoming IS_A), never encoded
+    # in the uuid; the name lives on the node, not the id.
+    assert not type_uuid.startswith("type_")
+    assert "concept" not in type_uuid
 
-    tdef = [n for n in hcg.added_nodes if n["node_type"] == "type_definition"]
+    tdef = [n for n in hcg.added_nodes if n["node_type"] == "entity"]
     assert len(tdef) == 1
     props = tdef[0]["properties"]
     assert "is_type_definition" not in props
@@ -117,9 +124,9 @@ def test_mint_creates_type_node_and_centroid_without_touching_members():
     assert hcg.updated == []
     assert not any(src in {"u1", "u2"} for src, _tgt, _rel in hcg.edges)
 
-    # The minted type IS_A its default parent (type_entity) -- this taxonomy edge
+    # The minted type IS_A the parent it was given -- this taxonomy edge
     # (type-definition -> parent type-definition) IS the structure and is KEPT.
-    assert (type_uuid, "type_entity", "IS_A") in hcg.edges
+    assert (type_uuid, "entity-uuid", "IS_A") in hcg.edges
 
 
 def test_mint_under_explicit_parent_creates_is_a_edge():
@@ -136,9 +143,10 @@ def test_mint_under_explicit_parent_creates_is_a_edge():
         milvus=milvus,
         source_cluster_id="cl1",
         parent_type_uuid="type_animal",
+        realm="entity",
     )
 
-    tdef = [n for n in hcg.added_nodes if n["node_type"] == "type_definition"]
+    tdef = [n for n in hcg.added_nodes if n["node_type"] == "entity"]
     assert "ancestors" not in tdef[0]["properties"]
     assert (type_uuid, "type_animal", "IS_A") in hcg.edges
 
@@ -148,38 +156,47 @@ def test_same_label_mints_are_distinct_no_overwrite():
     hcg, milvus = FakeHCG(), FakeMilvus()
     name = NameResult(label="concept", description="", confidence=0.8)
 
-    uuid_a = mint_type(_cluster(), name, hcg=hcg, milvus=milvus, source_cluster_id="a")
-    uuid_b = mint_type(_cluster(), name, hcg=hcg, milvus=milvus, source_cluster_id="b")
+    uuid_a = mint_type(
+        _cluster(), name, hcg=hcg, milvus=milvus,
+        source_cluster_id="a", parent_type_uuid="entity-uuid", realm="entity",
+    )
+    uuid_b = mint_type(
+        _cluster(), name, hcg=hcg, milvus=milvus,
+        source_cluster_id="b", parent_type_uuid="entity-uuid", realm="entity",
+    )
 
     assert uuid_a != uuid_b
-    assert uuid_a.startswith("type_concept_")
-    assert uuid_b.startswith("type_concept_")
+    assert not uuid_a.startswith("type_") and not uuid_b.startswith("type_")
     assert uuid_a in milvus.centroids and uuid_b in milvus.centroids
     # Distinct taxonomy IS_A edges (minted type -> parent); the members are never
     # touched by mint -- membership is the instance->type IS_A edge, owned by the
     # draining caller (B2/B3).
-    assert (uuid_a, "type_entity", "IS_A") in hcg.edges
-    assert (uuid_b, "type_entity", "IS_A") in hcg.edges
+    assert (uuid_a, "entity-uuid", "IS_A") in hcg.edges
+    assert (uuid_b, "entity-uuid", "IS_A") in hcg.edges
     assert hcg.updated == []
     assert not any(src in {"u1", "u2"} for src, _tgt, _rel in hcg.edges)
 
 
-def test_messy_label_is_slugified_into_the_type_uuid():
-    """A multi-word/punctuated Hermes label must not inject spaces into the
-    type_uuid (greptile #149). The human-readable label is preserved in
+def test_messy_label_is_not_encoded_in_the_opaque_uuid():
+    """A multi-word/punctuated Hermes label encodes nothing into the uuid: the
+    uuid is opaque (uuid4), so spaces/punctuation can never leak into the id.
+    The human-readable label is preserved verbatim on the node name and in
     name_history. Members are not retyped here (membership is the IS_A edge)."""
     hcg, milvus = FakeHCG(), FakeMilvus()
     name = NameResult(label="Living Thing!", description="", confidence=0.7)
 
     type_uuid = mint_type(
-        _cluster(), name, hcg=hcg, milvus=milvus, source_cluster_id="cl1"
+        _cluster(), name, hcg=hcg, milvus=milvus,
+        source_cluster_id="cl1", parent_type_uuid="entity-uuid", realm="entity",
     )
 
-    assert type_uuid.startswith("type_living_thing_")
+    assert not type_uuid.startswith("type_")
     assert " " not in type_uuid and "!" not in type_uuid
+    assert "living" not in type_uuid.lower()
     # Members are not touched -- no slug/type_uuid stamp.
     assert hcg.updated == []
-    tdef = [n for n in hcg.added_nodes if n["node_type"] == "type_definition"]
+    tdef = [n for n in hcg.added_nodes if n["node_type"] == "entity"]
+    assert tdef[0]["name"] == "Living Thing!"
     assert tdef[0]["properties"]["name_history"][0]["name"] == "Living Thing!"
 
 
@@ -201,7 +218,8 @@ def test_mint_does_not_touch_member_is_a_edges():
     name = NameResult(label="hammer", description="", confidence=0.8)
 
     new_uuid = mint_type(
-        _cluster(), name, hcg=hcg, milvus=FakeMilvus(), source_cluster_id="cl"
+        _cluster(), name, hcg=hcg, milvus=FakeMilvus(),
+        source_cluster_id="cl", parent_type_uuid=parent, realm="entity",
     )
 
     # mint touches no member: no edge created/deleted, no property stamped.
@@ -209,9 +227,9 @@ def test_mint_does_not_touch_member_is_a_edges():
     assert hcg.updated == []
     assert not any(src in {"u1", "u2"} for src, _tgt, _rel in hcg.edges)
     # Only the taxonomy IS_A (new type -> parent) is created.
-    assert (new_uuid, "type_entity", "IS_A") in hcg.edges
+    assert (new_uuid, parent, "IS_A") in hcg.edges
     # Human-readable label preserved for display/lineage.
-    tdef = [n for n in hcg.added_nodes if n["node_type"] == "type_definition"]
+    tdef = [n for n in hcg.added_nodes if n["node_type"] == "entity"]
     assert tdef[0]["properties"]["name_history"][0]["name"] == "hammer"
 
 
@@ -230,10 +248,11 @@ def test_mint_writes_no_ancestors_property():
         milvus=milvus,
         source_cluster_id="cl1",
         parent_type_uuid="type_animal",
+        realm="entity",
     )
 
     # The add_node call captured the node's properties kwarg.
-    tdef = [n for n in hcg.added_nodes if n["node_type"] == "type_definition"]
+    tdef = [n for n in hcg.added_nodes if n["node_type"] == "entity"]
     assert len(tdef) == 1
     props = tdef[0]["properties"]
     assert "ancestors" not in props
@@ -256,6 +275,7 @@ def test_mint_carries_placed_by_on_parent_is_a_edge():
         milvus=milvus,
         source_cluster_id="cl1",
         parent_type_uuid="type_vehicle",
+        realm="entity",
         placed_by="parent_resolution",
     )
 
@@ -271,8 +291,9 @@ def test_mint_omits_placed_by_property_when_absent():
     name = NameResult(label="boat", description="", confidence=0.8)
 
     type_uuid = mint_type(
-        _cluster(), name, hcg=hcg, milvus=milvus, source_cluster_id="cl1"
+        _cluster(), name, hcg=hcg, milvus=milvus,
+        source_cluster_id="cl1", parent_type_uuid="entity-uuid", realm="entity",
     )
 
-    idx = hcg.edges.index((type_uuid, "type_entity", "IS_A"))
+    idx = hcg.edges.index((type_uuid, "entity-uuid", "IS_A"))
     assert hcg.edge_props[idx] is None

--- a/tests/maintenance/test_type_rollup.py
+++ b/tests/maintenance/test_type_rollup.py
@@ -1304,13 +1304,14 @@ def test_accreted_content_node_cannot_shadow_protected_root_in_root_uuid_by_name
     handler._load_type_layer()
 
     # The seeded root (zero ancestors depth) must win the "entity" slot.
-    assert handler._root_uuid_by_name.get("entity") == "type_entity_seeded", (
-        "_root_uuid_by_name['entity'] was shadowed by the accreted content node"
-    )
+    assert (
+        handler._root_uuid_by_name.get("entity") == "type_entity_seeded"
+    ), "_root_uuid_by_name['entity'] was shadowed by the accreted content node"
     # _entity_root_uuid is derived directly from _root_uuid_by_name in run();
     # set it the same way to verify the derivation produces the right uuid.
     from sophia.maintenance.type_rollup_handler import _BASE_TYPE
+
     entity_uuid = handler._root_uuid_by_name.get(_BASE_TYPE)
-    assert entity_uuid == "type_entity_seeded", (
-        "_entity_root_uuid would resolve to the wrong (accreted) node"
-    )
+    assert (
+        entity_uuid == "type_entity_seeded"
+    ), "_entity_root_uuid would resolve to the wrong (accreted) node"

--- a/tests/maintenance/test_type_rollup.py
+++ b/tests/maintenance/test_type_rollup.py
@@ -275,11 +275,22 @@ def test_tier1_lifts_explicit_subsumption(monkeypatch):
         _td("type_insect_part_bb", "insect part", ["root", "node", "entity"]),
     ]
     members = [
-        {"uuid": "e1", "type_uuid": "type_anatomy_aa"},
-        {"uuid": "e2", "type_uuid": "type_insect_part_bb"},
+        {"uuid": "e1", "name": "bone", "properties": {}},
+        {"uuid": "e2", "name": "wing", "properties": {}},
     ]
-    edges = [{"id": "r1", "source": "e1", "target": "e2", "relation": "HAS_PART"}]
-    hcg = FakeHCG(tds, members=members, other_edges=edges)
+    # Membership is expressed by IS_A edges (positional, no type_uuid property).
+    is_a_edges = [
+        {"id": "m1", "source": "e1", "target": "type_anatomy_aa", "relation": "IS_A"},
+        {
+            "id": "m2",
+            "source": "e2",
+            "target": "type_insect_part_bb",
+            "relation": "IS_A",
+        },
+    ]
+    # The domain edge under scrutiny: e1 HAS_PART e2 => insect_part IS_A anatomy.
+    other_edges = [{"id": "r1", "source": "e1", "target": "e2", "relation": "HAS_PART"}]
+    hcg = FakeHCG(tds, members=members, is_a=is_a_edges, other_edges=other_edges)
     milvus = FakeMilvus(
         {"type_anatomy_aa": [1.0, 0.0], "type_insect_part_bb": [0.0, 1.0]}
     )
@@ -1315,3 +1326,162 @@ def test_accreted_content_node_cannot_shadow_protected_root_in_root_uuid_by_name
     assert (
         entity_uuid == "type_entity_seeded"
     ), "_entity_root_uuid would resolve to the wrong (accreted) node"
+
+
+# ---------------------------------------------------------------------------
+# Tests for edge-based _type_uuid_map (#209)
+# ---------------------------------------------------------------------------
+
+
+def test_type_uuid_map_uses_is_a_edge_not_type_uuid_property():
+    """_type_uuid_map must return the IS_A-edge TARGET, not a type_uuid property.
+
+    On a positional/reseeded graph there is no `type_uuid` property; the IS_A
+    edge is the sole membership fact (placement.py L198, #209).
+    """
+    # Two type-defs (so the rollup doesn't short-circuit at len(rows) < 2).
+    tds = [
+        {"uuid": "type_animal", "name": "animal", "properties": {}},
+        {"uuid": "type_plant", "name": "plant", "properties": {}},
+    ]
+    # Two member nodes: explicitly no `type_uuid` property, membership only via
+    # IS_A edge.
+    is_a_edges = [
+        {
+            "id": "e1",
+            "source": "member_dog",
+            "target": "type_animal",
+            "relation": "IS_A",
+        },
+        {
+            "id": "e2",
+            "source": "member_oak",
+            "target": "type_plant",
+            "relation": "IS_A",
+        },
+    ]
+    # Members live in the FakeHCG node map so get_nodes_batch (unused now) would
+    # find them, but we do NOT give them a `type_uuid` property.
+    members = [
+        {"uuid": "member_dog", "name": "dog", "properties": {}},
+        {"uuid": "member_oak", "name": "oak", "properties": {}},
+    ]
+    hcg = FakeHCG(tds, members=members, is_a=is_a_edges)
+    handler = _handler(hcg, FakeMilvus({}))
+    handler._load_type_layer()
+    # _protected_root_uuids must be populated before calling _type_uuid_map.
+    handler._protected_root_uuids = frozenset(
+        handler._root_uuid_by_name.get(n, "")
+        for n in ("root", "node", "entity", "concept", "process", "cognition")
+    )
+
+    result = handler._type_uuid_map(["member_dog", "member_oak"])
+
+    assert (
+        result["member_dog"] == "type_animal"
+    ), "_type_uuid_map should return IS_A edge target, got %r" % result.get(
+        "member_dog"
+    )
+    assert (
+        result["member_oak"] == "type_plant"
+    ), "_type_uuid_map should return IS_A edge target, got %r" % result.get(
+        "member_oak"
+    )
+
+
+def test_type_uuid_map_ignores_type_uuid_property():
+    """Even if a stale `type_uuid` property is present, _type_uuid_map must use
+    the IS_A edge target, not the property value.  The property is a relic of
+    pre-positional graphs; trusting it causes the rollup to no-op on reseeded
+    graphs where edges and properties disagree.
+    """
+    tds = [
+        {"uuid": "type_animal", "name": "animal", "properties": {}},
+        {"uuid": "type_stale", "name": "stale_type", "properties": {}},
+    ]
+    is_a_edges = [
+        # Correct IS_A edge points at type_animal.
+        {
+            "id": "e1",
+            "source": "member_dog",
+            "target": "type_animal",
+            "relation": "IS_A",
+        },
+    ]
+    members = [
+        # Stale property points at type_stale -- should be ignored.
+        {
+            "uuid": "member_dog",
+            "name": "dog",
+            "properties": {"type_uuid": "type_stale"},
+        },
+    ]
+    hcg = FakeHCG(tds, members=members, is_a=is_a_edges)
+    handler = _handler(hcg, FakeMilvus({}))
+    handler._load_type_layer()
+    handler._protected_root_uuids = frozenset(
+        handler._root_uuid_by_name.get(n, "")
+        for n in ("root", "node", "entity", "concept", "process", "cognition")
+    )
+
+    result = handler._type_uuid_map(["member_dog"])
+
+    assert (
+        result["member_dog"] == "type_animal"
+    ), "_type_uuid_map used type_uuid property instead of IS_A edge target"
+
+
+def test_type_uuid_map_returns_empty_for_node_with_no_is_a_edge():
+    """A node with no IS_A edge should not appear in the result dict."""
+    tds = [
+        {"uuid": "type_animal", "name": "animal", "properties": {}},
+        {"uuid": "type_plant", "name": "plant", "properties": {}},
+    ]
+    members = [{"uuid": "member_orphan", "name": "orphan", "properties": {}}]
+    hcg = FakeHCG(tds, members=members, is_a=[])
+    handler = _handler(hcg, FakeMilvus({}))
+    handler._load_type_layer()
+    handler._protected_root_uuids = frozenset()
+
+    result = handler._type_uuid_map(["member_orphan"])
+
+    assert (
+        "member_orphan" not in result
+    ), "Orphan node (no IS_A edge) should not appear in _type_uuid_map result"
+
+
+def test_type_uuid_map_prefers_non_root_target_on_multiple_is_a():
+    """When a node has multiple IS_A edges, the non-protected-root target is
+    preferred so that realm-root membership doesn't mask the node's type identity.
+    """
+    tds = [
+        {"uuid": "type_animal", "name": "animal", "properties": {}},
+        {"uuid": "type_plant", "name": "plant", "properties": {}},
+    ]
+    members = [{"uuid": "member_dog", "name": "dog", "properties": {}}]
+    # Two IS_A edges: one to `entity` (a protected root), one to `type_animal`.
+    is_a_edges = [
+        {
+            "id": "e1",
+            "source": "member_dog",
+            "target": "type_entity",
+            "relation": "IS_A",
+        },
+        {
+            "id": "e2",
+            "source": "member_dog",
+            "target": "type_animal",
+            "relation": "IS_A",
+        },
+    ]
+    hcg = FakeHCG(tds, members=members, is_a=is_a_edges)
+    handler = _handler(hcg, FakeMilvus({}))
+    handler._load_type_layer()
+    # Mark type_entity as a protected root (it was auto-injected by FakeHCG).
+    handler._protected_root_uuids = frozenset({"type_entity"})
+
+    result = handler._type_uuid_map(["member_dog"])
+
+    assert (
+        result["member_dog"] == "type_animal"
+    ), "Should prefer non-root IS_A target over protected realm root"

--- a/tests/maintenance/test_type_rollup.py
+++ b/tests/maintenance/test_type_rollup.py
@@ -1267,3 +1267,50 @@ def test_top_level_super_grafts_under_deeper_domain_type(monkeypatch):
         and e["relation"] == "IS_A"
         for e in hcg.edges
     )
+
+
+def test_accreted_content_node_cannot_shadow_protected_root_in_root_uuid_by_name():
+    """An accreted content node named 'entity' must not overwrite the seeded
+    realm-root uuid in _root_uuid_by_name / _entity_root_uuid.
+
+    In the original last-wins dict comprehension, if get_all_type_definitions()
+    returned the content node AFTER the seeded root, the content node's uuid
+    would win, causing every domain graft to land under the wrong parent.
+
+    The fix: for protected root names, the candidate with the fewest ancestors
+    (i.e. structurally highest -- the seeded root) always wins, regardless of
+    iteration order.
+    """
+    # Seeded entity root: no ancestors (typical seeded root shape).
+    seeded_entity = {
+        "uuid": "type_entity_seeded",
+        "name": "entity",
+        "properties": {"type": "type_definition"},  # no 'ancestors' key
+    }
+    # Accreted content node that shares the protected name "entity".
+    # It sits deeper: ancestors = ["root", "node", "entity", "thing"].
+    accreted_entity = {
+        "uuid": "accreted_entity_node",
+        "name": "entity",
+        "properties": {
+            "type": "type_definition",
+            "ancestors": ["root", "node", "entity", "thing"],
+        },
+    }
+    # Build with accreted node listed LAST so last-wins would give the wrong uuid.
+    tds = [seeded_entity, accreted_entity]
+    hcg = FakeHCG(tds)
+    handler = _handler(hcg, FakeMilvus({}))
+    handler._load_type_layer()
+
+    # The seeded root (zero ancestors depth) must win the "entity" slot.
+    assert handler._root_uuid_by_name.get("entity") == "type_entity_seeded", (
+        "_root_uuid_by_name['entity'] was shadowed by the accreted content node"
+    )
+    # _entity_root_uuid is derived directly from _root_uuid_by_name in run();
+    # set it the same way to verify the derivation produces the right uuid.
+    from sophia.maintenance.type_rollup_handler import _BASE_TYPE
+    entity_uuid = handler._root_uuid_by_name.get(_BASE_TYPE)
+    assert entity_uuid == "type_entity_seeded", (
+        "_entity_root_uuid would resolve to the wrong (accreted) node"
+    )

--- a/tests/maintenance/test_type_rollup.py
+++ b/tests/maintenance/test_type_rollup.py
@@ -21,6 +21,17 @@ class FakeHCG:
         self.nodes = {td["uuid"]: td for td in type_defs}
         for m in members or []:  # entity members carry a type_uuid
             self.nodes[m["uuid"]] = m
+        # The seeder always creates the structural/realm roots; inject any not
+        # explicitly provided so the rollup can resolve root parents by name
+        # positionally (name -> real uuid), mirroring the live graph. Roots are
+        # protected names, so they never become rollup candidates.
+        for _rn in ("root", "node", "entity", "concept", "process", "cognition"):
+            if not any(n.get("name") == _rn for n in self.nodes.values()):
+                self.nodes[f"type_{_rn}"] = {
+                    "uuid": f"type_{_rn}",
+                    "name": _rn,
+                    "properties": {"type": "type_definition"},
+                }
         # edges: list of {id, source, target, relation}
         self.edges = list(is_a or []) + list(other_edges or [])
         self._eid = 0
@@ -130,6 +141,7 @@ def _handler(hcg, milvus, mint_calls=None, name_label="mathematics"):
         milvus,
         source_cluster_id,
         parent_type_uuid,
+        realm,
     ):
         uuid = f"type_{name.label}_super01"
         hcg.nodes[uuid] = {
@@ -187,50 +199,34 @@ def test_candidate_minted_type_shape_detected():
     assert _is_rollup_candidate(td)
 
 
-def test_candidate_requires_nested_properties_type():
-    """The ONE canonical record shape is the full node map nested under
-    `properties` (what get_all_type_definitions returns). A top-level `type`
-    is never consulted -- neither to admit a flattened record nor to shadow
-    the nested value (PR #173 review)."""
-    flattened = {
-        "uuid": "type_location",
-        "name": "location",
-        "type": "type_definition",
-        "properties": {},
-    }
-    assert not _is_rollup_candidate(flattened)
-    shadowed = {
-        "uuid": "type_location",
-        "name": "location",
-        "type": "Node",
-        "properties": {"type": "type_definition"},
-    }
-    assert _is_rollup_candidate(shadowed)
+def test_candidate_is_label_agnostic():
+    """Candidacy is purely structural now (positional rework): a type_-prefixed
+    uuid + non-reserved name qualifies regardless of the node `type` label /
+    properties (which `mint_type` will set to the realm, not "type_definition")."""
+    for props in ({"type": "type_definition"}, {"type": "entity"}, {}):
+        td = {"uuid": "type_location", "name": "location", "properties": props}
+        assert _is_rollup_candidate(td), props
 
 
-def test_candidate_rejects_non_type_definition_nodes():
-    """Instance/entity nodes are not type-defs, whatever their uuid shape."""
-    # type_ uuid prefix but a non-type node type: structure says no.
-    odd = {"uuid": "type_oddball", "name": "oddball", "properties": {"type": "entity"}}
-    assert not _is_rollup_candidate(odd)
-    # plain instance: uuid4, domain type.
-    inst = {
+def test_candidate_accepts_opaque_uuid_positional_type():
+    """Candidacy no longer keys on a `type_` uuid scheme. Records reaching this
+    predicate come from get_all_type_definitions() -- i.e. they are already
+    types POSITIONALLY (a node with incoming IS_A) -- so an opaque-uuid type
+    qualifies. Only an empty uuid (or a reserved/protected name) is rejected."""
+    opaque = {
         "uuid": "9be07f63-2f6a-4f8e-9c1d-0a1b2c3d4e5f",
-        "name": "rex",
-        "properties": {"type": "dog"},
+        "name": "dog",
+        "properties": {"type": "entity"},
     }
-    assert not _is_rollup_candidate(inst)
+    assert _is_rollup_candidate(opaque)
+    assert not _is_rollup_candidate({"uuid": "", "name": "x", "properties": {}})
 
 
-def test_candidate_rejects_legacy_flag_without_structure():
-    """The legacy flag alone no longer qualifies a record (structure, not
-    flags; dev DBs are wiped/reseeded, so no migration path is needed)."""
-    td = {
-        "uuid": "type_legacy",
-        "name": "legacy",
-        "properties": {"is_type_definition": True},
-    }
-    assert not _is_rollup_candidate(td)
+def test_candidate_ignores_legacy_flag_and_missing_type():
+    """A minted type qualifies with no `type` label and no legacy flag -- the
+    type_ uuid + name is the structure (dev DBs are wiped/reseeded; no flags)."""
+    td = {"uuid": "type_legacy", "name": "legacy", "properties": {}}
+    assert _is_rollup_candidate(td)
 
 
 def test_candidate_protected_and_reserved_exclusions_hold():
@@ -477,6 +473,7 @@ def test_cycle_is_recorded_as_ambiguous_not_minted_as_edge():
     hcg = FakeHCG(tds, is_a=is_a)
     milvus = FakeMilvus({"type_a_aa": [1.0, 0.0], "type_b_bb": [0.9, 0.1]})
     h = _handler(hcg, milvus)
+    h._load_type_layer()  # populates _type_uuids (run() does this before adjacency)
     h._build_is_a_adjacency()
     # Try to make b the parent of a -> would close the 2-cycle a->b->a.
     h._reparent_one("type_a_aa", "type_b_bb")
@@ -518,6 +515,7 @@ def test_adjacency_ignores_instance_taxonomy():
     ]
     hcg = FakeHCG(tds, is_a=is_a)
     h = _handler(hcg, FakeMilvus({}))
+    h._load_type_layer()  # populates _type_uuids (run() does this before adjacency)
     h._build_is_a_adjacency()
     assert h._children_of.get("type_entity") == ["type_x_aa"]
     assert "natural_resource_inst" not in h._children_of  # instance edge excluded
@@ -670,6 +668,7 @@ def test_reused_super_is_reparented_to_intended_parent(monkeypatch):
         milvus,
         source_cluster_id,
         parent_type_uuid,
+        realm,
     ):
         uuid = f"type_{name.label}_super01"
         hcg.nodes[uuid] = {
@@ -902,6 +901,7 @@ def test_top_level_super_grafts_under_realm_root(monkeypatch):
         milvus,
         source_cluster_id,
         parent_type_uuid,
+        realm,
     ):
         uuid = f"type_{name.label}_super01"
         hcg.nodes[uuid] = {
@@ -1047,6 +1047,14 @@ def test_resolve_parent_accepts_covering_types_and_rejects_forbidden():
         "mathematics": "type_mathematics",
         "metaschema": "type_metaschema",
     }
+    # Realm/protected roots resolve positionally via the canonical root map
+    # (name -> real uuid), built from the full type layer in run().
+    handler._root_uuid_by_name = {
+        "concept": "type_concept",
+        "process": "type_process",
+        "cognition": "type_cognition",
+        "entity": "type_entity",
+    }
 
     # Realm roots resolve to their canonical seeded uuid + ancestors.
     assert handler._resolve_parent("concept") == "type_concept"
@@ -1144,8 +1152,16 @@ def test_resolve_parent_ignores_shadowing_domain_type():
     ]
     hcg = FakeHCG(tds)
     handler = _handler(hcg, FakeMilvus({}))
+    # The candidate map (deeper types) can be shadowed by a case-variant
+    # "Concept"; realm roots, however, resolve via the canonical positional root
+    # map (`_root_uuid_by_name`, built from the full type layer), so the shadow
+    # in `_uuid_by_name` can never win for a realm root.
     handler._uuid_by_name = {
-        "concept": "type_concept_shadow01",  # shadow owns the realm key
+        "concept": "type_concept_shadow01",  # shadow owns the realm key HERE
+        "process": "type_process",
+    }
+    handler._root_uuid_by_name = {
+        "concept": "type_concept",  # canonical seeded root wins
         "process": "type_process",
     }
     assert handler._resolve_parent("concept") == "type_concept"
@@ -1217,6 +1233,7 @@ def test_top_level_super_grafts_under_deeper_domain_type(monkeypatch):
         milvus,
         source_cluster_id,
         parent_type_uuid,
+        realm,
     ):
         uuid = f"type_{name.label}_super01"
         hcg.nodes[uuid] = {

--- a/tests/maintenance/test_type_snapshot.py
+++ b/tests/maintenance/test_type_snapshot.py
@@ -1,0 +1,88 @@
+"""Tests for the shared positional type-snapshot writer."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+from sophia.maintenance.type_snapshot import REDIS_KEY, publish_type_snapshot
+
+
+def _hcg(records):
+    hcg = MagicMock()
+    hcg.get_all_type_definitions.return_value = records
+    return hcg
+
+
+def test_writes_name_keyed_snapshot() -> None:
+    """Snapshot is keyed by type NAME with {uuid, member_count} values."""
+    redis = MagicMock()
+    hcg = _hcg(
+        [
+            {"uuid": "u-engine", "name": "engine",
+             "properties": {"member_count": 5}},
+            {"uuid": "u-protein", "name": "protein",
+             "properties": {"member_count": 3}},
+        ]
+    )
+
+    count = publish_type_snapshot(hcg, redis)
+
+    assert count == 2
+    key, payload = redis.set.call_args[0]
+    assert key == REDIS_KEY
+    assert json.loads(payload) == {
+        "engine": {"uuid": "u-engine", "member_count": 5},
+        "protein": {"uuid": "u-protein", "member_count": 3},
+    }
+
+
+def test_skips_records_without_a_name() -> None:
+    """Nameless rows are dropped rather than written under an empty key."""
+    redis = MagicMock()
+    hcg = _hcg(
+        [
+            {"uuid": "u-x", "name": "", "properties": {"member_count": 1}},
+            {"uuid": "u-engine", "name": "engine", "properties": {}},
+        ]
+    )
+
+    count = publish_type_snapshot(hcg, redis)
+
+    assert count == 1
+    _, payload = redis.set.call_args[0]
+    assert json.loads(payload) == {"engine": {"uuid": "u-engine", "member_count": 0}}
+
+
+def test_missing_properties_defaults_member_count_to_zero() -> None:
+    """A record with no properties dict still serialises with member_count 0."""
+    redis = MagicMock()
+    hcg = _hcg([{"uuid": "u-engine", "name": "engine"}])
+
+    publish_type_snapshot(hcg, redis)
+
+    _, payload = redis.set.call_args[0]
+    assert json.loads(payload) == {"engine": {"uuid": "u-engine", "member_count": 0}}
+
+
+def test_fail_soft_on_none_redis() -> None:
+    """No Redis handle -> no-op returning 0, never touching the graph."""
+    hcg = _hcg([{"uuid": "u", "name": "engine", "properties": {}}])
+    assert publish_type_snapshot(hcg, None) == 0
+    hcg.get_all_type_definitions.assert_not_called()
+
+
+def test_fail_soft_on_none_hcg() -> None:
+    """No HCG client -> no-op returning 0, never touching Redis."""
+    redis = MagicMock()
+    assert publish_type_snapshot(None, redis) == 0
+    redis.set.assert_not_called()
+
+
+def test_fail_soft_on_graph_error() -> None:
+    """A graph/Redis exception is swallowed and reported as 0 (sophia#195)."""
+    redis = MagicMock()
+    hcg = MagicMock()
+    hcg.get_all_type_definitions.side_effect = RuntimeError("neo4j down")
+    assert publish_type_snapshot(hcg, redis) == 0
+    redis.set.assert_not_called()

--- a/tests/maintenance/test_type_snapshot.py
+++ b/tests/maintenance/test_type_snapshot.py
@@ -86,9 +86,14 @@ def test_fail_soft_on_graph_error() -> None:
     redis.set.assert_not_called()
 
 
-def test_name_collision_logs_warning(caplog) -> None:
-    """Same-name types produce a warning; the second clobbers the first."""
-    import logging
+def test_name_collision_logs_warning() -> None:
+    """Same-name types produce a warning; the second clobbers the first.
+
+    Uses unittest.mock to capture the warning directly on the module logger so
+    the test is not sensitive to whether a parent logger (e.g. "sophia") has
+    propagate=False (which breaks caplog when API tests run in the same session).
+    """
+    from unittest.mock import patch
 
     redis = MagicMock()
     hcg = _hcg(
@@ -98,7 +103,7 @@ def test_name_collision_logs_warning(caplog) -> None:
         ]
     )
 
-    with caplog.at_level(logging.WARNING, logger="sophia.maintenance.type_snapshot"):
+    with patch("sophia.maintenance.type_snapshot.logger") as mock_logger:
         count = publish_type_snapshot(hcg, redis)
 
     # Only one key written (collision); last wins
@@ -107,4 +112,6 @@ def test_name_collision_logs_warning(caplog) -> None:
     written = json.loads(payload)
     assert written["engine"]["uuid"] == "u-beta"
     # Warning was emitted
-    assert any("collision" in r.message for r in caplog.records)
+    mock_logger.warning.assert_called_once()
+    warning_args = mock_logger.warning.call_args[0]
+    assert "collision" in warning_args[0]

--- a/tests/maintenance/test_type_snapshot.py
+++ b/tests/maintenance/test_type_snapshot.py
@@ -86,3 +86,25 @@ def test_fail_soft_on_graph_error() -> None:
     hcg.get_all_type_definitions.side_effect = RuntimeError("neo4j down")
     assert publish_type_snapshot(hcg, redis) == 0
     redis.set.assert_not_called()
+
+def test_name_collision_logs_warning(caplog) -> None:
+    """Same-name types produce a warning; the second clobbers the first."""
+    import logging
+    redis = MagicMock()
+    hcg = _hcg(
+        [
+            {"uuid": "u-alpha", "name": "engine", "properties": {"member_count": 2}},
+            {"uuid": "u-beta", "name": "engine", "properties": {"member_count": 7}},
+        ]
+    )
+
+    with caplog.at_level(logging.WARNING, logger="sophia.maintenance.type_snapshot"):
+        count = publish_type_snapshot(hcg, redis)
+
+    # Only one key written (collision); last wins
+    assert count == 1
+    _, payload = redis.set.call_args[0]
+    written = json.loads(payload)
+    assert written["engine"]["uuid"] == "u-beta"
+    # Warning was emitted
+    assert any("collision" in r.message for r in caplog.records)

--- a/tests/maintenance/test_type_snapshot.py
+++ b/tests/maintenance/test_type_snapshot.py
@@ -19,10 +19,8 @@ def test_writes_name_keyed_snapshot() -> None:
     redis = MagicMock()
     hcg = _hcg(
         [
-            {"uuid": "u-engine", "name": "engine",
-             "properties": {"member_count": 5}},
-            {"uuid": "u-protein", "name": "protein",
-             "properties": {"member_count": 3}},
+            {"uuid": "u-engine", "name": "engine", "properties": {"member_count": 5}},
+            {"uuid": "u-protein", "name": "protein", "properties": {"member_count": 3}},
         ]
     )
 
@@ -87,9 +85,11 @@ def test_fail_soft_on_graph_error() -> None:
     assert publish_type_snapshot(hcg, redis) == 0
     redis.set.assert_not_called()
 
+
 def test_name_collision_logs_warning(caplog) -> None:
     """Same-name types produce a warning; the second clobbers the first."""
     import logging
+
     redis = MagicMock()
     hcg = _hcg(
         [

--- a/tests/unit/ingestion/test_proposal_processor.py
+++ b/tests/unit/ingestion/test_proposal_processor.py
@@ -1339,8 +1339,12 @@ class TestProposalProcessorRedisSnapshot:
         # Should not raise even without redis_client
         result = processor.process(self._make_proposal())
         assert "stored_node_ids" in result
-        # get_all_type_definitions should NOT be called for type snapshot when no redis
-        mock_hcg.get_all_type_definitions.assert_not_called()
+        # With the positional model, get_all_type_definitions is called during
+        # ingest to build the realm-root catalog (uuid_by_name) regardless of
+        # whether redis is configured -- it is NOT a snapshot-only call. The
+        # snapshot write is skipped because publish_type_snapshot short-circuits
+        # when redis is None. Verify processing succeeded without raising.
+        assert isinstance(result["stored_node_ids"], list)
 
     def test_process_redis_write_failure_does_not_break_processing(self):
         """If the Redis snapshot write fails, neither construction nor
@@ -1462,11 +1466,20 @@ class TestRealmTriage:
 
         mock_hcg = MagicMock()
         mock_hcg.add_node.return_value = "node-1"
-        mock_hcg.list_all_nodes.return_value = [
-            {"name": "entity", "uuid": "realm-entity", "type": "type_definition"},
-            {"name": "concept", "uuid": "realm-concept", "type": "type_definition"},
-            {"name": "process", "uuid": "realm-process", "type": "type_definition"},
+        # Positional model: realm roots are discovered via get_all_type_definitions,
+        # not list_all_nodes. Provide uuid+name so uuid_by_name is populated.
+        mock_hcg.get_all_type_definitions.return_value = [
+            {"name": "entity", "uuid": "realm-entity"},
+            {"name": "concept", "uuid": "realm-concept"},
+            {"name": "process", "uuid": "realm-process"},
         ]
+        # placement._walk_to_realm calls get_node to confirm a node is a realm root.
+        _realm_nodes = {
+            "realm-entity": {"name": "entity", "uuid": "realm-entity"},
+            "realm-concept": {"name": "concept", "uuid": "realm-concept"},
+            "realm-process": {"name": "process", "uuid": "realm-process"},
+        }
+        mock_hcg.get_node.side_effect = lambda uuid: _realm_nodes.get(uuid, {})
         mock_hcg.query_edges_from.return_value = []
         mock_hcg.add_edge.return_value = "edge-1"
 


### PR DESCRIPTION
## What

Makes sophia's type layer fully **positional** and pins logos to the matching release.

### Detection / encoding (8aa0120)
- Type detection reads `hcg.get_all_type_definitions()` (positional: a node is a type iff it has an incoming reified IS_A edge) everywhere — emergence (`current_categories`, `uuid_by_name`), `type_correction`, `type_rollup`.
- `mint_type`: opaque `uuid4()` (no `type_<slug>`); `.type` now holds the **realm** (entity/concept/process), uniform with content nodes; type-ness is positional, never a stored `type_definition` label.
- `type_rollup`: resolves roots/types positionally via one name→uuid map; dropped `_PROTECTED_ROOT_UUIDS`, the `uuid.startswith("type_")` candidate gate, and all `f"type_{name}"` slugs; adjacency keys on the positional type-uuid set.
- `_type_name`: no longer parses a `type_` prefix.
- Redis type-snapshot sync (#4): shared `type_snapshot.publish_type_snapshot` driven from ingest + scheduler reconcile + `ontology.type_created` event.

### Evolving centroids (77144c4)
- A type's centroid is the **count-weighted mean of its members**, kept current: incremental online-mean fold on the emergence attach path + `reconcile_centroids` full-recompute backstop. No model invocation/fabrication (model read off member vectors; dimension is the enforced invariant).

### Pin
- `logos-foundry` → **v0.7.4** (the positional rework, tagged from logos#561), so `poetry install --sync` installs positional logos durably.

## Tests
158 → 169 maintenance+ingestion tests green; ruff clean.

## Follow-ups (ticketed)
- Rollup sub-type graft fold (count-weighted, up-chain) + scheduled centroid reconcile (reconcile backstops correctness today).