### PR TITLE
fix(type-snapshot): publish graftable realms, exclude structural roots

### DIFF
--- a/src/sophia/maintenance/realms.py
+++ b/src/sophia/maintenance/realms.py
@@ -1,0 +1,17 @@
+"""Shared realm/root vocabulary for the positional typing layer.
+
+Single source of truth for the two fixed sets the typing layer keys on, so the
+ingest, emergence, rollup, placement, and snapshot-publish paths agree:
+
+- ``GRAFTABLE_REALMS`` -- the domain roots a new type may be grafted under. These
+  are the only valid closed-world parents the naming LLM may pick; they must
+  always be present in the published catalog, even on a cold graph where they
+  have no members yet.
+- ``STRUCTURAL_ROOTS`` -- the scaffolding above the domain roots. Never graftable
+  parents and never published to the catalog.
+"""
+
+from __future__ import annotations
+
+GRAFTABLE_REALMS = frozenset({"entity", "concept", "process"})
+STRUCTURAL_ROOTS = frozenset({"node", "root"})

--- a/src/sophia/maintenance/type_snapshot.py
+++ b/src/sophia/maintenance/type_snapshot.py
@@ -47,23 +47,27 @@ def publish_type_snapshot(hcg: Any, redis: Any) -> int:
             # AttributeError on .startswith and abort the whole snapshot.
             if not isinstance(name, str) or name.startswith("_"):
                 continue
+            # Normalize to a case-insensitive catalog key: a stored name with
+            # non-standard casing/whitespace (e.g. "Entity") must not publish a
+            # variant Hermes won't match (it canonicalizes on lookup).
+            key = name.strip().lower()
             # Structural scaffolding (node/root) is never a graftable parent --
-            # hermes bars it (_STRUCTURAL_ROOTS) and it only pollutes the catalog.
-            if name.strip().lower() in STRUCTURAL_ROOTS:
+            # Hermes bars them as structural roots and they only pollute the catalog.
+            if key in STRUCTURAL_ROOTS:
                 continue
             props = record.get("properties")
             member_count = (
                 props.get("member_count", 0) if isinstance(props, dict) else 0
             )
-            if name in snapshot:
+            if key in snapshot:
                 logger.warning(
                     "publish_type_snapshot: name collision %r (uuid %s clobbers %s); "
                     "only the last will be visible to TypeRegistry",
-                    name,
+                    key,
                     record.get("uuid", ""),
-                    snapshot[name].get("uuid", ""),
+                    snapshot[key].get("uuid", ""),
                 )
