### PR TITLE
fix(emergence): read embedding_model so type centroids get written

### DIFF
--- a/src/sophia/maintenance/emergence_handler.py
+++ b/src/sophia/maintenance/emergence_handler.py
@@ -133,7 +133,12 @@ def _build_member(
         current_type=row.get("type", type_name),
         hermes_type_hint=props.get("hermes_type_hint"),
         neighbors=neighbors,
-        model=emb.get("model"),
+        # HCGMilvusSync.get_embedding returns the model under `embedding_model`;
+        # there is no `model` key, so reading it left every Member.model None.
+        # Harmless until #206 brought in count-weighted centroids, which feed
+        # Member.model into update_centroid -> Milvus rejects a null embedding_model
+        # and no centroid is ever written. Read the field Milvus actually returns.
+        model=emb.get("embedding_model"),
     )
 
 

--- a/tests/maintenance/test_emergence_adapters.py
+++ b/tests/maintenance/test_emergence_adapters.py
@@ -79,7 +79,7 @@ def test_load_type_members_builds_member_with_signature():
         edges={"u1": [{"relation": "DEFINED_AS", "target": "u2"}]},
         batch={"u2": {"uuid": "u2", "name": "limit", "type": "entity"}},
     )
-    milvus = _FakeMilvus({"u1": {"embedding": [0.1, 0.2], "model": "m"}})
+    milvus = _FakeMilvus({"u1": {"embedding": [0.1, 0.2], "embedding_model": "m"}})
 
     members = load_type_members(hcg, milvus, "type_entity")
 
@@ -116,8 +116,8 @@ def test_load_type_members_minted_type_uses_is_a_edge_query():
     )
     milvus = _FakeMilvus(
         {
-            "u1": {"embedding": [0.1, 0.2], "model": "m"},
-            "u2": {"embedding": [0.3, 0.4], "model": "m"},
+            "u1": {"embedding": [0.1, 0.2], "embedding_model": "m"},
+            "u2": {"embedding": [0.3, 0.4], "embedding_model": "m"},
         }
     )
     members = load_type_members(hcg, milvus, type_uuid)
@@ -135,7 +135,7 @@ def test_load_type_members_skips_minted_member_without_embedding():
             ]
         },
     )
-    milvus = _FakeMilvus({"u1": {"embedding": [0.1], "model": "m"}})
+    milvus = _FakeMilvus({"u1": {"embedding": [0.1], "embedding_model": "m"}})
     members = load_type_members(hcg, milvus, type_uuid)
     assert {m.uuid for m in members} == {"u1"}
 
@@ -159,7 +159,7 @@ def test_minted_member_embeddings_read_from_base_collection():
         def get_embedding(self, node_type, uuid):
             if node_type != "Entity":
                 return None
-            return {"embedding": [0.1, 0.2], "model": "m"}
+            return {"embedding": [0.1, 0.2], "embedding_model": "m"}
 
     members = load_type_members(hcg, _CollectionAwareMilvus(), type_uuid)
     # Read from Entity (base), not Concept (the slug's mapping) -> member kept.
@@ -183,8 +183,8 @@ def test_retyped_member_excluded_from_parent_by_is_a_edge():
     )
     milvus = _FakeMilvus(
         {
-            "u1": {"embedding": [0.1], "model": "m"},
-            "u2": {"embedding": [0.2], "model": "m"},
+            "u1": {"embedding": [0.1], "embedding_model": "m"},
+            "u2": {"embedding": [0.2], "embedding_model": "m"},
         }
     )
     members = load_type_members(hcg, milvus, parent_uuid)
@@ -220,8 +220,8 @@ def test_member_read_uses_is_a_edge_query_for_realm_root_and_minted():
     )
     milvus = _FakeMilvus(
         {
-            "r1": {"embedding": [0.1], "model": "m"},
-            "c1": {"embedding": [0.2], "model": "m"},
+            "r1": {"embedding": [0.1], "embedding_model": "m"},
+            "c1": {"embedding": [0.2], "embedding_model": "m"},
         }
     )
 


### PR DESCRIPTION
Closes #213.

> ⚠️ **Stacked on #211** (`fix/ingest-realm-park-by-name`) so the two #206 cold-start regressions can be tested together. Retarget to `main` once #211 merges.

## Problem
`_build_member` read `emb.get("model")`; `get_embedding` returns `embedding_model` → `Member.model` always `None`. Inert until #206's count-weighted centroids (`77144c4`) consumed it → `update_centroid` upserts a null `embedding_model` → Milvus rejects → **no centroid written** for any emergent type.

## Fix
Read `embedding_model`. Aligned the adapter-test fakes (which used the wrong `model` key, hiding this).

## Verified
176 maintenance tests pass; live re-run of emergence writes centroids (0 → 2).