### PR TITLE
feat(hcg): scoped de-reified query endpoints (stats/types/neighborhood/search)

### DIFF
--- a/src/sophia/api/app.py
+++ b/src/sophia/api/app.py
@@ -2092,6 +2092,103 @@ def create_app() -> FastAPI:
                 detail=f"Failed to fetch HCG snapshot: {str(e)}",
             )
 
+    @app.get("/hcg/stats", dependencies=[Depends(verify_token)], tags=["hcg"])
+    async def get_hcg_stats() -> Dict[str, Any]:
+        """Graph size: content nodes vs reified edge-nodes, types, predicates."""
+        span = get_current_span()
+        span.update_name("sophia.hcg.stats")
+        if not _hcg_client:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="HCG client not available",
+            )
+        try:
+            return _hcg_client.get_graph_stats()
+        except Exception as e:
+            span.record_exception(e)
+            span.set_status(StatusCode.ERROR, str(e))
+            logger.error(f"Error fetching HCG stats: {e}")
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Failed to fetch HCG stats: {str(e)}",
+            )
+
+    @app.get("/hcg/types", dependencies=[Depends(verify_token)], tags=["hcg"])
+    async def get_hcg_types(
+        limit: int = Query(default=500, ge=1, le=2000, description="Max types"),
+    ) -> List[Dict[str, Any]]:
+        """The positional type layer (any IS_A target) with member counts + parent."""
+        span = get_current_span()
+        span.update_name("sophia.hcg.types")
+        if not _hcg_client:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="HCG client not available",
+            )
+        try:
+            return _hcg_client.get_type_summaries(limit=limit)
+        except Exception as e:
+            span.record_exception(e)
+            span.set_status(StatusCode.ERROR, str(e))
+            logger.error(f"Error fetching HCG types: {e}")
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Failed to fetch HCG types: {str(e)}",
+            )
+
+    @app.get(
+        "/hcg/neighborhood/{uuid}",
+        dependencies=[Depends(verify_token)],
+        tags=["hcg"],
+    )
+    async def get_hcg_neighborhood(
+        uuid: str,
+        depth: int = Query(default=1, ge=1, le=4, description="Logical hops"),
+        limit: int = Query(default=100, ge=1, le=1000, description="Max nodes"),
+    ) -> Dict[str, Any]:
+        """De-reified logical neighborhood of a node, scoped by depth + limit."""
+        span = get_current_span()
+        span.update_name("sophia.hcg.neighborhood")
+        if not _hcg_client:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="HCG client not available",
+            )
+        try:
+            return _hcg_client.get_neighborhood(uuid, depth=depth, limit=limit)
+        except Exception as e:
+            span.record_exception(e)
+            span.set_status(StatusCode.ERROR, str(e))
+            logger.error(f"Error fetching HCG neighborhood: {e}")
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Failed to fetch HCG neighborhood: {str(e)}",
+            )
+
+    @app.get("/hcg/search", dependencies=[Depends(verify_token)], tags=["hcg"])
+    async def get_hcg_search(
+        q: str = Query(..., min_length=1, description="Name or uuid to search for"),
+        limit: int = Query(default=25, ge=1, le=200, description="Max results"),
+    ) -> List[Dict[str, Any]]:
+        """Find content nodes by name (or exact uuid) -- entry points for a UI."""
+        span = get_current_span()
+        span.update_name("sophia.hcg.search")
+        if not _hcg_client:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="HCG client not available",
+            )
+        try:
+            return _hcg_client.search_nodes(q, limit=limit)
+        except Exception as e:
+            span.record_exception(e)
+            span.set_status(StatusCode.ERROR, str(e))
+            logger.error(f"Error searching HCG nodes: {e}")
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Failed to search HCG nodes: {str(e)}",
+            )
+
     @app.get(
         "/hcg/entities/{entity_id}",
         response_model=HCGEntityResponse,

--- a/src/sophia/hcg_client/client.py
+++ b/src/sophia/hcg_client/client.py
@@ -717,7 +717,9 @@ class HCGClient(LogosHCGClient):
             MATCH (isa:Node {relation:'IS_A'})-[:TO]->(t:Node)
             WITH t, count(DISTINCT isa) AS member_count
             OPTIONAL MATCH (t)<-[:FROM]-(:Node {relation:'IS_A'})-[:TO]->(parent:Node)
-            RETURN t.uuid AS uuid, t.name AS name, member_count, parent.name AS parent
+            WITH t, member_count, collect(DISTINCT parent.name) AS parents
+            RETURN t.uuid AS uuid, t.name AS name, member_count,
+                   head(parents) AS parent
             ORDER BY member_count DESC, name
             LIMIT $limit
             """,
@@ -806,10 +808,15 @@ class HCGClient(LogosHCGClient):
             return []
         records = self._execute_read(
             """
-            MATCH (n:Node)
-            WHERE n.relation IS NULL
-              AND ((n.name IS NOT NULL AND toLower(n.name) CONTAINS toLower($q))
-                   OR n.uuid = $q)
+            CALL {
+                MATCH (n:Node) WHERE n.relation IS NULL AND n.uuid = $q
+                RETURN n
+                UNION
+                MATCH (n:Node)
+                WHERE n.relation IS NULL AND n.name IS NOT NULL
+                  AND toLower(n.name) CONTAINS toLower($q)
+                RETURN n
+            }
             RETURN n.uuid AS uuid, n.name AS name, n.type AS type
             ORDER BY n.name
             LIMIT $limit

--- a/src/sophia/hcg_client/client.py
+++ b/src/sophia/hcg_client/client.py
@@ -644,6 +644,163 @@ class HCGClient(LogosHCGClient):
             )
         return edges
 
