### PR TITLE
fix(ingestion): drop IS_A edges at ingest, defer specific typing to emergence (#217)

### DIFF
--- a/src/sophia/ingestion/proposal_processor.py
+++ b/src/sophia/ingestion/proposal_processor.py
@@ -116,6 +116,13 @@ _RESERVED_EDGE_KEYS = frozenset(
     }
 )
 
+# #217: specific typing (instance -> type IS_A) is NOT created at ingest. The
+# realm-park already writes the one upward IS_A (node -> realm root); emergence/
+# drainage later reparents it onto a minted type. An LLM-proposed IS_A edge here
+# would mint a positional type at ingest (bypassing emergence) and leave the node
+# with two upward IS_A edges. Such edges are dropped; non-IS_A relations are kept.
+_DEFERRED_TYPING_RELATION = "IS_A"
+
 
 def _realm_for(ontology_type: str) -> str:
     """Collapse a hermes NER ontology type to one of the 3 realms.
@@ -471,11 +478,16 @@ class ProposalProcessor:
             with tracer.start_as_current_span("proposal_processor.ingest_edges"):
                 stored_edge_ids: list[str] = []
                 dropped_count = 0
+                dropped_typing = 0
                 proposed_edges = proposal.get("proposed_edges") or []
 
                 # Pre-resolve unresolved edge names in batch
                 unresolved_names: set[str] = set()
                 for edge in proposed_edges:
+                    # Skip deferred IS_A typing edges (dropped below): no point
+                    # resolving names only they reference.
+                    if edge.get("relation", "RELATED_TO") == _DEFERRED_TYPING_RELATION:
+                        continue
                     src_name = edge.get("source_name", "")
                     tgt_name = edge.get("target_name", "")
                     if src_name and src_name not in name_to_uuid:
@@ -493,6 +505,14 @@ class ProposalProcessor:
                         logger.debug("Batch name resolution failed: %s", e)
 
                 for edge in proposed_edges:
+                    relation = edge.get("relation", "RELATED_TO")
+                    # #217: defer specific typing to emergence -- never create an
+                    # IS_A edge at ingest (the realm-park already provides the one
+                    # upward IS_A to the realm root). Emergence is the sole typer.
+                    if relation == _DEFERRED_TYPING_RELATION:
+                        dropped_typing += 1
+                        continue
+
                     src_name = edge.get("source_name", "")
                     tgt_name = edge.get("target_name", "")
                     src_uuid = name_to_uuid.get(src_name)
@@ -508,13 +528,12 @@ class ProposalProcessor:
                             "Dropping edge in proposal %s: relation=%s "
                             "unresolved src=%s tgt=%s",
                             proposal.get("proposal_id", ""),
-                            edge.get("relation", "RELATED_TO"),
+                            relation,
                             not src_uuid,
                             not tgt_uuid,
                         )
                         continue
 
-                    relation = edge.get("relation", "RELATED_TO")
                     bidirectional = edge.get("bidirectional", False)
                     properties = dict(edge.get("properties") or {})
                     properties["confidence"] = edge.get("confidence", 0.5)
@@ -556,21 +575,27 @@ class ProposalProcessor:
                 # Only emit at INFO when something dropped (the signal we care
                 # about); the all-resolved case is already covered by the
                 # per-proposal summary logged in the API layer.
-                if dropped_count:
-                    # received = created + dropped_unresolved + errored (every
-                    # proposed edge takes exactly one of those three paths), so
-                    # surface the errored term too — otherwise the counts don't
-                    # reconcile when an edge resolves but add_edge raises.
+                if dropped_count or dropped_typing:
+                    # received = created + dropped_unresolved + dropped_typing +
+                    # errored (every proposed edge takes exactly one of those
+                    # paths), so surface the errored term too — otherwise the
+                    # counts don't reconcile when an edge resolves but add_edge
+                    # raises. dropped_typing counts IS_A edges deferred to
+                    # emergence (#217).
                     errored_count = (
-                        len(proposed_edges) - dropped_count - len(stored_edge_ids)
+                        len(proposed_edges)
+                        - dropped_count
+                        - dropped_typing
+                        - len(stored_edge_ids)
                     )
                     logger.info(
                         "Edge ingestion for proposal %s: received=%d created=%d "
-                        "dropped_unresolved=%d errored=%d",
+                        "dropped_unresolved=%d dropped_typing=%d errored=%d",
                         proposal.get("proposal_id", ""),
                         len(proposed_edges),
                         len(stored_edge_ids),
                         dropped_count,
+                        dropped_typing,
                         errored_count,
                     )
 

--- a/tests/unit/ingestion/test_proposal_processor.py
+++ b/tests/unit/ingestion/test_proposal_processor.py
@@ -440,6 +440,70 @@ class TestProposalProcessor:
         # No individual lookups
         mock_hcg.find_node_by_name.assert_not_called()
 
+    def test_is_a_edges_dropped_deferring_typing_to_emergence(self):
+        """Ingest must NOT create IS_A edges: specific typing is deferred to
+        emergence/drainage, which reparents the realm-park IS_A onto a minted
+        type. Creating an IS_A here would mint a positional type at ingest and
+        leave the node with two upward IS_A edges. Non-IS_A relations are
+        unaffected. (#217)"""
+        from sophia.ingestion.proposal_processor import ProposalProcessor
+
+        mock_hcg = MagicMock()
+        mock_hcg.add_node.return_value = "new-uuid"
+        mock_hcg.add_edge.return_value = "edge-uuid"
+        mock_hcg.find_nodes_by_names.return_value = {
+            "marine mammal": {"uuid": "mm-uuid"},
+            "ocean": {"uuid": "ocean-uuid"},
+        }
+        mock_milvus = MagicMock()
+        mock_milvus.search_similar.return_value = []
+        mock_milvus.find_nearest_types.return_value = []
+
+        processor = ProposalProcessor(hcg_client=mock_hcg, milvus_sync=mock_milvus)
+        result = processor.process(
+            {
+                "proposal_id": "p1",
+                "proposed_nodes": [
+                    {
+                        "name": "narwhal",
+                        "type": "entity",
+                        "embedding": [0.1] * 384,
+                        "embedding_id": "emb-1",
+                        "dimension": 384,
+                        "model": "all-MiniLM-L6-v2",
+                        "properties": {},
+                    }
+                ],
+                "proposed_edges": [
+                    {
+                        "source_name": "narwhal",
+                        "target_name": "marine mammal",
+                        "relation": "IS_A",
+                        "confidence": 0.9,
+                    },
+                    {
+                        "source_name": "narwhal",
+                        "target_name": "ocean",
+                        "relation": "LIVES_IN",
+                        "confidence": 0.8,
+                    },
+                ],
+                "document_embedding": None,
+                "raw_text": "The narwhal is a marine mammal that lives in the ocean.",
+                "source_service": "hermes",
+                "confidence": 0.8,
+                "metadata": {},
+            }
+        )
+
+        # Only the non-IS_A edge is stored; the IS_A edge is dropped (deferred).
+        assert len(result["stored_edge_ids"]) == 1
+        created_relations = [
+            c.kwargs["relation"] for c in mock_hcg.add_edge.call_args_list
+        ]
+        assert created_relations == ["LIVES_IN"]
+        assert "IS_A" not in created_relations
+
     def test_edge_batch_resolution_failure_graceful(self):
         """Batch resolution failure should skip unresolved edges, not crash."""
         from sophia.ingestion.proposal_processor import ProposalProcessor

--- a/tests/unit/ingestion/test_proposal_processor.py
+++ b/tests/unit/ingestion/test_proposal_processor.py
@@ -451,7 +451,9 @@ class TestProposalProcessor:
         mock_hcg = MagicMock()
         mock_hcg.add_node.return_value = "new-uuid"
         mock_hcg.add_edge.return_value = "edge-uuid"
+        mock_hcg.query_edges_from.return_value = []  # loose node: no existing parent
         mock_hcg.find_nodes_by_names.return_value = {
+            "entity": {"uuid": "realm-entity-uuid"},
             "marine mammal": {"uuid": "mm-uuid"},
             "ocean": {"uuid": "ocean-uuid"},
         }
@@ -496,13 +498,27 @@ class TestProposalProcessor:
             }
         )
 
