### PR TITLE
fix(emergence): read embedding_model so type centroids get written (#213)

### DIFF
--- a/src/sophia/maintenance/emergence_handler.py
+++ b/src/sophia/maintenance/emergence_handler.py
@@ -133,7 +133,12 @@ def _build_member(
         current_type=row.get("type", type_name),
         hermes_type_hint=props.get("hermes_type_hint"),
         neighbors=neighbors,
-        model=emb.get("model"),
+        # HCGMilvusSync.get_embedding returns the model under `embedding_model`;
+        # there is no `model` key, so reading it left every Member.model None.
+        # Harmless until #206 brought in count-weighted centroids, which feed
+        # Member.model into update_centroid -> Milvus rejects a null embedding_model
+        # and no centroid is ever written. Read the field Milvus actually returns.
+        model=emb.get("embedding_model"),
     )
 
 

--- a/src/sophia/maintenance/emergence_handler.py
+++ b/src/sophia/maintenance/emergence_handler.py
@@ -137,8 +137,10 @@ def _build_member(
         # there is no `model` key, so reading it left every Member.model None.
         # Harmless until #206 brought in count-weighted centroids, which feed
         # Member.model into update_centroid -> Milvus rejects a null embedding_model
-        # and no centroid is ever written. Read the field Milvus actually returns.
-        model=emb.get("embedding_model"),
+        # and no centroid is ever written. Read the field Milvus actually returns,
+        # falling back to "unknown" (as the ingest path does) so a legacy or
+        # missing value can't reintroduce the null that Milvus rejects.
+        model=emb.get("embedding_model") or "unknown",
     )
 
 

--- a/tests/maintenance/test_emergence_adapters.py
+++ b/tests/maintenance/test_emergence_adapters.py
@@ -79,7 +79,7 @@ def test_load_type_members_builds_member_with_signature():
         edges={"u1": [{"relation": "DEFINED_AS", "target": "u2"}]},
         batch={"u2": {"uuid": "u2", "name": "limit", "type": "entity"}},
     )
-    milvus = _FakeMilvus({"u1": {"embedding": [0.1, 0.2], "model": "m"}})
+    milvus = _FakeMilvus({"u1": {"embedding": [0.1, 0.2], "embedding_model": "m"}})
 
     members = load_type_members(hcg, milvus, "type_entity")
 
@@ -116,8 +116,8 @@ def test_load_type_members_minted_type_uses_is_a_edge_query():
     )
     milvus = _FakeMilvus(
         {
-            "u1": {"embedding": [0.1, 0.2], "model": "m"},
-            "u2": {"embedding": [0.3, 0.4], "model": "m"},
+            "u1": {"embedding": [0.1, 0.2], "embedding_model": "m"},
+            "u2": {"embedding": [0.3, 0.4], "embedding_model": "m"},
         }
     )
     members = load_type_members(hcg, milvus, type_uuid)
@@ -135,7 +135,7 @@ def test_load_type_members_skips_minted_member_without_embedding():
             ]
         },
     )
-    milvus = _FakeMilvus({"u1": {"embedding": [0.1], "model": "m"}})
+    milvus = _FakeMilvus({"u1": {"embedding": [0.1], "embedding_model": "m"}})
     members = load_type_members(hcg, milvus, type_uuid)
     assert {m.uuid for m in members} == {"u1"}
 
@@ -159,7 +159,7 @@ def test_minted_member_embeddings_read_from_base_collection():
         def get_embedding(self, node_type, uuid):
             if node_type != "Entity":
                 return None
-            return {"embedding": [0.1, 0.2], "model": "m"}
+            return {"embedding": [0.1, 0.2], "embedding_model": "m"}
 
     members = load_type_members(hcg, _CollectionAwareMilvus(), type_uuid)
     # Read from Entity (base), not Concept (the slug's mapping) -> member kept.
@@ -183,8 +183,8 @@ def test_retyped_member_excluded_from_parent_by_is_a_edge():
     )
     milvus = _FakeMilvus(
         {
-            "u1": {"embedding": [0.1], "model": "m"},
-            "u2": {"embedding": [0.2], "model": "m"},
+            "u1": {"embedding": [0.1], "embedding_model": "m"},
+            "u2": {"embedding": [0.2], "embedding_model": "m"},
         }
     )
     members = load_type_members(hcg, milvus, parent_uuid)
@@ -220,8 +220,8 @@ def test_member_read_uses_is_a_edge_query_for_realm_root_and_minted():
     )
     milvus = _FakeMilvus(
         {
-            "r1": {"embedding": [0.1], "model": "m"},
-            "c1": {"embedding": [0.2], "model": "m"},
+            "r1": {"embedding": [0.1], "embedding_model": "m"},
+            "c1": {"embedding": [0.2], "embedding_model": "m"},
         }
     )
 

--- a/tests/maintenance/test_emergence_adapters.py
+++ b/tests/maintenance/test_emergence_adapters.py
@@ -91,6 +91,22 @@ def test_load_type_members_builds_member_with_signature():
     assert m.neighbors[0]["neighbor_name"] == "limit"
 
 
+def test_build_member_falls_back_to_unknown_when_embedding_model_missing():
+    # A legacy/partial Milvus payload with no embedding_model must not propagate a
+    # null model into update_centroid (Milvus rejects null) -- fall back to "unknown".
+    hcg = _FakeHCG(
+        members_by_type={
+            "type_entity": [{"uuid": "u1", "name": "x", "type": "entity"}]
+        },
+    )
+    milvus = _FakeMilvus({"u1": {"embedding": [0.1, 0.2]}})  # no embedding_model
+
+    members = load_type_members(hcg, milvus, "type_entity")
+
+    assert len(members) == 1
+    assert members[0].model == "unknown"
+
+
 def test_load_type_members_skips_nodes_without_embedding():
     hcg = _FakeHCG(
         members_by_type={


### PR DESCRIPTION
Supersedes #214 (auto-closed when its base branch fix/ingest-realm-park-by-name was deleted during the #211 merge). Same fix, now targeting main directly.

Closes #213.

_build_member read emb.get('model'), but HCGMilvusSync.get_embedding returns the model under embedding_model, so every Member.model was None. Latent since #505; became load-bearing at the #206 merge (count-weighted centroids feed Member.model into update_centroid), where a null embedding_model is rejected by Milvus and no centroid is ever written for an emergent type.

Changes:
- emergence_handler._build_member: read embedding_model (the field Milvus actually returns), defaulting to 'unknown' so a legacy/missing value can't reintroduce the null Milvus rejects (gemini review carried over from #214).
- test_emergence_adapters.py: six _FakeMilvus fixtures corrected to embedding_model; added a regression test for the unknown fallback.

Verified live previously: emergence over a real entity pool wrote 0 -> 2 centroids with no further embedding_model null errors.