### PR TITLE
fix(ingestion): resolve realm roots by name so the IS_A edge lands with the type stamp

### DIFF
--- a/src/sophia/ingestion/proposal_processor.py
+++ b/src/sophia/ingestion/proposal_processor.py
@@ -302,7 +302,6 @@ class ProposalProcessor:
                     for name, node in self._hcg.find_nodes_by_names(
                         ["entity", "concept", "process"]
                     ).items()
-                    if node and node.get("uuid")
                 }
             except Exception:
                 logger.exception(

--- a/src/sophia/ingestion/proposal_processor.py
+++ b/src/sophia/ingestion/proposal_processor.py
@@ -286,23 +286,28 @@ class ProposalProcessor:
                     relevant_context = relevant_context[:10]
 
             # 2. Ingest proposed nodes
-            # Resolve the seeded realm roots (entity/concept/process) BY NAME from
-            # the type-definition catalog so each new instance can be parked under
-            # its realm via an IS_A edge (#505). Mirrors the maintenance tier's
-            # name->uuid resolution (emergence_handler); built once per batch.
-            # Fail-soft: if the catalog query fails (e.g. Neo4j transient error),
-            # proceed with an empty map -- nodes are created but left unparked
-            # (the maintenance reconcile loop re-parks them later).
+            # Resolve the seeded realm roots (entity/concept/process) BY NODE
+            # NAME so each new instance is parked under its realm with an IS_A
+            # edge -- the same act as stamping its realm `type`. Resolve by name,
+            # NOT via the positional type catalog (get_all_type_definitions):
+            # that catalog omits a realm root until something already IS_A's it,
+            # so on a cold/quiet graph every fresh instance was stranded unparked
+            # while its `type` stamp still landed -- the two halves of "put it in
+            # the realm pool" came apart (regression from the positional-type
+            # layer). Fail-soft: if the lookup fails, proceed with an empty map
+            # -- nodes are created but left unparked (the reconcile loop re-parks).
             try:
                 uuid_by_name = {
-                    n["name"].strip().lower(): n["uuid"]
-                    for n in self._hcg.get_all_type_definitions()
-                    if n.get("name") and n.get("uuid")
+                    name: node["uuid"]
+                    for name, node in self._hcg.find_nodes_by_names(
+                        ["entity", "concept", "process"]
+                    ).items()
+                    if node and node.get("uuid")
                 }
             except Exception:
                 logger.exception(
-                    "ingest: failed to fetch realm-root catalog; nodes will be "
-                    "created unparked and re-parked by the reconcile loop"
+                    "ingest: failed to resolve realm roots by name; nodes will "
+                    "be created unparked and re-parked by the reconcile loop"
                 )
                 uuid_by_name = {}
 

--- a/tests/unit/ingestion/test_proposal_processor.py
+++ b/tests/unit/ingestion/test_proposal_processor.py
@@ -358,7 +358,14 @@ class TestProposalProcessor:
 
         # Should have resolved "France" via batch find_nodes_by_names
         assert len(result["stored_edge_ids"]) == 1
-        mock_hcg.find_nodes_by_names.assert_called_once()
+        # Exclude the ingest realm-park lookup (entity/concept/process); the edge
+        # names must be batch-resolved in a single call.
+        edge_lookups = [
+            c
+            for c in mock_hcg.find_nodes_by_names.call_args_list
+            if c.args[0] != ["entity", "concept", "process"]
+        ]
+        assert len(edge_lookups) == 1
         # Individual find_node_by_name should NOT be called
         mock_hcg.find_node_by_name.assert_not_called()
 
@@ -419,10 +426,15 @@ class TestProposalProcessor:
 
         # Both edges should be created
         assert len(result["stored_edge_ids"]) == 2
-        # Batch call made once with both unresolved names
-        mock_hcg.find_nodes_by_names.assert_called_once()
-        call_args = mock_hcg.find_nodes_by_names.call_args[0][0]
-        assert set(call_args) == {"France", "Europe"}
+        # Batch call made once with both unresolved names (excluding the ingest
+        # realm-park lookup of entity/concept/process).
+        edge_lookups = [
+            c
+            for c in mock_hcg.find_nodes_by_names.call_args_list
+            if c.args[0] != ["entity", "concept", "process"]
+        ]
+        assert len(edge_lookups) == 1
+        assert set(edge_lookups[0].args[0]) == {"France", "Europe"}
         # No individual lookups
         mock_hcg.find_node_by_name.assert_not_called()
 
@@ -530,9 +542,15 @@ class TestProposalProcessor:
             }
         )
 