-        # Only the non-IS_A edge is stored; the IS_A edge is dropped (deferred).
+        # Exactly one upward IS_A is created -- the realm-park edge to the realm
+        # root (via placement.attach, a positional add_edge) -- while the LLM's
+        # proposed IS_A (narwhal -> marine mammal) is dropped. Non-IS_A relations
+        # survive. (#217)
+        def _rel(c):
+            return c.kwargs.get("relation") or (c.args[2] if len(c.args) > 2 else None)
+
+        def _tgt(c):
+            return c.kwargs.get("target_uuid") or (
+                c.args[1] if len(c.args) > 1 else None
+            )
+
+        edges = [(_rel(c), _tgt(c)) for c in mock_hcg.add_edge.call_args_list]
+        # realm-park IS_A to the realm root lands:
+        assert ("IS_A", "realm-entity-uuid") in edges
+        # the proposed IS_A (-> marine mammal) is dropped, never created:
+        assert ("IS_A", "mm-uuid") not in edges
+        # the non-IS_A relation survives:
+        assert ("LIVES_IN", "ocean-uuid") in edges
+        # only the non-IS_A proposed edge is stored from the proposed_edges loop:
         assert len(result["stored_edge_ids"]) == 1
-        created_relations = [
-            c.kwargs["relation"] for c in mock_hcg.add_edge.call_args_list
-        ]
-        assert created_relations == ["LIVES_IN"]
-        assert "IS_A" not in created_relations
 
     def test_edge_batch_resolution_failure_graceful(self):
         """Batch resolution failure should skip unresolved edges, not crash."""


