### PR TITLE
fix(type-snapshot): exclude reserved/internal (_*) names from the published catalog

### DIFF
--- a/src/sophia/maintenance/type_snapshot.py
+++ b/src/sophia/maintenance/type_snapshot.py
@@ -41,7 +41,9 @@ def publish_type_snapshot(hcg: Any, redis: Any) -> int:
             # Reserved/internal scaffolding (`_reserved_*`, `_cognition`) is not a
             # graftable type: never publish it to the catalog, or the naming LLM
             # picks it as a parent and re-roots real subtrees under it (#152).
-            if name.startswith("_"):
+            # Guard isinstance first: a malformed non-string name would raise
+            # AttributeError on .startswith and abort the whole snapshot.
+            if not isinstance(name, str) or name.startswith("_"):
                 continue
             props = record.get("properties")
             member_count = (

--- a/src/sophia/maintenance/type_snapshot.py
+++ b/src/sophia/maintenance/type_snapshot.py
@@ -38,6 +38,11 @@ def publish_type_snapshot(hcg: Any, redis: Any) -> int:
             name = record.get("name", "")
             if not name:
                 continue
+            # Reserved/internal scaffolding (`_reserved_*`, `_cognition`) is not a
+            # graftable type: never publish it to the catalog, or the naming LLM
+            # picks it as a parent and re-roots real subtrees under it (#152).
+            if name.startswith("_"):
+                continue
             props = record.get("properties")
             member_count = (
                 props.get("member_count", 0) if isinstance(props, dict) else 0

--- a/tests/maintenance/test_type_snapshot.py
+++ b/tests/maintenance/test_type_snapshot.py
@@ -52,6 +52,45 @@ def test_skips_records_without_a_name() -> None:
     assert json.loads(payload) == {"engine": {"uuid": "u-engine", "member_count": 0}}
 
 
+def test_skips_reserved_underscore_names() -> None:
+    """Reserved/internal scaffolding (`_`-prefixed) is never published (#152)."""
+    redis = MagicMock()
+    hcg = _hcg(
+        [
+            {
+                "uuid": "u-res",
+                "name": "_reserved_node",
+                "properties": {"member_count": 9},
+            },
+            {"uuid": "u-cog", "name": "_cognition", "properties": {"member_count": 4}},
+            {"uuid": "u-engine", "name": "engine", "properties": {"member_count": 5}},
+        ]
+    )
+
+    count = publish_type_snapshot(hcg, redis)
+
+    assert count == 1
+    _, payload = redis.set.call_args[0]
+    assert json.loads(payload) == {"engine": {"uuid": "u-engine", "member_count": 5}}
+
+
+def test_skips_non_string_name_without_crashing() -> None:
+    """A malformed non-string name is dropped, not raised on .startswith."""
+    redis = MagicMock()
+    hcg = _hcg(
+        [
+            {"uuid": "u-bad", "name": 123, "properties": {"member_count": 1}},
+            {"uuid": "u-engine", "name": "engine", "properties": {"member_count": 5}},
+        ]
+    )
+
+    count = publish_type_snapshot(hcg, redis)
+
+    assert count == 1
+    _, payload = redis.set.call_args[0]
+    assert json.loads(payload) == {"engine": {"uuid": "u-engine", "member_count": 5}}
+
+
 def test_missing_properties_defaults_member_count_to_zero() -> None:
     """A record with no properties dict still serialises with member_count 0."""
     redis = MagicMock()


### PR DESCRIPTION
## Problem
The `/type-cluster` naming catalog is built from sophia's published type snapshot (`logos:ontology:types`), which published **every** positional type-def — including the reserved scaffolding (`_reserved_*`, `_cognition`). The naming LLM was offered `_reserved_node` as a valid parent, picked it, and sophia grafted real content entities under it, corrupting the ontology (observed: berry, car, fern, snow, sunflower, hatchback, … parked under `_reserved_node` instead of `entity`).

## Fix
Filter `_`-prefixed names in `publish_type_snapshot` so only graftable realms (entity/concept/process) and their real descendants reach the catalog. Combines with hermes' existing `_CATALOG_EXCLUDED` (node/root/cognition).

## Validation (warm graph, 611 entities, animals+vehicles+cell-biology)
- real entities under `_reserved_node`: **0** (was: many)
- `/type-cluster` "no valid parent" 502s: **0** (was ~40%)
- emergence+rollup produced clean multi-level hierarchy (catalyst→biocatalyst, structural unit→cell→red blood cell, …)

Relates to #152 (hermes — naming satisfices / mis-roots).