+    # ------------------------------------------------------------------
+    # Scoped / de-reified queries (apollo-cli + explorer ask sophia for these)
+    # ------------------------------------------------------------------
+    def get_graph_stats(self) -> Dict[str, Any]:
+        """Graph size: content nodes vs reified edge-nodes, types, predicates.
+
+        Lets a client size the graph (content = the logical graph; edge-nodes =
+        the reified predicate/IS_A edges) before fetching any of it.
+        """
+        totals = self._execute_read(
+            """
+            MATCH (n:Node)
+            RETURN count(n) AS total,
+                   count(CASE WHEN n.relation IS NULL THEN 1 END) AS content,
+                   count(CASE WHEN n.relation IS NOT NULL THEN 1 END) AS edges
+            """,
+            {},
+        )
+        type_rows = self._execute_read(
+            "MATCH (t:Node) WHERE t.type = 'type_definition' RETURN count(t) AS c", {}
+        )
+        by_realm = {
+            r["realm"]: r["c"]
+            for r in self._execute_read(
+                "MATCH (n:Node) WHERE n.relation IS NULL AND n.type IS NOT NULL "
+                "RETURN n.type AS realm, count(n) AS c ORDER BY c DESC",
+                {},
+            )
+        }
+        top_predicates = {
+            r["rel"]: r["c"]
+            for r in self._execute_read(
+                "MATCH (n:Node) WHERE n.relation IS NOT NULL "
+                "RETURN n.relation AS rel, count(n) AS c ORDER BY c DESC LIMIT 20",
+                {},
+            )
+        }
+        return {
+            "total_nodes": totals[0]["total"] if totals else 0,
+            "content_nodes": totals[0]["content"] if totals else 0,
+            "edge_nodes": totals[0]["edges"] if totals else 0,
+            "type_definitions": type_rows[0]["c"] if type_rows else 0,
+            "by_realm": by_realm,
+            "top_predicates": top_predicates,
+        }
+
+    def get_type_summaries(self, limit: int = 500) -> List[Dict[str, Any]]:
+        """The positional type layer: any node something IS_A's, with its member
+        count (incoming IS_A) and parent type."""
+        records = self._execute_read(
+            """
+            MATCH (isa:Node {relation:'IS_A'})-[:TO]->(t:Node)
+            WITH t, count(DISTINCT isa) AS member_count
+            OPTIONAL MATCH (t)<-[:FROM]-(:Node {relation:'IS_A'})-[:TO]->(parent:Node)
+            RETURN t.uuid AS uuid, t.name AS name, member_count, parent.name AS parent
+            ORDER BY member_count DESC, name
+            LIMIT $limit
+            """,
+            {"limit": limit},
+        )
+        return [
+            {
+                "uuid": r["uuid"],
+                "name": r["name"],
+                "member_count": r["member_count"],
+                "parent": r["parent"],
+            }
+            for r in records
+        ]
+
+    def get_neighborhood(
+        self, uuid: str, depth: int = 1, limit: int = 100
+    ) -> Dict[str, Any]:
+        """De-reified logical neighborhood of a node, scoped by depth + limit.
+
+        Edge-nodes carry ``source``/``target``/``relation`` props, so logical
+        edges (src --predicate--> tgt) come back directly; a depth-bounded BFS
+        keeps the payload small no matter the graph size.
+        """
+        depth = max(1, min(depth, 4))
+        node_uuids = {uuid}
+        edges: Dict[str, Dict[str, Any]] = {}
+        frontier = [uuid]
+        seen: set = set()
+        for _ in range(depth):
+            roots = [r for r in frontier if r not in seen]
+            seen.update(roots)
+            if not roots or len(node_uuids) >= limit:
+                break
+            records = self._execute_read(
+                """
+                UNWIND $roots AS rid
+                MATCH (e:Node)
+                WHERE e.relation IS NOT NULL AND (e.source = rid OR e.target = rid)
+                RETURN DISTINCT e.uuid AS id, e.source AS source,
+                       e.target AS target, e.relation AS relation
+                """,
+                {"roots": roots},
+            )
+            next_frontier: List[str] = []
+            for r in records:
+                edges[r["id"]] = {
+                    "id": r["id"],
+                    "source": r["source"],
+                    "target": r["target"],
+                    "relation": r["relation"],
+                }
+                for endpoint in (r["source"], r["target"]):
+                    if (
+                        endpoint
+                        and endpoint not in node_uuids
+                        and len(node_uuids) < limit
+                    ):
+                        node_uuids.add(endpoint)
+                        next_frontier.append(endpoint)
+            frontier = next_frontier
+
+        nodes = self.get_nodes_batch(list(node_uuids))
+        present = {n["uuid"] for n in nodes}
+        kept_edges = [
+            e
+            for e in edges.values()
+            if e["source"] in present and e["target"] in present
+        ]
+        return {
+            "nodes": nodes,
+            "edges": kept_edges,
+            "metadata": {
+                "root": uuid,
+                "depth": depth,
+                "reified": False,
+                "node_count": len(nodes),
+                "edge_count": len(kept_edges),
+            },
+        }
+
+    def search_nodes(self, query: str, limit: int = 25) -> List[Dict[str, Any]]:
+        """Find content nodes by name (or exact uuid) -- entry points for a UI."""
+        q = (query or "").strip()
+        if not q:
+            return []
+        records = self._execute_read(
+            """
+            MATCH (n:Node)
+            WHERE n.relation IS NULL
+              AND ((n.name IS NOT NULL AND toLower(n.name) CONTAINS toLower($q))
+                   OR n.uuid = $q)
+            RETURN n.uuid AS uuid, n.name AS name, n.type AS type
+            ORDER BY n.name
+            LIMIT $limit
+            """,
+            {"q": q, "limit": limit},
+        )
+        return [
+            {"uuid": r["uuid"], "name": r["name"], "type": r["type"]} for r in records
+        ]
+
     def list_all_nodes(
         self,
         node_type: Optional[str] = None,

--- a/src/sophia/hcg_client/client.py
+++ b/src/sophia/hcg_client/client.py
@@ -681,11 +681,30 @@ class HCGClient(LogosHCGClient):
                 {},
             )
         }