### PR DESCRIPTION
Closes #217. Closes #216.

## Problem (#217)
The proposed_edges loop created every LLM-proposed edge unfiltered. An LLM 'X IS_A Y' proposal therefore (a) minted a positional type at ingest -- Y becomes a type because something IS_A's it -- bypassing emergence, and (b) left the node with two upward IS_A edges: the realm-park root edge (#211) plus the proposed one, violating the one-upward-IS_A invariant.

## Fix
Ingest no longer creates IS_A edges. Specific typing is deferred to emergence/drainage, which reparents the realm-park IS_A onto a minted type. relation == IS_A is dropped in both the pre-resolve and creation loops (new _DEFERRED_TYPING_RELATION constant); non-IS_A relations are unaffected. A dropped_typing counter is added to the edge-ingestion accounting/log so received = created + dropped_unresolved + dropped_typing + errored still reconciles.

## Why this also closes #216 (centroid coverage gap)
With ingest no longer minting specific types, mint_type becomes the sole specific-type creator (emergence leaf mint + rollup super-type mint both route through it), and mint_type seeds the type centroid atomically. Every specific type therefore has a centroid by construction; the gap reported in #216 (25 emergent types, only 10 centroids) came from ingest creating positional types with no centroid -- exactly the path this removes. reconcile_centroids remains available as a periodic repair net, not the primary writer. Combined with #218 (emergent centroid writes no longer null-skipped), emergent types now get centroids deterministically.

## Acceptance (#217)
After a cold ingest, every content node has exactly one upward IS_A (to its realm root); no specific/emergent types exist until emergence runs; no double-IS_A nodes.

## Tests
- test_is_a_edges_dropped_deferring_typing_to_emergence: an IS_A proposal is dropped while a sibling non-IS_A relation is still created.
- Full ingestion unit suite green (49 passed).