-        # Both A and B were just created, so no batch resolution needed
+        # Both A and B were just created, so no edge batch resolution is needed
+        # (the only find_nodes_by_names call is the ingest realm-park lookup).
         assert len(result["stored_edge_ids"]) == 1
-        mock_hcg.find_nodes_by_names.assert_not_called()
+        edge_lookups = [
+            c
+            for c in mock_hcg.find_nodes_by_names.call_args_list
+            if c.args[0] != ["entity", "concept", "process"]
+        ]
+        assert edge_lookups == []
 
     def test_edge_properties_cannot_overwrite_reserved_keys(self):
         """Untrusted properties must not overwrite uuid, source, target, relation."""
@@ -1466,13 +1484,14 @@ class TestRealmTriage:
 
         mock_hcg = MagicMock()
         mock_hcg.add_node.return_value = "node-1"
-        # Positional model: realm roots are discovered via get_all_type_definitions,
-        # not list_all_nodes. Provide uuid+name so uuid_by_name is populated.
-        mock_hcg.get_all_type_definitions.return_value = [
-            {"name": "entity", "uuid": "realm-entity"},
-            {"name": "concept", "uuid": "realm-concept"},
-            {"name": "process", "uuid": "realm-process"},
-        ]
+        # Realm roots are resolved BY NODE NAME (find_nodes_by_names), not the
+        # member-gated type catalog -- so a childless realm still resolves and the
+        # IS_A edge is written in the same breath as the `type` stamp.
+        mock_hcg.find_nodes_by_names.return_value = {
+            "entity": {"name": "entity", "uuid": "realm-entity"},
+            "concept": {"name": "concept", "uuid": "realm-concept"},
+            "process": {"name": "process", "uuid": "realm-process"},
+        }
         # placement._walk_to_realm calls get_node to confirm a node is a realm root.
         _realm_nodes = {
             "realm-entity": {"name": "entity", "uuid": "realm-entity"},
@@ -1525,6 +1544,59 @@ class TestRealmTriage:
         assert batch_calls
         assert batch_calls[0].kwargs.get("node_type") == "Entity"
         assert batch_calls[0].kwargs["embeddings"][0]["uuid"] == "node-1"
+
+    def test_cold_start_parks_via_name_when_realm_has_no_members(self):
+        """Regression: on a cold graph the realm roots have no members, so the
+        positional type catalog (get_all_type_definitions) omits them. Parking
+        must still resolve the realm BY NAME and write the instance->realm IS_A
+        edge -- not strand the node unparked while its `type` stamp lands.
+        """
+        from sophia.ingestion.proposal_processor import ProposalProcessor
+
+        mock_hcg = MagicMock()
+        mock_hcg.add_node.return_value = "n1"
+        # Childless realms -> the positional catalog is empty...
+        mock_hcg.get_all_type_definitions.return_value = []
+        # ...but the realm roots still exist as nodes and resolve by name.
+        mock_hcg.find_nodes_by_names.return_value = {
+            "entity": {"name": "entity", "uuid": "realm-entity"},
+            "concept": {"name": "concept", "uuid": "realm-concept"},
+            "process": {"name": "process", "uuid": "realm-process"},
+        }
+        mock_hcg.get_node.side_effect = lambda uuid: {
+            "realm-entity": {"name": "entity", "uuid": "realm-entity"},
+        }.get(uuid, {})
+        mock_hcg.query_edges_from.return_value = []
+        mock_hcg.add_edge.return_value = "e1"
+
+        mock_milvus = MagicMock()
+        mock_milvus.search_similar.return_value = []
+
+        processor = ProposalProcessor(hcg_client=mock_hcg, milvus_sync=mock_milvus)
+        processor.process(
+            {
+                "proposal_id": "p1",
+                "proposed_nodes": [
+                    {
+                        "name": "narwhal",
+                        "type": "entity",
+                        "embedding": [0.1] * 384,
+                        "model": "all-MiniLM-L6-v2",
+                        "properties": {},
+                    }
+                ],
+                "proposed_edges": [],
+                "document_embedding": {},
+                "raw_text": "narwhal",
+                "source_service": "hermes",
+                "confidence": 0.7,
+            }
+        )
+
+        is_a = [c for c in mock_hcg.add_edge.call_args_list if c.args[2:3] == ("IS_A",)]
+        assert is_a, "instance must be parked under its realm even with empty catalog"
+        assert is_a[0].args[0] == "n1"
+        assert is_a[0].args[1] == "realm-entity"
 
 
 class TestSnapshotPublishOnInit:

--- a/tests/unit/ingestion/test_proposal_processor.py
+++ b/tests/unit/ingestion/test_proposal_processor.py
@@ -363,7 +363,8 @@ class TestProposalProcessor:
         edge_lookups = [
             c
             for c in mock_hcg.find_nodes_by_names.call_args_list
-            if c.args[0] != ["entity", "concept", "process"]
+            if (c.args[0] if c.args else c.kwargs.get("names"))
+            != ["entity", "concept", "process"]
         ]
         assert len(edge_lookups) == 1
         # Individual find_node_by_name should NOT be called
@@ -431,7 +432,8 @@ class TestProposalProcessor:
         edge_lookups = [
             c
             for c in mock_hcg.find_nodes_by_names.call_args_list
-            if c.args[0] != ["entity", "concept", "process"]
+            if (c.args[0] if c.args else c.kwargs.get("names"))
+            != ["entity", "concept", "process"]
         ]
         assert len(edge_lookups) == 1
         assert set(edge_lookups[0].args[0]) == {"France", "Europe"}
@@ -548,7 +550,8 @@ class TestProposalProcessor:
         edge_lookups = [
             c
             for c in mock_hcg.find_nodes_by_names.call_args_list
-            if c.args[0] != ["entity", "concept", "process"]
+            if (c.args[0] if c.args else c.kwargs.get("names"))
+            != ["entity", "concept", "process"]
         ]
         assert edge_lookups == []
 


### PR DESCRIPTION
Closes #210.

## Problem
The positional type layer made the ingest realm-park resolve the realm root through `get_all_type_definitions()` (positional — only returns a node once something already `IS_A`'s it). On a cold/quiet graph the seeded realms have no members, so the lookup returns nothing and every new instance is left **unparked**: the `type` stamp lands but the instance→realm `IS_A` edge doesn't. The drainage pool stays empty and emergence/rollup have nothing to drain.

## Fix
Resolve the seeded realm roots **by node name** — `find_nodes_by_names(["entity","concept","process"])` — a bounded 3-name lookup (not an all-node scan). The realms always resolve, so the `IS_A` edge is written in the same breath as the `type` stamp, regardless of whether the realm has members yet. (Restores the pre-positional-layer behavior.)

## Tests
- New cold-start regression: empty positional catalog, realm still resolves by name → instance parks under its realm.
- Realm-park test now mocks `find_nodes_by_names`.
- Three edge-resolution tests updated to exclude the constant realm-park lookup from their `find_nodes_by_names` call-count assertions.
- proposal_processor suite: 40 passed; ingestion + placement: 77 passed; ruff + black clean.

## Verified live
Reset → ingest 16-block corpus: **47/47** corpus nodes clumped under `entity`, **0** `left unparked` warnings (was 47).

## Follow-up
Smarter ingest-time placement via embedding ANN — see #212.