+        # Typing coverage: how many content nodes are typed under a SPECIFIC
+        # type (not just a bare realm) -- i.e. actually classified vs parked.
+        realms = ["entity", "concept", "process", "node", "root"]
+        cov = self._execute_read(
+            """
+            MATCH (n:Node) WHERE n.relation IS NULL
+            WITH n,
+              size([ (n)<-[:FROM]-(:Node {relation:'IS_A'})-[:TO]->(t:Node)
+                     WHERE NOT t.name IN $realms | 1 ]) AS specific,
+              size([ (n)<-[:FROM]-(:Node {relation:'IS_A'})-[:TO]->(t:Node)
+                     WHERE t.name IN $realms | 1 ]) AS realm
+            RETURN count(n) AS total,
+                   sum(CASE WHEN specific > 0 THEN 1 ELSE 0 END) AS classified,
+                   sum(CASE WHEN specific = 0 AND realm > 0 THEN 1 ELSE 0 END) AS parked
+            """,
+            {"realms": realms},
+        )
         return {
             "total_nodes": totals[0]["total"] if totals else 0,
             "content_nodes": totals[0]["content"] if totals else 0,
             "edge_nodes": totals[0]["edges"] if totals else 0,
             "type_definitions": type_rows[0]["c"] if type_rows else 0,
+            "content_classified": cov[0]["classified"] if cov else 0,
+            "content_parked": cov[0]["parked"] if cov else 0,
             "by_realm": by_realm,
             "top_predicates": top_predicates,
         }

--- a/tests/unit/api/test_hcg_endpoints.py
+++ b/tests/unit/api/test_hcg_endpoints.py
@@ -63,6 +63,15 @@ class TestHCGScopedEndpoints:
     def test_stats_requires_authentication(self, client):
         assert client.get("/hcg/stats").status_code == 403
 