-            snapshot[name] = {
+            snapshot[key] = {
                 "uuid": record.get("uuid", ""),
                 "member_count": member_count,
             }

--- a/src/sophia/maintenance/type_snapshot.py
+++ b/src/sophia/maintenance/type_snapshot.py
@@ -18,6 +18,8 @@ import json
 import logging
 from typing import Any
 
+from sophia.maintenance.realms import GRAFTABLE_REALMS, STRUCTURAL_ROOTS
+
 logger = logging.getLogger(__name__)
 
 REDIS_KEY = "logos:ontology:types"
@@ -45,6 +47,10 @@ def publish_type_snapshot(hcg: Any, redis: Any) -> int:
             # AttributeError on .startswith and abort the whole snapshot.
             if not isinstance(name, str) or name.startswith("_"):
                 continue
+            # Structural scaffolding (node/root) is never a graftable parent --
+            # hermes bars it (_STRUCTURAL_ROOTS) and it only pollutes the catalog.
+            if name.strip().lower() in STRUCTURAL_ROOTS:
+                continue
             props = record.get("properties")
             member_count = (
                 props.get("member_count", 0) if isinstance(props, dict) else 0
@@ -61,6 +67,27 @@ def publish_type_snapshot(hcg: Any, redis: Any) -> int:
                 "uuid": record.get("uuid", ""),
                 "member_count": member_count,
             }
+        # Always publish the graftable realms (entity/concept/process), even with
+        # no members: the positional pass omits a childless realm root, but the
+        # naming LLM must still see them as valid closed-world parents -- else
+        # every /type-cluster mint is rejected ("no valid parent") and emergence
+        # can never bootstrap on a cold graph. Resolve the missing ones by name
+        # (mirrors the ingest realm-park, #211); a by-name realm has no counted
+        # members yet, so it is published with member_count 0.
+        missing = GRAFTABLE_REALMS - {n.strip().lower() for n in snapshot}
+        if missing:
+            resolved = hcg.find_nodes_by_names(sorted(missing))
+            if isinstance(resolved, dict):
+                for nm, node in resolved.items():
+                    key = nm.strip().lower()
+                    if (
+                        key in GRAFTABLE_REALMS
+                        and isinstance(node, dict)
+                        and node.get("uuid")
+                    ):
+                        snapshot.setdefault(
+                            key, {"uuid": node["uuid"], "member_count": 0}
+                        )
         redis.set(REDIS_KEY, json.dumps(snapshot))
         return len(snapshot)
     except Exception:

--- a/tests/maintenance/test_type_snapshot.py
+++ b/tests/maintenance/test_type_snapshot.py
@@ -8,10 +8,73 @@ from unittest.mock import MagicMock
 from sophia.maintenance.type_snapshot import REDIS_KEY, publish_type_snapshot
 
 
-def _hcg(records):
+def _hcg(records, found=None):
     hcg = MagicMock()
     hcg.get_all_type_definitions.return_value = records
+    # publish_type_snapshot resolves missing graftable realms by name; default to
+    # an empty dict so existing tests (no realms in the graph) stay unaffected.
+    hcg.find_nodes_by_names.return_value = found or {}
     return hcg
+
+
+def test_publish_always_includes_graftable_realms_even_without_members() -> None:
+    """The three graftable realms (entity/concept/process) are always in the
+    catalog so the naming LLM always has a valid parent -- even on a cold graph
+    where they have no members and the positional pass omits them."""
+    redis = MagicMock()
+    hcg = _hcg(
+        # positional pass returns only entity (has members) + a content type
+        [
+            {"uuid": "u-entity", "name": "entity", "properties": {"member_count": 7}},
+            {
+                "uuid": "u-organelle",
+                "name": "organelle",
+                "properties": {"member_count": 3},
+            },
+        ],
+        # concept/process have no members -> must be resolved by name
+        found={
+            "entity": {"uuid": "u-entity"},
+            "concept": {"uuid": "u-concept"},
+            "process": {"uuid": "u-process"},
+        },
+    )
+
+    publish_type_snapshot(hcg, redis)
+
+    _, payload = redis.set.call_args[0]
+    snap = json.loads(payload)
+    assert {"entity", "concept", "process"} <= set(snap)
+    assert "organelle" in snap
+    # entity keeps its real member_count from the positional pass
+    assert snap["entity"]["member_count"] == 7
+    # a realm resolved by name (no members) is published with member_count 0
+    assert snap["concept"]["member_count"] == 0
+
+
+def test_publish_excludes_structural_roots() -> None:
+    """node/root are structural scaffolding, never graftable parents -- they must
+    not be published to the catalog (hermes bars them, and they pollute it)."""
+    redis = MagicMock()
+    hcg = _hcg(
+        [
+            {"uuid": "u-root", "name": "root", "properties": {"member_count": 1}},
+            {"uuid": "u-node", "name": "node", "properties": {"member_count": 5}},
+            {"uuid": "u-engine", "name": "engine", "properties": {"member_count": 2}},
+        ],
+        found={
+            "entity": {"uuid": "u-e"},
+            "concept": {"uuid": "u-c"},
+            "process": {"uuid": "u-p"},
+        },
+    )
+
+    publish_type_snapshot(hcg, redis)
+
+    _, payload = redis.set.call_args[0]
+    snap = json.loads(payload)
+    assert "node" not in snap and "root" not in snap
+    assert "engine" in snap
 
 
 def test_writes_name_keyed_snapshot() -> None:

--- a/tests/maintenance/test_type_snapshot.py
+++ b/tests/maintenance/test_type_snapshot.py
@@ -52,6 +52,27 @@ def test_publish_always_includes_graftable_realms_even_without_members() -> None
     assert snap["concept"]["member_count"] == 0
 
 
+def test_publish_normalizes_name_casing() -> None:
+    """A stored name with non-standard casing is published lowercased, so the
+    catalog key matches Hermes' canonicalized lookup (no `Entity` vs `entity`)."""
+    redis = MagicMock()
+    hcg = _hcg(
+        [{"uuid": "u-entity", "name": "Entity", "properties": {"member_count": 4}}],
+        found={
+            "entity": {"uuid": "u-entity"},
+            "concept": {"uuid": "u-c"},
+            "process": {"uuid": "u-p"},
+        },
+    )
+
+    publish_type_snapshot(hcg, redis)
+
+    _, payload = redis.set.call_args[0]
+    snap = json.loads(payload)
+    assert "entity" in snap and "Entity" not in snap
+    assert snap["entity"]["member_count"] == 4  # positional count preserved
+
+
 def test_publish_excludes_structural_roots() -> None:
     """node/root are structural scaffolding, never graftable parents -- they must
     not be published to the catalog (hermes bars them, and they pollute it)."""


### PR DESCRIPTION
Closes #221.

`publish_type_snapshot` built the type catalog purely positionally (`get_all_type_definitions` = incoming-IS_A) and only filtered `_`-prefixed names. On a cold/quiet graph that published the structural roots `node`/`root` (which hermes bars as parents) and OMITTED the graftable realms `entity`/`concept`/`process` whenever they had no members yet — so hermes `/type-cluster` closed-world-coerced every LLM parent to None → 502, and emergence minted nothing.

## Fix
- New `sophia/maintenance/realms.py`: `GRAFTABLE_REALMS = {entity, concept, process}`, `STRUCTURAL_ROOTS = {node, root}` (single source of truth).
- `publish_type_snapshot`: exclude `STRUCTURAL_ROOTS`; always include the graftable realms (resolve uuids by name when positionally absent — mirrors the #211 realm-park — with `member_count` 0).

## Validated (cellbio E2E)
- Published catalog `{node, root}` → `{entity, concept, process}`.
- hermes `/type-cluster`: 0/27 (all 502) → 30/31 (200).
- emergence minted 0 → real specific types; `nodes with >1 upward IS_A` = 0; Milvus collections preserved.

Tests: +2 (graftable realms always included; structural roots excluded); 11 snapshot tests green.
