### PR TITLE
feat(embodiment): minimal Sophia inhabitant (perceive odom, emit cmd_vel)

### DIFF
--- a/src/sophia/embodiment/__init__.py
+++ b/src/sophia/embodiment/__init__.py
@@ -1,0 +1,1 @@
+"""Sophia's embodiment inhabitant — the seed of a descending-command generator."""

--- a/src/sophia/embodiment/inhabitant.py
+++ b/src/sophia/embodiment/inhabitant.py
@@ -22,21 +22,3 @@ class Inhabitant:
         cmd = {"cmd_vel": [0.8, 0.0]} if scripted_step < 10 else {"cmd_vel": [0.4, 0.6]}
         self._emb.command(cmd)
         return cmd
-
-
-def run(
-    host: str = "127.0.0.1", port: int = 57610, steps: int = 200
-) -> None:  # pragma: no cover
-    import time
-
-    from talos.embodiment.socket_embodiment import SocketEmbodiment
-
-    emb = SocketEmbodiment(host, port)
-    emb.connect()
-    inh = Inhabitant(emb)
-    try:
-        for i in range(steps):
-            inh.act(i)
-            time.sleep(0.05)
-    finally:
-        emb.close()

--- a/src/sophia/embodiment/inhabitant.py
+++ b/src/sophia/embodiment/inhabitant.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+
+class Inhabitant:
+    """Minimal embodied Sophia: attaches to a body, perceives odom, emits simple cmd_vel.
+
+    Open-loop by design — proves inhabitation + faithful interpretation, NOT navigation
+    competence. Routed straight to the embodiment, not through the stub Planner/Executor.
+    """
+
+    def __init__(self, embodiment: Any) -> None:
+        self._emb = embodiment
+        self._emb.describe().actuator("cmd_vel")  # bind; raises if not advertised
+
+    def perceive(self) -> dict[str, Any]:
+        return cast(dict[str, Any], self._emb.read().obs)
+
+    def act(self, scripted_step: int) -> dict[str, Any]:
+        # Scripted, open-loop: forward for the first stretch, then a steady yaw.
+        cmd = {"cmd_vel": [0.8, 0.0]} if scripted_step < 10 else {"cmd_vel": [0.4, 0.6]}
+        self._emb.command(cmd)
+        return cmd
+
+
+def run(
+    host: str = "127.0.0.1", port: int = 57610, steps: int = 200
+) -> None:  # pragma: no cover
+    import time
+
+    from talos.embodiment.socket_embodiment import SocketEmbodiment
+
+    emb = SocketEmbodiment(host, port)
+    emb.connect()
+    inh = Inhabitant(emb)
+    try:
+        for i in range(steps):
+            inh.act(i)
+            time.sleep(0.05)
+    finally:
+        emb.close()

--- a/tests/embodiment/test_inhabitant.py
+++ b/tests/embodiment/test_inhabitant.py
@@ -1,0 +1,48 @@
+from sophia.embodiment.inhabitant import Inhabitant
+
+
+class FakeEmb:
+    def __init__(self):
+        self.sent = []
+        self._obs = {"odom": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]}
+
+    def describe(self):
+        class S:  # minimal manifest stand-in
+            entity_id = "creature-0"
+
+            def actuator(self, n):
+                assert n == "cmd_vel"
+                return object()
+
+        return S()
+
+    def read(self):
+        class R:
+            pass
+
+        r = R()
+        r.obs = self._obs
+        r.sim_time = 1.0
+        return r
+
+    def command(self, cmd):
+        self.sent.append(cmd)
+
+
+def test_perceive_returns_odom():
+    inh = Inhabitant(FakeEmb())
+    assert inh.perceive()["odom"][3] == 0.0
+
+
+def test_act_emits_forward_then_turn():
+    emb = FakeEmb()
+    inh = Inhabitant(emb)
+    fwd = inh.act(0)  # scripted step 0 = go forward
+    turn = inh.act(10)  # scripted step 10 = yaw
+    assert fwd["cmd_vel"][0] > 0 and fwd["cmd_vel"][1] == 0.0
+    assert turn["cmd_vel"][1] != 0.0
+    assert emb.sent == [fwd, turn]
+
+
+def test_inhabitant_binds_to_cmd_vel_actuator():
+    Inhabitant(FakeEmb())  # asserts the manifest advertises cmd_vel; raises if not


### PR DESCRIPTION
Sophia half of the ocean-sim embodiment MVP.

Adds sophia.embodiment.Inhabitant — the seed of an embodied Sophia: it attaches to a Talos Embodiment (duck-typed describe/read/command), perceives odom, and emits simple open-loop cmd_vel commands. Deliberately open-loop and NOT routed through the stub Planner/Executor — this MVP proves inhabitation and faithful command interpretation, not navigation competence.

Conforms to docs/designs/ocean-sim-embodiment/ (doc 03 Slice 3, doc 04 §5).

Tests: 3 passing in tests/embodiment (run with --no-cov).

Review: an independent pass removed a dead run() that imported talos (not a sophia dependency) — the runnable entry point instead lives in an example script run where both packages are importable.

Companion PR: talos #67 (the Talos interface + socket client). The Unity sim seam and the end-to-end run are done in-editor, not in this PR.

https://claude.ai/code/session_01S5HmB4Yw1JchFKTb4VdT7R