+    def test_types_requires_authentication(self, client):
+        assert client.get("/hcg/types").status_code == 403
+
+    def test_neighborhood_requires_authentication(self, client):
+        assert client.get("/hcg/neighborhood/some-uuid").status_code == 403
+
+    def test_search_requires_authentication(self, client):
+        assert client.get("/hcg/search?q=x").status_code == 403
+
     @patch("sophia.api.app._hcg_client")
     def test_types_returns_positional_layer(self, mock_hcg, client, auth_headers):
         mock_hcg.get_type_summaries.return_value = [

--- a/tests/unit/api/test_hcg_endpoints.py
+++ b/tests/unit/api/test_hcg_endpoints.py
@@ -43,6 +43,58 @@ def auth_headers(api_token):
     return {"Authorization": f"Bearer {api_token}"}
 
 
+class TestHCGScopedEndpoints:
+    """Tests for the scoped/de-reified endpoints: stats, types, neighborhood, search."""
+
+    @patch("sophia.api.app._hcg_client")
+    def test_stats_returns_counts(self, mock_hcg, client, auth_headers):
+        mock_hcg.get_graph_stats.return_value = {
+            "total_nodes": 3,
+            "content_nodes": 2,
+            "edge_nodes": 1,
+            "type_definitions": 1,
+            "by_realm": {"entity": 2},
+            "top_predicates": {"IS_A": 5},
+        }
+        resp = client.get("/hcg/stats", headers=auth_headers)
+        assert resp.status_code == 200
+        assert resp.json()["content_nodes"] == 2
+
+    def test_stats_requires_authentication(self, client):
+        assert client.get("/hcg/stats").status_code == 403
+
+    @patch("sophia.api.app._hcg_client")
+    def test_types_returns_positional_layer(self, mock_hcg, client, auth_headers):
+        mock_hcg.get_type_summaries.return_value = [
+            {"uuid": "t1", "name": "cell", "member_count": 49, "parent": "entity"}
+        ]
+        resp = client.get("/hcg/types?limit=10", headers=auth_headers)
+        assert resp.status_code == 200
+        assert resp.json()[0]["name"] == "cell"
+
+    @patch("sophia.api.app._hcg_client")
+    def test_neighborhood_returns_dereified(self, mock_hcg, client, auth_headers):
+        mock_hcg.get_neighborhood.return_value = {
+            "nodes": [],
+            "edges": [
+                {"id": "e1", "source": "a", "target": "b", "relation": "PART_OF"}
+            ],
+            "metadata": {"reified": False, "node_count": 0, "edge_count": 1},
+        }
+        resp = client.get("/hcg/neighborhood/some-uuid?depth=1", headers=auth_headers)
+        assert resp.status_code == 200
+        assert resp.json()["metadata"]["reified"] is False
+
+    @patch("sophia.api.app._hcg_client")
+    def test_search_returns_matches(self, mock_hcg, client, auth_headers):
+        mock_hcg.search_nodes.return_value = [
+            {"uuid": "n1", "name": "cell", "type": "entity"}
+        ]
+        resp = client.get("/hcg/search?q=cell", headers=auth_headers)
+        assert resp.status_code == 200
+        assert resp.json()[0]["name"] == "cell"
+
+
 class TestHCGSnapshotEndpoint:
     """Tests for GET /hcg/snapshot endpoint."""
 

--- a/tests/unit/hcg_client/test_client_wrapper.py
+++ b/tests/unit/hcg_client/test_client_wrapper.py
@@ -73,6 +73,7 @@ def test_get_graph_stats_separates_content_and_edge_nodes(
                 [{"c": 1}],
                 [{"realm": "entity", "c": 2}],
                 [{"rel": "IS_A", "c": 5}],
+                [{"total": 2, "classified": 1, "parked": 1}],
             ]
         ),
     )
@@ -80,6 +81,8 @@ def test_get_graph_stats_separates_content_and_edge_nodes(
     assert stats["content_nodes"] == 2
     assert stats["edge_nodes"] == 1
     assert stats["type_definitions"] == 1
+    assert stats["content_classified"] == 1
+    assert stats["content_parked"] == 1
     assert stats["by_realm"] == {"entity": 2}
     assert stats["top_predicates"] == {"IS_A": 5}
 

--- a/tests/unit/hcg_client/test_client_wrapper.py
+++ b/tests/unit/hcg_client/test_client_wrapper.py
@@ -39,6 +39,92 @@ def client(monkeypatch: pytest.MonkeyPatch) -> HCGClient:
     )
 
 
+# ---------------------------------------------------------------------------
+# Scoped / de-reified query methods
+# ---------------------------------------------------------------------------
+def test_get_type_summaries_shapes_rows(
+    monkeypatch: pytest.MonkeyPatch, client: HCGClient
+) -> None:
+    """Positional type rows are shaped to {uuid, name, member_count, parent}."""
+    monkeypatch.setattr(
+        client,
+        "_execute_read",
+        MagicMock(
+            return_value=[
+                {"uuid": "t1", "name": "cell", "member_count": 49, "parent": "entity"}
+            ]
+        ),
+    )
+    assert client.get_type_summaries() == [
+        {"uuid": "t1", "name": "cell", "member_count": 49, "parent": "entity"}
+    ]
+
+
+def test_get_graph_stats_separates_content_and_edge_nodes(
+    monkeypatch: pytest.MonkeyPatch, client: HCGClient
+) -> None:
+    """Stats report content vs reified edge-node counts distinctly."""
+    monkeypatch.setattr(
+        client,
+        "_execute_read",
+        MagicMock(
+            side_effect=[
+                [{"total": 3, "content": 2, "edges": 1}],
+                [{"c": 1}],
+                [{"realm": "entity", "c": 2}],
+                [{"rel": "IS_A", "c": 5}],
+            ]
+        ),
+    )
+    stats = client.get_graph_stats()
+    assert stats["content_nodes"] == 2
+    assert stats["edge_nodes"] == 1
+    assert stats["type_definitions"] == 1
+    assert stats["by_realm"] == {"entity": 2}
+    assert stats["top_predicates"] == {"IS_A": 5}
+
+
+def test_get_neighborhood_returns_dereified_edges(
+    monkeypatch: pytest.MonkeyPatch, client: HCGClient
+) -> None:
+    """A reified edge-node collapses to one logical src--relation-->tgt edge."""
+    monkeypatch.setattr(
+        client,
+        "_execute_read",
+        MagicMock(
+            return_value=[
+                {"id": "e1", "source": "root", "target": "n2", "relation": "PART_OF"}
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        client,
+        "get_nodes_batch",
+        MagicMock(
+            return_value=[
+                {"uuid": "root", "name": "Root", "type": "entity", "properties": {}},
+                {"uuid": "n2", "name": "N2", "type": "entity", "properties": {}},
+            ]
+        ),
+    )
+    nb = client.get_neighborhood("root", depth=1, limit=20)
+    assert nb["metadata"]["reified"] is False
+    assert nb["edges"] == [
+        {"id": "e1", "source": "root", "target": "n2", "relation": "PART_OF"}
+    ]
+    assert {n["uuid"] for n in nb["nodes"]} == {"root", "n2"}
+
+
+def test_search_nodes_empty_query_short_circuits(
+    monkeypatch: pytest.MonkeyPatch, client: HCGClient
+) -> None:
+    """An empty/whitespace query returns [] without querying Neo4j."""
+    execute = MagicMock()
+    monkeypatch.setattr(client, "_execute_read", execute)
+    assert client.search_nodes("   ") == []
+    execute.assert_not_called()
+
+
 def test_add_node_runs_shacl_validation(
     monkeypatch: pytest.MonkeyPatch, client: HCGClient
 ) -> None:


### PR DESCRIPTION
Closes #226. Neo4j is sophia's — these endpoints let apollo-cli and the explorer ask *her* for scoped/de-reified graph data instead of reaching into Neo4j.

## What
`HCGClient` (reusing her existing query helpers + the reified edge `source`/`target`/`relation` props):
- `get_graph_stats()` — content vs reified edge-node counts + by-realm + top predicates
- `get_type_summaries()` — positional type layer (any IS_A target) + member counts + parent
- `get_neighborhood(uuid, depth, limit)` — de-reified logical neighborhood (src --predicate--> tgt), depth-bounded BFS
- `search_nodes(q, limit)` — name/uuid entry points

API (`Depends(verify_token)`, `get_current_span` pattern): `GET /hcg/{stats, types, neighborhood/{uuid}, search}`.

## Why
The graph-query layer belongs on the gatekeeper (sophia, co-located with Neo4j), not on edge clients that may deploy on separate devices. Re-homes the apollo work (apollo#198 closed) to the right module.

## Verification
All four verified live against the 7006-node graph (direct + over HTTP with Bearer). 9 unit tests (4 client + 5 endpoint), ruff/black/mypy clean.

https://claude.ai/code/session_01YbGTE3BmHaRBNmJRZbF2oA